### PR TITLE
Support DELETE on rewritten data files

### DIFF
--- a/src/delete_exec.rs
+++ b/src/delete_exec.rs
@@ -15,10 +15,6 @@
 //! - **Delete-all** (no `WHERE`): a metadata-only truncate — end every live data
 //!   file in one new snapshot. Much cheaper than positional-deleting every row.
 //!
-//! v1 handles insert-only data files. Files rewritten by an UPDATE/compaction
-//! (an embedded row-id column) cannot be resolved by physical position, so the
-//! filtered path cleanly errors on them rather than risk mis-deleting.
-//!
 //! # Session lifecycle (important)
 //!
 //! A [`DuckLakeCatalog`](crate::DuckLakeCatalog) pins its snapshot at creation
@@ -76,8 +72,7 @@ fn make_delete_count_schema() -> SchemaRef {
 /// means delete ALL rows.
 pub struct DuckLakeDeleteExec {
     /// A clone of the target table, used for its reader methods
-    /// (`resolve_positions`, `read_delete_file_positions`,
-    /// `file_has_embedded_rowid`).
+    /// (`resolve_positions`, `read_delete_file_positions`).
     table: Arc<DuckLakeTable>,
     /// Session captured at plan time. A bare `TaskContext` cannot build physical
     /// exprs or drive the positional sub-plans; `SessionState` is the concrete
@@ -289,19 +284,6 @@ async fn run_delete(
     let mut total_deleted: u64 = 0;
 
     for tf in &table_files {
-        // v1 refuses files rewritten by an UPDATE/compaction: their surviving
-        // rows carry embedded rowids whose physical order need not match the
-        // DuckLake `pos` space, so positional resolution could mis-delete. Clean
-        // error, never a silent wrong delete.
-        if table.file_has_embedded_rowid(state, &tf.file).await? {
-            return Err(DataFusionError::NotImplemented(format!(
-                "DELETE on data file '{}' is not supported: the file was rewritten by an \
-                 UPDATE or compaction (it embeds a row-id column), and v1 resolves delete \
-                 positions only for insert-only files",
-                tf.file.path
-            )));
-        }
-
         // Physical positions matching the predicate (raw scan; delete files NOT
         // applied — resolution is over the file's own rows).
         let matched = table

--- a/src/table.rs
+++ b/src/table.rs
@@ -1005,8 +1005,8 @@ impl DuckLakeTable {
     /// [`crate::metadata_writer::MetadataWriter::set_delete_file`].
     ///
     /// Scans the whole file; pushing `predicate` down for row-group/bloom pruning
-    /// is a possible optimization. Only valid for insert-only files, where
-    /// `position = rowid - row_id_start`.
+    /// is a possible optimization. The position is the physical index in the
+    /// current file, independent of whether rowids are synthesized or embedded.
     pub async fn resolve_positions(
         &self,
         state: &dyn Session,
@@ -1023,8 +1023,8 @@ impl DuckLakeTable {
         // (column index i = the i-th logical/data field); `Column::evaluate` is
         // index-based, so it resolves against the read batch regardless of any
         // physical rename. `ROW_POS_COLUMN_NAME` is appended last and is never
-        // referenced by the predicate. Valid for insert-only files, where the
-        // physical position equals `rowid - row_id_start`.
+        // referenced by the predicate. The physical position is the delete-file
+        // `pos` for both insert-only and rewritten files.
         let file_cfg = self.build_file_read_config(state, data_file).await?;
 
         // Row-group-aligned partitions + a non-repartition, non-pruning source so
@@ -1148,26 +1148,6 @@ impl DuckLakeTable {
         }
 
         Ok(positions)
-    }
-
-    /// Whether `file` embeds a `_ducklake_internal_row_id` column (tagged with
-    /// [`ROW_ID_PARQUET_FIELD_ID`]) — i.e. it was rewritten by an UPDATE or
-    /// compaction rather than being insert-only.
-    ///
-    /// [`Self::resolve_positions`] derives delete positions from the physical row
-    /// index, which is only the DuckLake `pos` for insert-only files; a rewritten
-    /// file's surviving rows carry embedded rowids whose physical order need not
-    /// match, so the delete path must refuse such files rather than mis-delete.
-    /// Memoized through the shared `file_read_config_cache`, so calling this right
-    /// before `resolve_positions` costs at most one extra footer read per file.
-    #[cfg(feature = "write")]
-    pub(crate) async fn file_has_embedded_rowid(
-        &self,
-        state: &dyn Session,
-        file: &DuckLakeFileData,
-    ) -> DataFusionResult<bool> {
-        let cfg = self.build_file_read_config(state, file).await?;
-        Ok(cfg.embedded_rowid_parquet_name.is_some())
     }
 
     /// Build a single execution plan for all files without delete files

--- a/tests/sql_delete_tests.rs
+++ b/tests/sql_delete_tests.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Array, Int32Array, UInt64Array};
+use arrow::array::{Array, Int32Array, Int64Array, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
@@ -87,6 +87,41 @@ async fn read_ids(temp: &TempDir) -> Vec<i32> {
     ids
 }
 
+/// Read `(rowid, id)` through a freshly-opened row-lineage catalog.
+async fn read_rowid_ids(temp: &TempDir) -> Vec<(i64, i32)> {
+    let conn = format!("sqlite:{}", temp.path().join("test.db").display());
+    let provider = SqliteMetadataProvider::new(&conn).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider)
+        .unwrap()
+        .with_row_lineage(true);
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT rowid, id FROM ducklake.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for batch in batches {
+        let rowids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let ids = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((rowids.value(i), ids.value(i)));
+        }
+    }
+    rows
+}
+
 /// Number of snapshots in the catalog (to assert a multi-file DELETE commits in
 /// exactly ONE new snapshot).
 async fn snapshot_count(temp: &TempDir) -> i64 {
@@ -98,10 +133,10 @@ async fn snapshot_count(temp: &TempDir) -> i64 {
         .unwrap()
 }
 
-/// Run a DELETE statement and return the reported rows-affected count.
-async fn run_delete(ctx: &SessionContext, sql: &str) -> u64 {
+/// Run a DML statement and return the reported rows-affected count.
+async fn run_dml_count(ctx: &SessionContext, sql: &str) -> u64 {
     let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
-    assert_eq!(batches.len(), 1, "DELETE returns a single count batch");
+    assert_eq!(batches.len(), 1, "DML returns a single count batch");
     assert_eq!(batches[0].num_rows(), 1, "count batch has one row");
     batches[0]
         .column(0)
@@ -124,7 +159,7 @@ async fn delete_single_file_predicate() {
     assert_eq!(read_ids(&temp).await, vec![1, 2, 3, 4], "baseline");
 
     let ctx = writable_ctx(&temp).await;
-    let count = run_delete(&ctx, "DELETE FROM ducklake.main.t WHERE id = 2").await;
+    let count = run_dml_count(&ctx, "DELETE FROM ducklake.main.t WHERE id = 2").await;
     assert_eq!(count, 1, "one row deleted");
     assert_eq!(read_ids(&temp).await, vec![1, 3, 4], "id 2 gone");
 }
@@ -148,7 +183,7 @@ async fn delete_multi_file_atomic() {
     let before = snapshot_count(&temp).await;
     let ctx = writable_ctx(&temp).await;
     // id 2 lives in file 1; ids 4 and 6 live in file 2.
-    let count = run_delete(
+    let count = run_dml_count(
         &ctx,
         "DELETE FROM ducklake.main.t WHERE id = 2 OR id = 4 OR id = 6",
     )
@@ -168,6 +203,66 @@ async fn delete_multi_file_atomic() {
     );
 }
 
+/// DELETE remains positional after UPDATE rewrites a row into an embedded-rowid
+/// file. Exercise an unrelated delete, the updated row itself, cumulative
+/// deletes on the source file, and one atomic delete spanning rewritten and
+/// insert-only files.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_after_update_rewrite_preserves_positions_and_rowids() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    let tw = DuckLakeTableWriter::new(writer, object_store()).unwrap();
+    tw.write_table("main", "t", &[id_batch(&[1, 2, 3])])
+        .await
+        .unwrap();
+    tw.append_table("main", "t", &[id_batch(&[4, 5])])
+        .await
+        .unwrap();
+
+    let update = writable_ctx(&temp).await;
+    assert_eq!(
+        run_dml_count(&update, "UPDATE ducklake.main.t SET id = 20 WHERE id = 2").await,
+        1
+    );
+
+    // This predicate misses the rewritten file, but DELETE must still inspect
+    // it without rejecting the table. The source file already has UPDATE's
+    // position 1 masked, so adding position 0 also proves cumulative deletes.
+    let unrelated_delete = writable_ctx(&temp).await;
+    assert_eq!(
+        run_dml_count(
+            &unrelated_delete,
+            "DELETE FROM ducklake.main.t WHERE id = 1",
+        )
+        .await,
+        1
+    );
+    assert_eq!(read_ids(&temp).await, vec![3, 4, 5, 20]);
+
+    let snapshots_before = snapshot_count(&temp).await;
+    let mixed_delete = writable_ctx(&temp).await;
+    assert_eq!(
+        run_dml_count(
+            &mixed_delete,
+            "DELETE FROM ducklake.main.t WHERE id = 20 OR id = 4",
+        )
+        .await,
+        2,
+        "delete one updated row and one insert-only row"
+    );
+    assert_eq!(
+        snapshot_count(&temp).await,
+        snapshots_before + 1,
+        "the mixed multi-file delete commits atomically"
+    );
+    assert_eq!(read_ids(&temp).await, vec![3, 5]);
+    assert_eq!(
+        read_rowid_ids(&temp).await,
+        vec![(2, 3), (4, 5)],
+        "fresh row-lineage reads preserve the surviving rowids"
+    );
+}
+
 /// `DELETE FROM t` with no WHERE removes ALL rows (metadata-only truncate).
 #[tokio::test(flavor = "multi_thread")]
 async fn delete_all_rows_no_where() {
@@ -180,7 +275,7 @@ async fn delete_all_rows_no_where() {
         .unwrap();
 
     let ctx = writable_ctx(&temp).await;
-    let count = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
+    let count = run_dml_count(&ctx, "DELETE FROM ducklake.main.t").await;
     assert_eq!(count, 4, "all four rows deleted");
     assert_eq!(read_ids(&temp).await, Vec::<i32>::new(), "table empty");
 }
@@ -200,13 +295,13 @@ async fn delete_after_delete_is_cumulative() {
 
     // First delete: id 2 (physical position 1).
     let ctx1 = writable_ctx(&temp).await;
-    let c1 = run_delete(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await;
+    let c1 = run_dml_count(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await;
     assert_eq!(c1, 1);
     assert_eq!(read_ids(&temp).await, vec![1, 3, 4], "after first delete");
 
     // Second delete (fresh ctx, sees the live delete file): id 4 (position 3).
     let ctx2 = writable_ctx(&temp).await;
-    let c2 = run_delete(&ctx2, "DELETE FROM ducklake.main.t WHERE id = 4").await;
+    let c2 = run_dml_count(&ctx2, "DELETE FROM ducklake.main.t WHERE id = 4").await;
     assert_eq!(c2, 1, "only the newly-matched row counts");
     assert_eq!(
         read_ids(&temp).await,
@@ -229,14 +324,14 @@ async fn delete_already_deleted_is_noop() {
 
     let ctx1 = writable_ctx(&temp).await;
     assert_eq!(
-        run_delete(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await,
+        run_dml_count(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await,
         1
     );
 
     let snaps = snapshot_count(&temp).await;
     // Re-delete the same (now already-deleted) row.
     let ctx2 = writable_ctx(&temp).await;
-    let c = run_delete(&ctx2, "DELETE FROM ducklake.main.t WHERE id = 2").await;
+    let c = run_dml_count(&ctx2, "DELETE FROM ducklake.main.t WHERE id = 2").await;
     assert_eq!(c, 0, "nothing new to delete");
     assert_eq!(
         snapshot_count(&temp).await,
@@ -258,7 +353,7 @@ async fn delete_no_match() {
         .unwrap();
 
     let ctx = writable_ctx(&temp).await;
-    let count = run_delete(&ctx, "DELETE FROM ducklake.main.t WHERE id = 999").await;
+    let count = run_dml_count(&ctx, "DELETE FROM ducklake.main.t WHERE id = 999").await;
     assert_eq!(count, 0);
     assert_eq!(read_ids(&temp).await, vec![1, 2, 3], "unchanged");
 }
@@ -326,7 +421,7 @@ async fn delete_truncate_repeat_same_ctx_no_spurious_snapshot() {
     let before = snapshot_count(&temp).await;
     let ctx = writable_ctx(&temp).await;
 
-    let c1 = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
+    let c1 = run_dml_count(&ctx, "DELETE FROM ducklake.main.t").await;
     assert_eq!(c1, 4, "first truncate removes all rows");
     let after_first = snapshot_count(&temp).await;
     assert_eq!(
@@ -336,7 +431,7 @@ async fn delete_truncate_repeat_same_ctx_no_spurious_snapshot() {
     );
 
     // Second truncate in the SAME (pinned) session: a DB-level no-op.
-    let c2 = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
+    let c2 = run_dml_count(&ctx, "DELETE FROM ducklake.main.t").await;
     assert_eq!(c2, 0, "nothing left to truncate");
     assert_eq!(
         snapshot_count(&temp).await,
@@ -366,7 +461,7 @@ async fn delete_second_in_session_conflicts_without_resurrection() {
     // One session, catalog pinned at the pre-delete snapshot.
     let ctx = writable_ctx(&temp).await;
     assert_eq!(
-        run_delete(&ctx, "DELETE FROM ducklake.main.t WHERE id = 2").await,
+        run_dml_count(&ctx, "DELETE FROM ducklake.main.t WHERE id = 2").await,
         1
     );
     assert_eq!(read_ids(&temp).await, vec![1, 3, 4], "id 2 deleted");


### PR DESCRIPTION
## Summary
- allow filtered DELETE to resolve physical positions in UPDATE/compaction output files
- remove the obsolete embedded-rowid rejection guard
- cover unrelated, updated-row, cumulative, multi-file atomic, reopen, and row-lineage behavior

## Root cause
`resolve_positions` already derives the current Parquet file physical positions with a non-pruning, row-group-aligned scan. Those positions are DuckLake delete-file `pos` values whether row IDs are synthesized or embedded.

## Validation
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/danielheres/Code/PolderDB/target cargo test --no-default-features --features write-sqlite --test sql_delete_tests` (10 passed)