### PR TITLE
Apply DuckLake column defaults on reads and writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and partition labels are identical at any setting (#280).
 
 - Add read-only DuckLake views across metadata backends and writer-compatible view metadata (#264).
+- Add literal column defaults for schema evolution and omitted `INSERT` fields
+  across metadata backends (#259).
 
 ### Changed
 
@@ -90,6 +92,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time (#280).
 
 ### Fixed
+
+- Fix `NULL` sentinels, BLOB decoding, expression-default reads, and legacy
+  schema migration (#259).
 
 - An upload whose final flush failed panicked with "Already shut down" instead of
   returning the error. `BufWriter::shutdown` leaves the writer shut down even when it

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -112,6 +112,25 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | Geometry                              |    ✅     | Mapped to `Binary` (WKB)                                     |
 | Complex / nested (list, struct, map)  | Supported | Recursive types and nullable‑field evolution; no pruning     |
 
+### Column defaults
+
+Parquet scans apply `initial_default` only when a file physically lacks the
+column. DataFusion inserts apply literal `default_value` metadata when the SQL
+statement omits the column. DuckLake's string sentinel `"NULL"` means no
+operational default, and BLOB defaults retain printable bytes while decoding
+DuckDB `\xNN` escapes.
+
+DuckDB expression defaults remain metadata-only: they do not prevent table
+reads, but DataFusion does not evaluate them. Supply those columns explicitly
+on insert. Defaults added to nested children are not materialized yet, and the
+table-change, insertion, and deletion functions do not fill defaults for fields
+missing from older files.
+
+Writer initialization migrates missing default-metadata columns on SQLite,
+MySQL, and PostgreSQL. DuckDB read providers project missing fields as `NULL`.
+For a legacy SQLite, MySQL, or PostgreSQL catalog opened through a read-only
+provider, run writer initialization with a schema-migration role before reading.
+
 ---
 
 ## Capabilities

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -37,7 +37,8 @@ pub const SQL_GET_VIEW_BY_NAME: &str =
        AND (? < end_snapshot OR end_snapshot IS NULL)";
 
 pub const SQL_GET_TABLE_COLUMNS: &str =
-    "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+    "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
+            initial_default, default_value, default_value_type, default_value_dialect
      FROM ducklake_column
      WHERE table_id = ?
        AND ? >= begin_snapshot
@@ -324,7 +325,11 @@ pub const SQL_LIST_ALL_COLUMNS: &str = "
         c.column_name,
         c.column_type,
         c.nulls_allowed,
-        c.parent_column
+        c.parent_column,
+        c.initial_default,
+        c.default_value,
+        c.default_value_type,
+        c.default_value_dialect
     FROM ducklake_schema s
     JOIN ducklake_table t ON s.schema_id = t.schema_id
     JOIN ducklake_column c ON t.table_id = c.table_id
@@ -571,6 +576,14 @@ pub struct DuckLakeTableColumn {
     pub is_nullable: bool,
     pub(crate) data_type: Option<DataType>,
     pub(crate) nested_column_ids: Vec<i64>,
+    /// Value substituted for this column in files that predate it
+    pub initial_default: Option<String>,
+    /// Value applied when a new write omits this column
+    pub default_value: Option<String>,
+    /// How to interpret the stored defaults (`literal` or `expression`)
+    pub default_value_type: Option<String>,
+    /// SQL dialect used to encode the stored defaults
+    pub default_value_dialect: Option<String>,
 }
 
 pub(crate) fn is_inlined_data_table(name: &str) -> bool {
@@ -701,6 +714,10 @@ impl DuckLakeTableColumn {
             is_nullable,
             data_type: None,
             nested_column_ids: Vec::new(),
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         }
     }
 
@@ -709,6 +726,22 @@ impl DuckLakeTableColumn {
             Some(data_type) => Ok(data_type.clone()),
             None => ducklake_to_arrow_type(&self.column_type),
         }
+    }
+
+    /// Attach the default metadata stored in `ducklake_column`.
+    pub(crate) fn with_defaults(
+        mut self,
+        initial_default: Option<String>,
+        default_value: Option<String>,
+        default_value_type: Option<String>,
+        default_value_dialect: Option<String>,
+    ) -> Self {
+        self.initial_default = initial_default;
+        // DuckLake stores a missing operational default as the string sentinel `NULL`
+        self.default_value = default_value.filter(|value| value != "NULL");
+        self.default_value_type = default_value_type;
+        self.default_value_dialect = default_value_dialect;
+        self
     }
 }
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -8,11 +8,10 @@ use crate::metadata_provider::{
     SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
     SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT, SQL_GET_PARTITION_SPEC,
     SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS,
-    SQL_GET_TABLE_COLUMNS, SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_COLUMNS,
-    SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES, SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS,
-    SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS, SQL_TABLE_EXISTS, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
-    build_inlined_batch, is_inlined_data_table, reconstruct_columns,
+    SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES,
+    SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS,
+    SQL_TABLE_EXISTS, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
+    ViewMetadata, ViewWithSchema, build_inlined_batch, is_inlined_data_table, reconstruct_columns,
     reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
@@ -166,12 +165,13 @@ fn decode_view(row: &duckdb::Row<'_>) -> duckdb::Result<ViewMetadata> {
     })
 }
 
-/// Optional catalog-schema capabilities probed before CDC / inlined-data queries.
+/// Optional catalog-schema capabilities probed before version-dependent queries.
 ///
 /// Older catalogs (spec 0.2) may lack the `partial_max` columns and the
 /// inlined-data registry. CDC queries fall back to the old-spec
 /// `partial_file_info` string (data files) or degrade the predicate to NULL
 /// (delete files); inlined-data reads return empty when a capability is absent.
+/// Older catalogs may also lack any or all of the four default-value columns.
 #[derive(Debug, Clone, Copy)]
 struct SchemaCapabilities {
     /// `ducklake_data_file.partial_max` exists.
@@ -182,6 +182,14 @@ struct SchemaCapabilities {
     inlined_data_tables: bool,
     /// The `ducklake_view` table exists.
     views: bool,
+    /// `ducklake_column.initial_default` exists.
+    column_initial_default: bool,
+    /// `ducklake_column.default_value` exists.
+    column_default_value: bool,
+    /// `ducklake_column.default_value_type` exists.
+    column_default_value_type: bool,
+    /// `ducklake_column.default_value_dialect` exists.
+    column_default_value_dialect: bool,
 }
 
 impl SchemaCapabilities {
@@ -190,7 +198,90 @@ impl SchemaCapabilities {
             && self.delete_file_partial_max
             && self.inlined_data_tables
             && self.views
+            && self.column_initial_default
+            && self.column_default_value
+            && self.column_default_value_type
+            && self.column_default_value_dialect
     }
+}
+
+fn get_table_columns_sql(capabilities: SchemaCapabilities) -> String {
+    let initial_default = if capabilities.column_initial_default {
+        "initial_default"
+    } else {
+        "NULL AS initial_default"
+    };
+    let default_value = if capabilities.column_default_value {
+        "default_value"
+    } else {
+        "NULL AS default_value"
+    };
+    let value_type = if capabilities.column_default_value_type {
+        "default_value_type"
+    } else {
+        "NULL AS default_value_type"
+    };
+    let dialect = if capabilities.column_default_value_dialect {
+        "default_value_dialect"
+    } else {
+        "NULL AS default_value_dialect"
+    };
+    format!(
+        "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
+                {initial_default}, {default_value}, {value_type}, {dialect}
+         FROM ducklake_column
+         WHERE table_id = ?
+           AND ? >= begin_snapshot
+           AND (? < end_snapshot OR end_snapshot IS NULL)
+         ORDER BY column_order"
+    )
+}
+
+fn list_all_columns_sql(capabilities: SchemaCapabilities) -> String {
+    let initial_default = if capabilities.column_initial_default {
+        "c.initial_default"
+    } else {
+        "NULL AS initial_default"
+    };
+    let default_value = if capabilities.column_default_value {
+        "c.default_value"
+    } else {
+        "NULL AS default_value"
+    };
+    let value_type = if capabilities.column_default_value_type {
+        "c.default_value_type"
+    } else {
+        "NULL AS default_value_type"
+    };
+    let dialect = if capabilities.column_default_value_dialect {
+        "c.default_value_dialect"
+    } else {
+        "NULL AS default_value_dialect"
+    };
+    format!(
+        "SELECT
+            s.schema_name,
+            t.table_name,
+            c.column_id,
+            c.column_name,
+            c.column_type,
+            c.nulls_allowed,
+            c.parent_column,
+            {initial_default},
+            {default_value},
+            {value_type},
+            {dialect}
+         FROM ducklake_schema s
+         JOIN ducklake_table t ON s.schema_id = t.schema_id
+         JOIN ducklake_column c ON t.table_id = c.table_id
+         WHERE ? >= s.begin_snapshot
+           AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
+           AND ? >= t.begin_snapshot
+           AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
+           AND ? >= c.begin_snapshot
+           AND (? < c.end_snapshot OR c.end_snapshot IS NULL)
+         ORDER BY s.schema_name, t.table_name, c.column_order"
+    )
 }
 
 /// DuckDB metadata provider
@@ -249,12 +340,16 @@ impl DuckdbMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let (data_file_partial_max, delete_file_partial_max, inlined_data_tables, views): (
-            bool,
-            bool,
-            bool,
-            bool,
-        ) = conn.query_row(
+        let (
+            data_file_partial_max,
+            delete_file_partial_max,
+            inlined_data_tables,
+            views,
+            column_initial_default,
+            column_default_value,
+            column_default_value_type,
+            column_default_value_dialect,
+        ): (bool, bool, bool, bool, bool, bool, bool, bool) = conn.query_row(
             "SELECT
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file')
                 WHERE name = 'partial_max') > 0,
@@ -263,15 +358,38 @@ impl DuckdbMetadataProvider {
                (SELECT COUNT(*) FROM information_schema.tables
                 WHERE table_name = 'ducklake_inlined_data_tables') > 0,
                (SELECT COUNT(*) FROM information_schema.tables
-                WHERE table_name = 'ducklake_view') > 0",
+                WHERE table_name = 'ducklake_view') > 0,
+                (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
+                 WHERE name = 'initial_default') > 0,
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
+                WHERE name = 'default_value') > 0,
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
+                WHERE name = 'default_value_type') > 0,
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
+                WHERE name = 'default_value_dialect') > 0",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            },
         )?;
         let caps = SchemaCapabilities {
             data_file_partial_max,
             delete_file_partial_max,
             inlined_data_tables,
             views,
+            column_initial_default,
+            column_default_value,
+            column_default_value_type,
+            column_default_value_dialect,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -396,7 +514,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
         snapshot_id: i64,
     ) -> crate::Result<Vec<DuckLakeTableColumn>> {
         let conn = self.connection();
-        let mut stmt = conn.prepare(SQL_GET_TABLE_COLUMNS)?;
+        let sql = get_table_columns_sql(self.schema_capabilities(&conn)?);
+        let mut stmt = conn.prepare(&sql)?;
 
         let raw_columns: Vec<(DuckLakeTableColumn, Option<i64>)> = stmt
             .query_map(duckdb::params![table_id, snapshot_id, snapshot_id], |row| {
@@ -411,6 +530,12 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         column_name,
                         column_type,
                         nulls_allowed.unwrap_or(true),
+                    )
+                    .with_defaults(
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                        row.get(8)?,
                     ),
                     parent_column,
                 ))
@@ -1087,7 +1212,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
 
     fn list_all_columns(&self, snapshot_id: i64) -> crate::Result<Vec<ColumnWithTable>> {
         let conn = self.connection();
-        let mut stmt = conn.prepare(SQL_LIST_ALL_COLUMNS)?;
+        let sql = list_all_columns_sql(self.schema_capabilities(&conn)?);
+        let mut stmt = conn.prepare(&sql)?;
 
         let raw_columns: Vec<(ColumnWithTable, Option<i64>)> = stmt
             .query_map(
@@ -1104,14 +1230,18 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     let table_name: String = row.get(1)?;
                     let nulls_allowed: Option<bool> = row.get(5)?;
                     let parent_column: Option<i64> = row.get(6)?;
-                    let column = DuckLakeTableColumn {
-                        column_id: row.get(2)?,
-                        column_name: row.get(3)?,
-                        column_type: row.get(4)?,
-                        is_nullable: nulls_allowed.unwrap_or(true),
-                        data_type: None,
-                        nested_column_ids: Vec::new(),
-                    };
+                    let column = DuckLakeTableColumn::new(
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        nulls_allowed.unwrap_or(true),
+                    )
+                    .with_defaults(
+                        row.get(7)?,
+                        row.get(8)?,
+                        row.get(9)?,
+                        row.get(10)?,
+                    );
                     Ok((
                         ColumnWithTable {
                             schema_name,
@@ -1350,7 +1480,11 @@ mod tests {
     use duckdb::arrow::array::{Int32Builder, ListBuilder};
     use duckdb::types::{ListType, ValueRef};
 
-    use super::{duckdb_inlined_scalar, parse_partial_file_info_max};
+    use super::{
+        SchemaCapabilities, duckdb_inlined_scalar, get_table_columns_sql, list_all_columns_sql,
+        parse_partial_file_info_max,
+    };
+    use duckdb::{Connection, params};
 
     #[test]
     fn nested_inlined_value_reports_recovery() {
@@ -1374,6 +1508,79 @@ mod tests {
              which cannot be decoded as List(Int32); flush inlined data to Parquet (or disable \
              data inlining at write time)"
         );
+    }
+
+    #[test]
+    fn legacy_columns_without_defaults_are_null_projected() -> duckdb::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE ducklake_schema (
+                schema_id BIGINT, schema_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT
+            );
+            CREATE TABLE ducklake_table (
+                table_id BIGINT, schema_id BIGINT, table_name VARCHAR,
+                begin_snapshot BIGINT, end_snapshot BIGINT
+            );
+            CREATE TABLE ducklake_column (
+                column_id BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR,
+                column_type VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT,
+                begin_snapshot BIGINT, end_snapshot BIGINT
+            );
+            INSERT INTO ducklake_schema VALUES (1, 'main', 1, NULL);
+            INSERT INTO ducklake_table VALUES (2, 1, 'events', 1, NULL);
+            INSERT INTO ducklake_column VALUES (3, 2, 0, 'id', 'int64', false, NULL, 1, NULL);",
+        )?;
+        let capabilities = SchemaCapabilities {
+            data_file_partial_max: false,
+            delete_file_partial_max: false,
+            inlined_data_tables: false,
+            views: false,
+            column_initial_default: false,
+            column_default_value: false,
+            column_default_value_type: false,
+            column_default_value_dialect: false,
+        };
+
+        let table_defaults = conn.query_row(
+            &get_table_columns_sql(capabilities),
+            params![2, 1, 1],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                    row.get::<_, Option<String>>(8)?,
+                ))
+            },
+        )?;
+        let listed_defaults = conn.query_row(
+            &list_all_columns_sql(capabilities),
+            params![1, 1, 1, 1, 1, 1],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(7)?,
+                    row.get::<_, Option<String>>(8)?,
+                    row.get::<_, Option<String>>(9)?,
+                    row.get::<_, Option<String>>(10)?,
+                ))
+            },
+        )?;
+
+        assert_eq!(table_defaults, (None, None, None, None));
+        assert_eq!(
+            listed_defaults,
+            (
+                "main".to_string(),
+                "events".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -329,7 +329,8 @@ impl MetadataProvider for MySqlMetadataProvider {
     ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
             let rows = sqlx::query(
-                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
+                        initial_default, default_value, default_value_type, default_value_dialect
                  FROM ducklake_column
                  WHERE table_id = ?
                    AND ? >= begin_snapshot
@@ -348,14 +349,18 @@ impl MetadataProvider for MySqlMetadataProvider {
                     let nulls_allowed: Option<bool> = row.try_get(3)?;
                     let parent_column: Option<i64> = row.try_get(4)?;
                     Ok((
-                        DuckLakeTableColumn {
-                            column_id: row.try_get(0)?,
-                            column_name: row.try_get(1)?,
-                            column_type: row.try_get(2)?,
-                            is_nullable: nulls_allowed.unwrap_or(true),
-                            data_type: None,
-                            nested_column_ids: Vec::new(),
-                        },
+                        DuckLakeTableColumn::new(
+                            row.try_get(0)?,
+                            row.try_get(1)?,
+                            row.try_get(2)?,
+                            nulls_allowed.unwrap_or(true),
+                        )
+                        .with_defaults(
+                            row.try_get(5)?,
+                            row.try_get(6)?,
+                            row.try_get(7)?,
+                            row.try_get(8)?,
+                        ),
                         parent_column,
                     ))
                 })
@@ -1111,7 +1116,9 @@ impl MetadataProvider for MySqlMetadataProvider {
     fn list_all_columns(&self, snapshot_id: i64) -> Result<Vec<ColumnWithTable>> {
         block_on(async {
             let rows = sqlx::query(
-                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type, c.nulls_allowed, c.parent_column
+                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type,
+                        c.nulls_allowed, c.parent_column, c.initial_default, c.default_value,
+                        c.default_value_type, c.default_value_dialect
                  FROM ducklake_schema s
                  JOIN ducklake_table t ON s.schema_id = t.schema_id
                  JOIN ducklake_column c ON t.table_id = c.table_id
@@ -1139,14 +1146,18 @@ impl MetadataProvider for MySqlMetadataProvider {
                     let table_name: String = row.try_get(1)?;
                     let nulls_allowed: Option<bool> = row.try_get(5)?;
                     let parent_column: Option<i64> = row.try_get(6)?;
-                    let column = DuckLakeTableColumn {
-                        column_id: row.try_get(2)?,
-                        column_name: row.try_get(3)?,
-                        column_type: row.try_get(4)?,
-                        is_nullable: nulls_allowed.unwrap_or(true),
-                        data_type: None,
-                        nested_column_ids: Vec::new(),
-                    };
+                    let column = DuckLakeTableColumn::new(
+                        row.try_get(2)?,
+                        row.try_get(3)?,
+                        row.try_get(4)?,
+                        nulls_allowed.unwrap_or(true),
+                    )
+                    .with_defaults(
+                        row.try_get(7)?,
+                        row.try_get(8)?,
+                        row.try_get(9)?,
+                        row.try_get(10)?,
+                    );
                     Ok((
                         ColumnWithTable {
                             schema_name,

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -369,7 +369,8 @@ impl MetadataProvider for PostgresMetadataProvider {
     ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
             let rows = sqlx::query(
-                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
+                        initial_default, default_value, default_value_type, default_value_dialect
                  FROM ducklake_column
                  WHERE table_id = $1
                    AND $2 >= begin_snapshot
@@ -388,14 +389,18 @@ impl MetadataProvider for PostgresMetadataProvider {
                     let nulls_allowed: Option<bool> = row.try_get(3)?;
                     let parent_column: Option<i64> = row.try_get(4)?;
                     Ok((
-                        DuckLakeTableColumn {
-                            column_id: row.try_get(0)?,
-                            column_name: row.try_get(1)?,
-                            column_type: row.try_get(2)?,
-                            is_nullable: nulls_allowed.unwrap_or(true),
-                            data_type: None,
-                            nested_column_ids: Vec::new(),
-                        },
+                        DuckLakeTableColumn::new(
+                            row.try_get(0)?,
+                            row.try_get(1)?,
+                            row.try_get(2)?,
+                            nulls_allowed.unwrap_or(true),
+                        )
+                        .with_defaults(
+                            row.try_get(5)?,
+                            row.try_get(6)?,
+                            row.try_get(7)?,
+                            row.try_get(8)?,
+                        ),
                         parent_column,
                     ))
                 })
@@ -1266,7 +1271,9 @@ impl MetadataProvider for PostgresMetadataProvider {
     fn list_all_columns(&self, snapshot_id: i64) -> Result<Vec<ColumnWithTable>> {
         block_on(async {
             let rows = sqlx::query(
-                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type, c.nulls_allowed, c.parent_column
+                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type,
+                        c.nulls_allowed, c.parent_column, c.initial_default, c.default_value,
+                        c.default_value_type, c.default_value_dialect
                  FROM ducklake_schema s
                  JOIN ducklake_table t ON s.schema_id = t.schema_id
                  JOIN ducklake_column c ON t.table_id = c.table_id
@@ -1294,14 +1301,18 @@ impl MetadataProvider for PostgresMetadataProvider {
                     let table_name: String = row.try_get(1)?;
                     let nulls_allowed: Option<bool> = row.try_get(5)?;
                     let parent_column: Option<i64> = row.try_get(6)?;
-                    let column = DuckLakeTableColumn {
-                        column_id: row.try_get(2)?,
-                        column_name: row.try_get(3)?,
-                        column_type: row.try_get(4)?,
-                        is_nullable: nulls_allowed.unwrap_or(true),
-                        data_type: None,
-                        nested_column_ids: Vec::new(),
-                    };
+                    let column = DuckLakeTableColumn::new(
+                        row.try_get(2)?,
+                        row.try_get(3)?,
+                        row.try_get(4)?,
+                        nulls_allowed.unwrap_or(true),
+                    )
+                    .with_defaults(
+                        row.try_get(7)?,
+                        row.try_get(8)?,
+                        row.try_get(9)?,
+                        row.try_get(10)?,
+                    );
                     Ok((
                         ColumnWithTable {
                             schema_name,

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -435,7 +435,8 @@ impl MetadataProvider for SqliteMetadataProvider {
     ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
             let rows = sqlx::query(
-                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
+                        initial_default, default_value, default_value_type, default_value_dialect
                  FROM ducklake_column
                  WHERE table_id = ?
                    AND ? >= begin_snapshot
@@ -454,14 +455,18 @@ impl MetadataProvider for SqliteMetadataProvider {
                     let nulls_allowed: Option<bool> = row.try_get(3)?;
                     let parent_column: Option<i64> = row.try_get(4)?;
                     Ok((
-                        DuckLakeTableColumn {
-                            column_id: row.try_get(0)?,
-                            column_name: row.try_get(1)?,
-                            column_type: row.try_get(2)?,
-                            is_nullable: nulls_allowed.unwrap_or(true),
-                            data_type: None,
-                            nested_column_ids: Vec::new(),
-                        },
+                        DuckLakeTableColumn::new(
+                            row.try_get(0)?,
+                            row.try_get(1)?,
+                            row.try_get(2)?,
+                            nulls_allowed.unwrap_or(true),
+                        )
+                        .with_defaults(
+                            row.try_get(5)?,
+                            row.try_get(6)?,
+                            row.try_get(7)?,
+                            row.try_get(8)?,
+                        ),
                         parent_column,
                     ))
                 })
@@ -1322,7 +1327,9 @@ impl MetadataProvider for SqliteMetadataProvider {
     fn list_all_columns(&self, snapshot_id: i64) -> Result<Vec<ColumnWithTable>> {
         block_on(async {
             let rows = sqlx::query(
-                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type, c.nulls_allowed, c.parent_column
+                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type,
+                        c.nulls_allowed, c.parent_column, c.initial_default, c.default_value,
+                        c.default_value_type, c.default_value_dialect
                  FROM ducklake_schema s
                  JOIN ducklake_table t ON s.schema_id = t.schema_id
                  JOIN ducklake_column c ON t.table_id = c.table_id
@@ -1350,14 +1357,18 @@ impl MetadataProvider for SqliteMetadataProvider {
                     let table_name: String = row.try_get(1)?;
                     let nulls_allowed: Option<bool> = row.try_get(5)?;
                     let parent_column: Option<i64> = row.try_get(6)?;
-                    let column = DuckLakeTableColumn {
-                        column_id: row.try_get(2)?,
-                        column_name: row.try_get(3)?,
-                        column_type: row.try_get(4)?,
-                        is_nullable: nulls_allowed.unwrap_or(true),
-                        data_type: None,
-                        nested_column_ids: Vec::new(),
-                    };
+                    let column = DuckLakeTableColumn::new(
+                        row.try_get(2)?,
+                        row.try_get(3)?,
+                        row.try_get(4)?,
+                        nulls_allowed.unwrap_or(true),
+                    )
+                    .with_defaults(
+                        row.try_get(7)?,
+                        row.try_get(8)?,
+                        row.try_get(9)?,
+                        row.try_get(10)?,
+                    );
                     Ok((
                         ColumnWithTable {
                             schema_name,

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -160,6 +160,14 @@ pub struct ColumnDef {
     pub(crate) is_nullable: bool,
     /// Arrow type retained so nested child names and nullability survive catalog flattening.
     pub(crate) data_type: DataType,
+    /// Literal used for files that predate a newly added column
+    pub(crate) initial_default: Option<String>,
+    /// Literal applied when a write omits this column
+    pub(crate) default_value: Option<String>,
+    /// Default encoding kind (`literal` when a default is set)
+    pub(crate) default_value_type: Option<String>,
+    /// SQL dialect recorded for interoperability
+    pub(crate) default_value_dialect: Option<String>,
 }
 
 impl ColumnDef {
@@ -198,6 +206,10 @@ impl ColumnDef {
             ducklake_type,
             is_nullable,
             data_type,
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         })
     }
 
@@ -221,7 +233,28 @@ impl ColumnDef {
             ducklake_type,
             is_nullable,
             data_type: data_type.clone(),
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         })
+    }
+
+    /// Set a DuckLake literal default for this column.
+    pub fn with_default(mut self, value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        let data_type = ducklake_to_arrow_type(&self.ducklake_type)?;
+        if crate::types::parse_ducklake_default_scalar(&value, &data_type).is_none() {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "Cannot decode default '{value}' for column '{}' as {data_type}",
+                self.name
+            )));
+        }
+        self.initial_default = Some(value.clone());
+        self.default_value = Some(value);
+        self.default_value_type = Some("literal".to_string());
+        self.default_value_dialect = Some("duckdb".to_string());
+        Ok(self)
     }
 }
 
@@ -232,6 +265,10 @@ pub(crate) struct CatalogColumnDef {
     pub logical_type: String,
     pub is_nullable: bool,
     pub parent_index: Option<usize>,
+    pub initial_default: Option<String>,
+    pub default_value: Option<String>,
+    pub default_value_type: Option<String>,
+    pub default_value_dialect: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -245,6 +282,7 @@ pub(crate) struct ExistingCatalogColumn {
 pub(crate) fn catalog_column_defs(columns: &[ColumnDef]) -> Result<Vec<CatalogColumnDef>> {
     let mut result = Vec::new();
     for column in columns {
+        let root_index = result.len();
         append_column_def(
             &column.name,
             &column.data_type,
@@ -252,6 +290,13 @@ pub(crate) fn catalog_column_defs(columns: &[ColumnDef]) -> Result<Vec<CatalogCo
             None,
             &mut result,
         )?;
+        let root = &mut result[root_index];
+        root.initial_default.clone_from(&column.initial_default);
+        root.default_value.clone_from(&column.default_value);
+        root.default_value_type
+            .clone_from(&column.default_value_type);
+        root.default_value_dialect
+            .clone_from(&column.default_value_dialect);
     }
     Ok(result)
 }
@@ -270,6 +315,10 @@ fn append_column_def(
         logical_type: arrow_to_ducklake_type(data_type)?,
         is_nullable,
         parent_index,
+        initial_default: None,
+        default_value: None,
+        default_value_type: None,
+        default_value_dialect: None,
     });
     match data_type {
         DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
@@ -2106,7 +2155,10 @@ mod tests {
             false,
         );
         let columns = vec![
-            ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+            ColumnDef::from_arrow("id", &DataType::Int32, false)
+                .unwrap()
+                .with_default("7")
+                .unwrap(),
             ColumnDef::from_arrow("levels", &levels, false).unwrap(),
             ColumnDef::from_arrow("attrs", &attrs, true).unwrap(),
         ];
@@ -2142,6 +2194,14 @@ mod tests {
             top_level_column_ids(&definitions, &[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]).unwrap(),
             vec![10, 11, 16]
         );
+        let defaults = definitions
+            .iter()
+            .enumerate()
+            .filter_map(|(index, column)| {
+                column.default_value.as_deref().map(|value| (index, value))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(defaults, vec![(0, "7")]);
     }
 
     #[test]

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -810,9 +810,10 @@ fn finalize_snapshot(
             None => {
                 tx.execute(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                          (column_id, table_id, column_name, column_type, column_order,
+                           nulls_allowed, parent_column, begin_snapshot, initial_default,
+                           default_value, default_value_type, default_value_dialect)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
                         column_id,
                         table_id,
@@ -821,7 +822,11 @@ fn finalize_snapshot(
                         order as i64,
                         column.is_nullable,
                         parent_id,
-                        snapshot_id
+                        snapshot_id,
+                        column.initial_default.as_deref(),
+                        column.default_value.as_deref(),
+                        column.default_value_type.as_deref(),
+                        column.default_value_dialect.as_deref()
                     ],
                 )?;
             },
@@ -978,9 +983,10 @@ impl MetadataWriter for DuckdbMetadataWriter {
             let parent_id = column.parent_index.map(|index| column_ids[index]);
             tx.execute(
                 "INSERT INTO ducklake_column
-                     (column_id, table_id, column_name, column_type, column_order,
-                      nulls_allowed, parent_column, begin_snapshot)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                      (column_id, table_id, column_name, column_type, column_order,
+                       nulls_allowed, parent_column, begin_snapshot, initial_default,
+                       default_value, default_value_type, default_value_dialect)
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     column_id,
                     table_id,
@@ -989,7 +995,11 @@ impl MetadataWriter for DuckdbMetadataWriter {
                     order as i64,
                     column.is_nullable,
                     parent_id,
-                    snapshot_id
+                    snapshot_id,
+                    column.initial_default.as_deref(),
+                    column.default_value.as_deref(),
+                    column.default_value_type.as_deref(),
+                    column.default_value_dialect.as_deref()
                 ],
             )?;
         }

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -876,9 +876,10 @@ async fn finalize_snapshot(
             None => {
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                          (column_id, table_id, column_name, column_type, column_order,
+                           nulls_allowed, parent_column, begin_snapshot, initial_default,
+                           default_value, default_value_type, default_value_dialect)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
@@ -888,6 +889,10 @@ async fn finalize_snapshot(
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .execute(&mut **tx)
                 .await?;
             },
@@ -1069,9 +1074,10 @@ impl MetadataWriter for MySqlMetadataWriter {
                 let parent_id = column.parent_index.map(|index| field_ids[index]);
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                          (column_id, table_id, column_name, column_type, column_order,
+                           nulls_allowed, parent_column, begin_snapshot, initial_default,
+                           default_value, default_value_type, default_value_dialect)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
@@ -1081,6 +1087,10 @@ impl MetadataWriter for MySqlMetadataWriter {
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .execute(&mut *tx)
                 .await?;
             }
@@ -1835,6 +1845,37 @@ impl MetadataWriter for MySqlMetadataWriter {
             // create each table separately (see SQL_CREATE_TABLES).
             for ddl in SQL_CREATE_TABLES {
                 sqlx::query(*ddl).execute(&self.pool).await?;
+            }
+            let default_columns: Vec<String> = sqlx::query_scalar(
+                "SELECT column_name FROM information_schema.columns
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'ducklake_column'
+                   AND column_name IN ('initial_default', 'default_value',
+                                       'default_value_type', 'default_value_dialect')",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+            for (name, ddl) in [
+                (
+                    "initial_default",
+                    "ALTER TABLE ducklake_column ADD COLUMN initial_default VARCHAR(1024)",
+                ),
+                (
+                    "default_value",
+                    "ALTER TABLE ducklake_column ADD COLUMN default_value VARCHAR(1024)",
+                ),
+                (
+                    "default_value_type",
+                    "ALTER TABLE ducklake_column ADD COLUMN default_value_type VARCHAR(1024)",
+                ),
+                (
+                    "default_value_dialect",
+                    "ALTER TABLE ducklake_column ADD COLUMN default_value_dialect VARCHAR(1024)",
+                ),
+            ] {
+                if !default_columns.iter().any(|column| column == name) {
+                    sqlx::query(ddl).execute(&self.pool).await?;
+                }
             }
             // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id.
             // MySQL has no `ADD COLUMN IF NOT EXISTS`, so probe information_schema first

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -84,6 +84,10 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
         column_order BIGINT NOT NULL,
         nulls_allowed BOOLEAN DEFAULT TRUE,
         parent_column BIGINT,
+        initial_default VARCHAR,
+        default_value VARCHAR,
+        default_value_type VARCHAR,
+        default_value_dialect VARCHAR,
         begin_snapshot BIGINT NOT NULL,
         end_snapshot BIGINT,
         PRIMARY KEY (table_id, column_id, begin_snapshot)
@@ -349,6 +353,22 @@ pub(crate) async fn migrate_ducklake_column_to_composite_pk(pool: &PgPool) -> Re
                 EXECUTE 'ALTER TABLE ducklake_column ADD PRIMARY KEY (table_id, column_id, begin_snapshot)';
             END IF;
         END $$;"#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Add default metadata to a catalog created before those DuckLake columns were
+/// supported. The fields are nullable, so existing column versions retain the
+/// specified absence of a default.
+pub(crate) async fn migrate_column_default_metadata(pool: &PgPool) -> Result<()> {
+    sqlx::query(
+        "ALTER TABLE ducklake_column
+         ADD COLUMN IF NOT EXISTS initial_default VARCHAR,
+         ADD COLUMN IF NOT EXISTS default_value VARCHAR,
+         ADD COLUMN IF NOT EXISTS default_value_type VARCHAR,
+         ADD COLUMN IF NOT EXISTS default_value_dialect VARCHAR",
     )
     .execute(pool)
     .await?;
@@ -858,6 +878,10 @@ async fn live_columns_for_stats(
                 .unwrap_or(arrow::datatypes::DataType::Null),
             ducklake_type,
             is_nullable: true,
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         });
     }
     Ok((columns, column_ids))
@@ -1247,10 +1271,11 @@ async fn finalize_snapshot(
                 None => {
                     sqlx::query(
                         "INSERT INTO ducklake_column
-                             (column_id, table_id, column_name, column_type, column_order,
-                              nulls_allowed, parent_column, begin_snapshot)
-                         OVERRIDING SYSTEM VALUE
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                               (column_id, table_id, column_name, column_type, column_order,
+                                nulls_allowed, parent_column, begin_snapshot, initial_default,
+                                default_value, default_value_type, default_value_dialect)
+                          OVERRIDING SYSTEM VALUE
+                          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
                     )
                     .bind(column_id)
                     .bind(table_id)
@@ -1260,6 +1285,10 @@ async fn finalize_snapshot(
                     .bind(column.is_nullable)
                     .bind(parent_id)
                     .bind(snapshot_id)
+                    .bind(&column.initial_default)
+                    .bind(&column.default_value)
+                    .bind(&column.default_value_type)
+                    .bind(&column.default_value_dialect)
                     .execute(&mut **tx)
                     .await?;
                 },
@@ -1401,8 +1430,9 @@ impl MetadataWriter for PostgresMetadataWriter {
 
             // Live version of the column.
             let row = sqlx::query(
-                "SELECT column_id, column_type, column_order, nulls_allowed, parent_column
-                 FROM ducklake_column
+                "SELECT column_id, column_type, column_order, nulls_allowed, parent_column,
+                        initial_default, default_value, default_value_type, default_value_dialect
+                  FROM ducklake_column
                  WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL
                    AND parent_column IS NULL",
             )
@@ -1422,6 +1452,10 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .try_get::<Option<bool>, _>("nulls_allowed")?
                 .unwrap_or(true);
             let parent_column: Option<i64> = row.try_get("parent_column")?;
+            let initial_default: Option<String> = row.try_get("initial_default")?;
+            let default_value: Option<String> = row.try_get("default_value")?;
+            let default_value_type: Option<String> = row.try_get("default_value_type")?;
+            let default_value_dialect: Option<String> = row.try_get("default_value_dialect")?;
 
             // No-op / not-a-widening guards (canonical first so an alias-only
             // restatement is "no change", not attempted).
@@ -1505,9 +1539,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             .await?;
             sqlx::query(
                 "INSERT INTO ducklake_column
-                     (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot, parent_column)
+                     (column_id, table_id, column_name, column_type, column_order, nulls_allowed,
+                      parent_column, begin_snapshot, initial_default, default_value,
+                      default_value_type, default_value_dialect)
                  OVERRIDING SYSTEM VALUE
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
             )
             .bind(column_id)
             .bind(table_id)
@@ -1515,8 +1551,12 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(new_ducklake_type)
             .bind(column_order)
             .bind(nulls_allowed)
-            .bind(snapshot_id)
             .bind(parent_column)
+            .bind(snapshot_id)
+            .bind(initial_default)
+            .bind(default_value)
+            .bind(default_value_type)
+            .bind(default_value_dialect)
             .execute(&mut *tx)
             .await?;
 
@@ -1686,9 +1726,11 @@ impl MetadataWriter for PostgresMetadataWriter {
                 let parent_id = column.parent_index.map(|index| column_ids[index]);
                 let row = sqlx::query(
                     "INSERT INTO ducklake_column
-                         (table_id, column_name, column_type, column_order, nulls_allowed,
-                          parent_column, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING column_id",
+                           (table_id, column_name, column_type, column_order, nulls_allowed,
+                            parent_column, begin_snapshot, initial_default, default_value,
+                            default_value_type, default_value_dialect)
+                       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                       RETURNING column_id",
                 )
                 .bind(table_id)
                 .bind(&column.name)
@@ -1697,6 +1739,10 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .fetch_one(&mut *tx)
                 .await?;
                 column_ids.push(row.try_get(0)?);
@@ -4114,6 +4160,7 @@ impl MetadataWriter for PostgresMetadataWriter {
         block_on(async {
             execute_ddl_statements(&self.pool, SQL_CREATE_STANDARD_TABLES).await?;
             execute_ddl_statements(&self.pool, SQL_CREATE_MULTICATALOG_TABLES).await?;
+            migrate_column_default_metadata(&self.pool).await?;
             // Upgrade a pre-existing store's ducklake_column to the composite PK
             // (legacy single-row column_id PK → versioned-capable). Idempotent.
             migrate_ducklake_column_to_composite_pk(&self.pool).await?;

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -911,9 +911,10 @@ async fn finalize_snapshot(
                     .await?;
                     sqlx::query(
                         "INSERT INTO ducklake_column
-                             (column_id, table_id, column_name, column_type, column_order,
-                              nulls_allowed, parent_column, begin_snapshot)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot, initial_default,
+                          default_value, default_value_type, default_value_dialect)
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
                     )
                     .bind(column_id)
                     .bind(table_id)
@@ -923,6 +924,10 @@ async fn finalize_snapshot(
                     .bind(column.is_nullable)
                     .bind(parent_id)
                     .bind(snapshot_id)
+                    .bind(&column.initial_default)
+                    .bind(&column.default_value)
+                    .bind(&column.default_value_type)
+                    .bind(&column.default_value_dialect)
                     .execute(&mut **tx)
                     .await?;
                 } else if *cur_order != order as i64 || *cur_nullable != column.is_nullable {
@@ -942,9 +947,10 @@ async fn finalize_snapshot(
             None => {
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                            (column_id, table_id, column_name, column_type, column_order,
+                             nulls_allowed, parent_column, begin_snapshot, initial_default,
+                             default_value, default_value_type, default_value_dialect)
+                            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
                 )
                 .bind(column_id)
                 .bind(table_id)
@@ -954,6 +960,10 @@ async fn finalize_snapshot(
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .execute(&mut **tx)
                 .await?;
             },
@@ -1139,9 +1149,10 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 let parent_id = column.parent_index.map(|index| field_ids[index]);
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                     (column_id, table_id, column_name, column_type, column_order,
+                      nulls_allowed, parent_column, begin_snapshot, initial_default,
+                      default_value, default_value_type, default_value_dialect)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
                 )
                 .bind(column_id)
                 .bind(table_id)
@@ -1151,6 +1162,10 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .execute(&mut *tx)
                 .await?;
             }
@@ -1889,6 +1904,15 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             for ddl in SQL_CREATE_TABLES {
                 sqlx::query(*ddl).execute(&self.pool).await?;
             }
+            sqlx::query(
+                "ALTER TABLE ducklake_column
+                 ADD COLUMN IF NOT EXISTS initial_default VARCHAR,
+                 ADD COLUMN IF NOT EXISTS default_value VARCHAR,
+                 ADD COLUMN IF NOT EXISTS default_value_type VARCHAR,
+                 ADD COLUMN IF NOT EXISTS default_value_dialect VARCHAR",
+            )
+            .execute(&self.pool)
+            .await?;
             // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id
             // (idempotent, lossless — NULL means "not partitioned").
             sqlx::query(

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -791,12 +791,13 @@ async fn reserve_ids(
 /// row sharing a `column_id`, which a versioned / type-promoted column requires,
 /// so this migration is what lets existing users' catalogs support type promotion.
 ///
-/// **Idempotent:** a no-op once `column_id` is no longer a PK (re-runs on every
-/// `initialize_schema`). **Crash-safe:** the rebuild is one transaction (SQLite
-/// DDL is transactional), so a crash leaves either the old or the new table whole,
-/// never a half-state. **Lossless:** every row and every `column_id` value is
-/// preserved (field-ids baked in Parquet stay valid), and it tolerates older
-/// catalogs missing some of the 13 columns (those are filled with `NULL`).
+/// **Idempotent:** a no-op once `column_id` is no longer a PK and all current
+/// metadata columns exist (re-runs on every `initialize_schema`). **Crash-safe:**
+/// SQLite runs the rebuild in one transaction, so a crash leaves either the old or
+/// the new table whole, never a half-state. **Lossless:** every row and every
+/// `column_id` value is preserved (field-ids baked in Parquet stay valid), and it
+/// tolerates older catalogs missing some of the 13 columns (those are filled with
+/// `NULL`).
 async fn migrate_ducklake_column_drop_pk(pool: &SqlitePool) -> Result<()> {
     // Legacy shape iff `column_id` is a PRIMARY KEY. `pragma_table_info` returns
     // one row per column with a `pk` flag (0 = not part of the PK).
@@ -813,8 +814,11 @@ async fn migrate_ducklake_column_drop_pk(pool: &SqlitePool) -> Result<()> {
         }
         legacy_cols.insert(name);
     }
-    if !column_id_is_pk {
-        // Fresh (already bare) or previously migrated — nothing to do.
+    let has_default_columns =
+        ["initial_default", "default_value", "default_value_type", "default_value_dialect"]
+            .iter()
+            .all(|name| legacy_cols.contains(*name));
+    if !column_id_is_pk && has_default_columns {
         return Ok(());
     }
 
@@ -1299,6 +1303,10 @@ async fn live_columns_for_stats(
                 .unwrap_or(arrow::datatypes::DataType::Null),
             ducklake_type,
             is_nullable: true,
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         });
     }
     Ok((columns, column_ids))
@@ -1558,9 +1566,10 @@ async fn finalize_snapshot(
             None => {
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                          (column_id, table_id, column_name, column_type, column_order,
+                           nulls_allowed, parent_column, begin_snapshot, initial_default,
+                           default_value, default_value_type, default_value_dialect)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
@@ -1570,6 +1579,10 @@ async fn finalize_snapshot(
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .execute(&mut **tx)
                 .await?;
             },
@@ -1803,8 +1816,9 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             // Locate the live version of the column.
             let row = sqlx::query(
-                "SELECT column_id, column_type, column_order, nulls_allowed, parent_column
-                 FROM ducklake_column
+                "SELECT column_id, column_type, column_order, nulls_allowed, parent_column,
+                        initial_default, default_value, default_value_type, default_value_dialect
+                  FROM ducklake_column
                  WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
                    AND parent_column IS NULL",
             )
@@ -1824,6 +1838,10 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .try_get::<Option<bool>, _>("nulls_allowed")?
                 .unwrap_or(true);
             let parent_column: Option<i64> = row.try_get("parent_column")?;
+            let initial_default: Option<String> = row.try_get("initial_default")?;
+            let default_value: Option<String> = row.try_get("default_value")?;
+            let default_value_type: Option<String> = row.try_get("default_value_type")?;
+            let default_value_dialect: Option<String> = row.try_get("default_value_dialect")?;
 
             // No-op / not-a-widening guards. Canonical equality first so an
             // alias-only restatement is reported as "no change", not attempted.
@@ -1860,8 +1878,10 @@ impl MetadataWriter for SqliteMetadataWriter {
             .await?;
             sqlx::query(
                 "INSERT INTO ducklake_column
-                     (column_id, begin_snapshot, end_snapshot, table_id, column_order, column_name, column_type, nulls_allowed, parent_column)
-                 VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)",
+                     (column_id, begin_snapshot, end_snapshot, table_id, column_order, column_name,
+                      column_type, nulls_allowed, parent_column, initial_default, default_value,
+                      default_value_type, default_value_dialect)
+                 VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(column_id)
             .bind(new_snapshot)
@@ -1871,6 +1891,10 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(new_ducklake_type)
             .bind(nulls_allowed)
             .bind(parent_column)
+            .bind(initial_default)
+            .bind(default_value)
+            .bind(default_value_type)
+            .bind(default_value_dialect)
             .execute(&mut *tx)
             .await?;
 
@@ -2263,9 +2287,10 @@ impl MetadataWriter for SqliteMetadataWriter {
                 let parent_id = column.parent_index.map(|index| column_ids[index]);
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order,
-                          nulls_allowed, parent_column, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                          (column_id, table_id, column_name, column_type, column_order,
+                           nulls_allowed, parent_column, begin_snapshot, initial_default,
+                           default_value, default_value_type, default_value_dialect)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
@@ -2275,6 +2300,10 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .bind(column.is_nullable)
                 .bind(parent_id)
                 .bind(snapshot_id)
+                .bind(&column.initial_default)
+                .bind(&column.default_value)
+                .bind(&column.default_value_type)
+                .bind(&column.default_value_dialect)
                 .execute(&mut *tx)
                 .await?;
             }
@@ -4351,6 +4380,58 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(cnt2, 2, "migration must be idempotent");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn migrate_bare_column_table_adds_default_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("legacy-defaults.db");
+        let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+        let pool = SqlitePool::connect(&conn_str).await.unwrap();
+
+        sqlx::query(
+            "CREATE TABLE ducklake_column (
+                column_id BIGINT,
+                begin_snapshot BIGINT,
+                end_snapshot BIGINT,
+                table_id BIGINT,
+                column_order BIGINT,
+                column_name VARCHAR,
+                column_type VARCHAR,
+                nulls_allowed BOOLEAN,
+                parent_column BIGINT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO ducklake_column
+             (column_id, begin_snapshot, table_id, column_order, column_name,
+              column_type, nulls_allowed)
+             VALUES (5, 1, 1, 0, 'id', 'int32', 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        migrate_ducklake_column_drop_pk(&pool).await.unwrap();
+
+        let default_columns: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
+             WHERE name IN ('initial_default', 'default_value',
+                            'default_value_type', 'default_value_dialect')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(default_columns, 4);
+        let row: (i64, String) =
+            sqlx::query_as("SELECT column_id, column_name FROM ducklake_column WHERE table_id = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row, (5, "id".to_string()));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -37,6 +37,7 @@ pub async fn initialize_multicatalog_schema(pool: &PgPool) -> Result<()> {
         crate::metadata_writer_postgres::SQL_CREATE_MULTICATALOG_TABLES,
     )
     .await?;
+    crate::metadata_writer_postgres::migrate_column_default_metadata(pool).await?;
     // Upgrade a pre-existing store's ducklake_column from the legacy single-row
     // column_id PK to the composite (table_id, column_id, begin_snapshot) PK so
     // versioned / type-promoted columns work on catalogs created before this

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -384,7 +384,8 @@ impl MetadataProvider for MulticatalogProvider {
         // commits before the head advances). Match the catalog head window.
         block_on(async {
             let rows = sqlx::query(
-                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
+                        initial_default, default_value, default_value_type, default_value_dialect
                  FROM ducklake_column
                  WHERE table_id = $1
                    AND $2 >= begin_snapshot
@@ -403,14 +404,18 @@ impl MetadataProvider for MulticatalogProvider {
                     let nulls_allowed: Option<bool> = row.try_get(3)?;
                     let parent_column: Option<i64> = row.try_get(4)?;
                     Ok((
-                        DuckLakeTableColumn {
-                            column_id: row.try_get(0)?,
-                            column_name: row.try_get(1)?,
-                            column_type: row.try_get(2)?,
-                            is_nullable: nulls_allowed.unwrap_or(true),
-                            data_type: None,
-                            nested_column_ids: Vec::new(),
-                        },
+                        DuckLakeTableColumn::new(
+                            row.try_get(0)?,
+                            row.try_get(1)?,
+                            row.try_get(2)?,
+                            nulls_allowed.unwrap_or(true),
+                        )
+                        .with_defaults(
+                            row.try_get(5)?,
+                            row.try_get(6)?,
+                            row.try_get(7)?,
+                            row.try_get(8)?,
+                        ),
                         parent_column,
                     ))
                 })
@@ -1218,7 +1223,8 @@ impl MetadataProvider for MulticatalogProvider {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type,
-                        c.nulls_allowed, c.parent_column
+                        c.nulls_allowed, c.parent_column, c.initial_default, c.default_value,
+                        c.default_value_type, c.default_value_dialect
                  FROM ducklake_schema s
                  JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
                  JOIN ducklake_table t ON s.schema_id = t.schema_id
@@ -1249,14 +1255,18 @@ impl MetadataProvider for MulticatalogProvider {
                     let table_name: String = row.try_get(1)?;
                     let nulls_allowed: Option<bool> = row.try_get(5)?;
                     let parent_column: Option<i64> = row.try_get(6)?;
-                    let column = DuckLakeTableColumn {
-                        column_id: row.try_get(2)?,
-                        column_name: row.try_get(3)?,
-                        column_type: row.try_get(4)?,
-                        is_nullable: nulls_allowed.unwrap_or(true),
-                        data_type: None,
-                        nested_column_ids: Vec::new(),
-                    };
+                    let column = DuckLakeTableColumn::new(
+                        row.try_get(2)?,
+                        row.try_get(3)?,
+                        row.try_get(4)?,
+                        nulls_allowed.unwrap_or(true),
+                    )
+                    .with_defaults(
+                        row.try_get(7)?,
+                        row.try_get(8)?,
+                        row.try_get(9)?,
+                        row.try_get(10)?,
+                    );
                     Ok((
                         ColumnWithTable {
                             schema_name,

--- a/src/table.rs
+++ b/src/table.rs
@@ -21,7 +21,8 @@ use crate::row_id::{
 };
 use crate::snapshot_filter::SnapshotFilterExec;
 use crate::types::{
-    build_arrow_schema, build_read_schema_with_field_id_mapping, extract_parquet_field_ids,
+    DuckLakeDefaultExprAdapterFactory, build_arrow_schema, build_read_schema_with_field_id_mapping,
+    ducklake_to_arrow_type, extract_parquet_field_ids, parse_ducklake_default_scalar,
     parse_ducklake_scalar,
 };
 
@@ -54,7 +55,9 @@ use datafusion::common::{Column, ColumnStatistics, ScalarValue, Statistics};
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroupAccess};
-use datafusion::datasource::physical_plan::{FileGroup, FileScanConfigBuilder, ParquetSource};
+use datafusion::datasource::physical_plan::{
+    FileGroup, FileScanConfigBuilder, FileSource, ParquetSource,
+};
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::object_store::ObjectStoreUrl;
@@ -249,6 +252,50 @@ fn parse_statistic_scalar(
         );
     }
     parsed
+}
+
+fn validate_column_defaults(columns: &[DuckLakeTableColumn]) -> Result<HashMap<String, Expr>> {
+    let mut defaults = HashMap::new();
+    for column in columns {
+        let data_type = ducklake_to_arrow_type(&column.column_type)?;
+        if let Some(value) = &column.initial_default
+            && parse_ducklake_default_scalar(value, &data_type).is_none()
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "Cannot decode initial_default '{value}' for column '{}' as {}",
+                column.column_name, data_type
+            )));
+        }
+
+        let Some(value) = &column.default_value else {
+            continue;
+        };
+        match column.default_value_type.as_deref() {
+            None | Some("literal") => {
+                let scalar = parse_ducklake_default_scalar(value, &data_type).ok_or_else(|| {
+                    crate::DuckLakeError::InvalidConfig(format!(
+                        "Cannot decode default_value '{value}' for column '{}' as {}",
+                        column.column_name, data_type
+                    ))
+                })?;
+                defaults.insert(column.column_name.clone(), Expr::Literal(scalar, None));
+            },
+            Some("expression") => {
+                tracing::debug!(
+                    column = %column.column_name,
+                    dialect = column.default_value_dialect.as_deref().unwrap_or("unknown"),
+                    "Ignoring unevaluated DuckLake expression default"
+                );
+            },
+            Some(value_type) => {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "Default value type '{value_type}' for column '{}' is not supported",
+                    column.column_name
+                )));
+            },
+        }
+    }
+    Ok(defaults)
 }
 
 /// Whether a stored float `max_value` is a usable upper bound.
@@ -880,6 +927,8 @@ pub struct DuckLakeTable {
     row_lineage: bool,
     /// Column metadata from DuckLake (needed for field_id mapping)
     columns: Vec<DuckLakeTableColumn>,
+    /// Literal defaults used by DataFusion when an INSERT omits a column
+    column_defaults: HashMap<String, Expr>,
     /// Table-level statistics for the physical schema.
     table_statistics: Statistics,
     /// The table's active partition spec at `snapshot_id`, if any. Loaded once at
@@ -934,6 +983,7 @@ impl DuckLakeTable {
         // File metadata is deliberately deferred until scan(), where it can be
         // consumed and pruned in bounded pages.
         let columns = provider.get_table_structure(table_id, snapshot_id)?;
+        let column_defaults = validate_column_defaults(&columns)?;
         // Active partition spec (if any) for pruning. Loaded once at the bound
         // snapshot; `None` for unpartitioned tables or catalogs without partitions.
         let partition_spec = provider.get_partition_spec(table_id, snapshot_id)?;
@@ -968,6 +1018,7 @@ impl DuckLakeTable {
             physical_schema,
             row_lineage: false,
             columns,
+            column_defaults,
             table_statistics,
             partition_spec,
             #[cfg(feature = "encryption")]
@@ -1462,6 +1513,11 @@ impl DuckLakeTable {
         ParquetSource::new(schema)
     }
 
+    fn scan_config_builder(&self, source: Arc<dyn FileSource>) -> FileScanConfigBuilder {
+        FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+            .with_expr_adapter(Some(Arc::new(DuckLakeDefaultExprAdapterFactory)))
+    }
+
     /// Add each file's decryption key — and that of its live delete file — to
     /// `builder`, resolving paths the same way the readers do. Separate from
     /// installation so a caller reading the catalog in pages can accumulate keys
@@ -1637,7 +1693,7 @@ impl DuckLakeTable {
         let physical_proj: Vec<usize> = (0..self.physical_schema.fields().len()).collect();
         let num_file_groups = file_groups.len();
         let scan = DataSourceExec::from_data_source(
-            FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+            self.scan_config_builder(source)
                 .with_file_groups(file_groups)
                 .with_output_partitioning(Some(
                     datafusion::physical_expr::Partitioning::UnknownPartitioning(num_file_groups),
@@ -1876,12 +1932,10 @@ impl DuckLakeTable {
         // group to the catalog schema (renamed columns or a differing Arrow type).
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(groups.len());
         for ((read_schema, name_mapping), partitioned_files) in groups {
-            let mut builder = FileScanConfigBuilder::new(
-                self.object_store_url.as_ref().clone(),
-                Arc::new(self.create_parquet_source(read_schema.clone())),
-            )
-            .with_limit(limit)
-            .with_file_group(FileGroup::new(partitioned_files));
+            let mut builder = self
+                .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
+                .with_limit(limit)
+                .with_file_group(FileGroup::new(partitioned_files));
 
             if let Some(proj) = projection {
                 builder = builder.with_projection_indices(Some(proj.clone()))?;
@@ -2024,20 +2078,18 @@ impl DuckLakeTable {
                 self.create_parquet_source(file_cfg.read_schema.clone()),
             ));
             let num_file_groups = file_groups.len();
-            let mut builder =
-                FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
-                    .with_file_groups(file_groups)
-                    // FileRowNumberExec seeds row positions from the scan
-                    // partition index, so each partition must read exactly
-                    // its configured row-group chunk. Declaring the output
-                    // partitioning pins the file-group-to-partition mapping;
-                    // otherwise DataFusion's shared work queue lets sibling
-                    // partitions steal chunks.
-                    .with_output_partitioning(Some(
-                        datafusion::physical_expr::Partitioning::UnknownPartitioning(
-                            num_file_groups,
-                        ),
-                    ));
+            let mut builder = self
+                .scan_config_builder(source)
+                .with_file_groups(file_groups)
+                // FileRowNumberExec seeds row positions from the scan
+                // partition index, so each partition must read exactly
+                // its configured row-group chunk. Declaring the output
+                // partitioning pins the file-group-to-partition mapping;
+                // otherwise DataFusion's shared work queue lets sibling
+                // partitions steal chunks.
+                .with_output_partitioning(Some(
+                    datafusion::physical_expr::Partitioning::UnknownPartitioning(num_file_groups),
+                ));
             builder = builder.with_projection_indices(Some(proj_indices.clone()))?;
             let scan = DataSourceExec::from_data_source(builder.build());
 
@@ -2055,12 +2107,12 @@ impl DuckLakeTable {
                 file_cfg.embedded_rowid_parquet_name.is_some(),
                 file_statistics,
             )?;
-            let mut builder = FileScanConfigBuilder::new(
-                self.object_store_url.as_ref().clone(),
-                Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
-            )
-            .with_limit(limit)
-            .with_file_group(FileGroup::new(vec![pf]));
+            let mut builder = self
+                .scan_config_builder(Arc::new(
+                    self.create_parquet_source(file_cfg.read_schema.clone()),
+                ))
+                .with_limit(limit)
+                .with_file_group(FileGroup::new(vec![pf]));
             builder = builder.with_projection_indices(Some(proj_indices.clone()))?;
             DataSourceExec::from_data_source(builder.build())
         };
@@ -2310,20 +2362,18 @@ impl DuckLakeTable {
                 self.create_parquet_source(file_cfg.read_schema.clone()),
             ));
             let num_file_groups = file_groups.len();
-            let mut builder =
-                FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
-                    .with_file_groups(file_groups)
-                    // FileRowNumberExec seeds row positions from the scan
-                    // partition index, so each partition must read exactly
-                    // its configured row-group chunk. Declaring the output
-                    // partitioning pins the file-group-to-partition mapping;
-                    // otherwise DataFusion's shared work queue lets sibling
-                    // partitions steal chunks.
-                    .with_output_partitioning(Some(
-                        datafusion::physical_expr::Partitioning::UnknownPartitioning(
-                            num_file_groups,
-                        ),
-                    ));
+            let mut builder = self
+                .scan_config_builder(source)
+                .with_file_groups(file_groups)
+                // FileRowNumberExec seeds row positions from the scan
+                // partition index, so each partition must read exactly
+                // its configured row-group chunk. Declaring the output
+                // partitioning pins the file-group-to-partition mapping;
+                // otherwise DataFusion's shared work queue lets sibling
+                // partitions steal chunks.
+                .with_output_partitioning(Some(
+                    datafusion::physical_expr::Partitioning::UnknownPartitioning(num_file_groups),
+                ));
             builder = builder.with_projection_indices(Some(parquet_projection))?;
             let scan = DataSourceExec::from_data_source(builder.build());
 
@@ -2346,12 +2396,12 @@ impl DuckLakeTable {
             // Embedded rowid, no deletes: legacy plain scan (cardinality-
             // preserving). Keep scan-level limit and reader pruning.
             let pf = self.partitioned_data_file(table_file, true, file_statistics)?;
-            let mut builder = FileScanConfigBuilder::new(
-                self.object_store_url.as_ref().clone(),
-                Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
-            )
-            .with_limit(limit)
-            .with_file_group(FileGroup::new(vec![pf]));
+            let mut builder = self
+                .scan_config_builder(Arc::new(
+                    self.create_parquet_source(file_cfg.read_schema.clone()),
+                ))
+                .with_limit(limit)
+                .with_file_group(FileGroup::new(vec![pf]));
             builder = builder.with_projection_indices(Some(parquet_projection))?;
             DataSourceExec::from_data_source(builder.build())
         };
@@ -2480,12 +2530,10 @@ impl DuckLakeTable {
         {
             pf = pf.with_metadata_size_hint(hint);
         }
-        let builder = FileScanConfigBuilder::new(
-            self.object_store_url.as_ref().clone(),
-            Arc::new(self.create_parquet_source(read_schema.clone())),
-        )
-        .with_file_group(FileGroup::new(vec![pf]))
-        .with_projection_indices(Some(projection))?;
+        let builder = self
+            .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
+            .with_file_group(FileGroup::new(vec![pf]))
+            .with_projection_indices(Some(projection))?;
         let scan = DataSourceExec::from_data_source(builder.build());
 
         // Drop rows newer than the read snapshot, then present the catalog schema.
@@ -2519,6 +2567,7 @@ impl DuckLakeTable {
             physical_schema: self.physical_schema.clone(),
             row_lineage: false,
             columns: self.columns.clone(),
+            column_defaults: self.column_defaults.clone(),
             table_statistics: self.table_statistics.clone(),
             partition_spec: self.partition_spec.clone(),
             // `snapshot_id`/cache match the post-#163 struct (Arc-wrapped cache,
@@ -2744,7 +2793,7 @@ impl DuckLakeTable {
         });
         let num_file_groups = file_groups.len();
         let scan = DataSourceExec::from_data_source(
-            FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+            self.scan_config_builder(source)
                 .with_file_groups(file_groups)
                 .with_output_partitioning(Some(
                     datafusion::physical_expr::Partitioning::UnknownPartitioning(num_file_groups),
@@ -3079,6 +3128,10 @@ impl TableProvider for DuckLakeTable {
 
     fn table_type(&self) -> TableType {
         TableType::Base
+    }
+
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.column_defaults.get(column)
     }
 
     fn statistics(&self) -> Option<Statistics> {
@@ -5131,6 +5184,34 @@ mod tests {
             parse_statistic_scalar("123.45", &decimal, &DataType::Decimal128(10, 2)),
             Some(ScalarValue::Decimal128(Some(12_345), 10, 2))
         );
+    }
+
+    #[test]
+    fn expression_column_default_does_not_block_table_reads() {
+        let column =
+            DuckLakeTableColumn::new(1, "created_at".to_string(), "timestamp".to_string(), false)
+                .with_defaults(
+                    None,
+                    Some("current_timestamp".to_string()),
+                    Some("expression".to_string()),
+                    Some("duckdb".to_string()),
+                );
+
+        assert!(validate_column_defaults(&[column]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn null_default_sentinel_does_not_create_an_operational_default() {
+        let column = DuckLakeTableColumn::new(1, "id".to_string(), "int32".to_string(), false)
+            .with_defaults(
+                None,
+                Some("NULL".to_string()),
+                Some("literal".to_string()),
+                Some("duckdb".to_string()),
+            );
+
+        assert!(column.default_value.is_none());
+        assert!(validate_column_defaults(&[column]).unwrap().is_empty());
     }
 
     // `sort_ordering_for` is `#[cfg(feature = "write")]`, so the test that exercises

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,11 +6,81 @@ use std::sync::Arc;
 use crate::metadata_provider::DuckLakeTableColumn;
 use crate::{DuckLakeError, Result};
 use arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
-use datafusion::common::ScalarValue;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::common::{Result as DataFusionResult, ScalarValue};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{self, Column};
+use datafusion::physical_expr_adapter::{
+    DefaultPhysicalExprAdapter, PhysicalExprAdapter, PhysicalExprAdapterFactory,
+};
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use parquet::file::metadata::ParquetMetaData;
 
 pub(crate) const MAX_NESTED_TYPE_DEPTH: usize = 128;
+
+const INITIAL_DEFAULT_METADATA_KEY: &str = "ducklake.initial_default";
+
+#[derive(Debug)]
+pub(crate) struct DuckLakeDefaultExprAdapterFactory;
+
+impl PhysicalExprAdapterFactory for DuckLakeDefaultExprAdapterFactory {
+    fn create(
+        &self,
+        logical_file_schema: Arc<Schema>,
+        physical_file_schema: Arc<Schema>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExprAdapter>> {
+        Ok(Arc::new(DuckLakeDefaultExprAdapter {
+            fallback: DefaultPhysicalExprAdapter::new(
+                Arc::clone(&logical_file_schema),
+                Arc::clone(&physical_file_schema),
+            ),
+            logical_file_schema,
+            physical_file_schema,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct DuckLakeDefaultExprAdapter {
+    fallback: DefaultPhysicalExprAdapter,
+    logical_file_schema: Arc<Schema>,
+    physical_file_schema: Arc<Schema>,
+}
+
+impl PhysicalExprAdapter for DuckLakeDefaultExprAdapter {
+    fn rewrite(&self, expr: Arc<dyn PhysicalExpr>) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let rewritten = expr
+            .transform(|expr| {
+                let Some(column) = expr.downcast_ref::<Column>() else {
+                    return Ok(Transformed::no(expr));
+                };
+                if self
+                    .physical_file_schema
+                    .field_with_name(column.name())
+                    .is_ok()
+                {
+                    return Ok(Transformed::no(expr));
+                }
+                let Ok(field) = self.logical_file_schema.field_with_name(column.name()) else {
+                    return Ok(Transformed::no(expr));
+                };
+                let Some(value) = field.metadata().get(INITIAL_DEFAULT_METADATA_KEY) else {
+                    return Ok(Transformed::no(expr));
+                };
+                let scalar =
+                    parse_ducklake_default_scalar(value, field.data_type()).ok_or_else(|| {
+                        datafusion::error::DataFusionError::Execution(format!(
+                            "Cannot decode initial_default '{value}' for column '{}' as {}",
+                            column.name(),
+                            field.data_type()
+                        ))
+                    })?;
+                Ok(Transformed::yes(expressions::lit(scalar)))
+            })
+            .data()?;
+        self.fallback.rewrite(rewritten)
+    }
+}
 
 pub(crate) fn parse_ducklake_scalar(value: &str, data_type: &DataType) -> Option<ScalarValue> {
     match data_type {
@@ -37,6 +107,39 @@ pub(crate) fn parse_ducklake_scalar(value: &str, data_type: &DataType) -> Option
         | DataType::Map(_, _) => None,
         _ => ScalarValue::try_from_string(value.to_string(), data_type).ok(),
     }
+}
+
+pub(crate) fn parse_ducklake_default_scalar(
+    value: &str,
+    data_type: &DataType,
+) -> Option<ScalarValue> {
+    match data_type {
+        DataType::Binary => Some(ScalarValue::Binary(Some(parse_duckdb_blob(value)?))),
+        DataType::LargeBinary => Some(ScalarValue::LargeBinary(Some(parse_duckdb_blob(value)?))),
+        DataType::BinaryView => Some(ScalarValue::BinaryView(Some(parse_duckdb_blob(value)?))),
+        _ => parse_ducklake_scalar(value, data_type),
+    }
+}
+
+fn parse_duckdb_blob(value: &str) -> Option<Vec<u8>> {
+    // DuckDB keeps printable bytes verbatim and escapes non-printable bytes as `\xNN`
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' && bytes.get(index + 1) == Some(&b'x') {
+            let pair = bytes.get(index + 2..index + 4)?;
+            let pair = std::str::from_utf8(pair).ok()?;
+            decoded.push(u8::from_str_radix(pair, 16).ok()?);
+            index += 4;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+
+    Some(decoded)
 }
 
 fn decode_hex(value: &str) -> Option<Vec<u8>> {
@@ -1032,14 +1135,21 @@ pub fn build_read_schema_with_field_id_mapping(
                 name_mapping.insert(read_name.clone(), col.column_name.clone());
             }
 
-            // An absent column is materialised as a null array by the scan, so its
-            // read field must be nullable; the catalog nullability is still
-            // enforced on output by ColumnRenameExec.
-            Ok(Field::new(
+            // Without an initial default, an absent column is materialised as a
+            // null array, so its read field must be nullable. ColumnRenameExec
+            // still enforces the catalog nullability on output.
+            let mut field = Field::new(
                 read_name,
                 data_type,
-                col.is_nullable || is_absent,
-            ))
+                col.is_nullable || (is_absent && col.initial_default.is_none()),
+            );
+            if is_absent && let Some(initial_default) = &col.initial_default {
+                field = field.with_metadata(HashMap::from([(
+                    INITIAL_DEFAULT_METADATA_KEY.to_string(),
+                    initial_default.clone(),
+                )]));
+            }
+            Ok(field)
         })
         .collect();
 
@@ -1054,22 +1164,18 @@ mod tests {
     fn test_build_read_schema_with_renamed_columns() {
         // Simulate: column was originally named "user_id", now renamed to "userId"
         let current_columns = vec![
-            DuckLakeTableColumn {
-                column_id: 1,
-                column_name: "userId".to_string(), // Current name (renamed)
-                column_type: "int32".to_string(),
-                is_nullable: true,
-                data_type: None,
-                nested_column_ids: Vec::new(),
-            },
-            DuckLakeTableColumn {
-                column_id: 2,
-                column_name: "name".to_string(), // Not renamed
-                column_type: "varchar".to_string(),
-                is_nullable: true,
-                data_type: None,
-                nested_column_ids: Vec::new(),
-            },
+            DuckLakeTableColumn::new(
+                1,
+                "userId".to_string(), // Current name (renamed)
+                "int32".to_string(),
+                true,
+            ),
+            DuckLakeTableColumn::new(
+                2,
+                "name".to_string(), // Not renamed
+                "varchar".to_string(),
+                true,
+            ),
         ];
 
         // Parquet file has original names
@@ -1092,14 +1198,8 @@ mod tests {
 
     #[test]
     fn test_build_read_schema_no_rename_needed() {
-        let current_columns = vec![DuckLakeTableColumn {
-            column_id: 1,
-            column_name: "id".to_string(),
-            column_type: "int32".to_string(),
-            is_nullable: true,
-            data_type: None,
-            nested_column_ids: Vec::new(),
-        }];
+        let current_columns =
+            vec![DuckLakeTableColumn::new(1, "id".to_string(), "int32".to_string(), true)];
 
         let mut parquet_field_ids = HashMap::new();
         parquet_field_ids.insert(1, "id".to_string()); // Same name
@@ -1115,14 +1215,8 @@ mod tests {
     #[test]
     fn test_build_read_schema_no_field_ids() {
         // External file without field_ids
-        let current_columns = vec![DuckLakeTableColumn {
-            column_id: 1,
-            column_name: "id".to_string(),
-            column_type: "int32".to_string(),
-            is_nullable: true,
-            data_type: None,
-            nested_column_ids: Vec::new(),
-        }];
+        let current_columns =
+            vec![DuckLakeTableColumn::new(1, "id".to_string(), "int32".to_string(), true)];
 
         let parquet_field_ids = HashMap::new(); // No field_ids in Parquet
 
@@ -1142,22 +1236,8 @@ mod tests {
         // carries a column literally named "tag" (the dropped one, different
         // field_id), which must NOT be aliased.
         let current_columns = vec![
-            DuckLakeTableColumn {
-                column_id: 1,
-                column_name: "id".to_string(),
-                column_type: "int32".to_string(),
-                is_nullable: true,
-                data_type: None,
-                nested_column_ids: Vec::new(),
-            },
-            DuckLakeTableColumn {
-                column_id: 2,
-                column_name: "tag".to_string(),
-                column_type: "varchar".to_string(),
-                is_nullable: true,
-                data_type: None,
-                nested_column_ids: Vec::new(),
-            },
+            DuckLakeTableColumn::new(1, "id".to_string(), "int32".to_string(), true),
+            DuckLakeTableColumn::new(2, "tag".to_string(), "varchar".to_string(), true),
         ];
 
         let mut parquet_field_ids = HashMap::new();
@@ -1201,6 +1281,10 @@ mod tests {
                 .into(),
             )),
             nested_column_ids: vec![2, 3, 4],
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         }];
         let parquet_field_ids = HashMap::from([
             (1, "payload".to_string()),
@@ -1257,6 +1341,10 @@ mod tests {
                 vec![Arc::new(Field::new("c", DataType::Int32, true))].into(),
             )),
             nested_column_ids: vec![4],
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         }];
         let parquet_field_ids = HashMap::from([(1, "payload".to_string()), (3, "c".to_string())]);
         let id_metadata =
@@ -1340,6 +1428,10 @@ mod tests {
                     true,
                 )))),
                 nested_column_ids: vec![2],
+                initial_default: None,
+                default_value: None,
+                default_value_type: None,
+                default_value_dialect: None,
             },
             DuckLakeTableColumn {
                 column_id: 3,
@@ -1354,6 +1446,10 @@ mod tests {
                     .into(),
                 )),
                 nested_column_ids: vec![4, 5],
+                initial_default: None,
+                default_value: None,
+                default_value_type: None,
+                default_value_dialect: None,
             },
             DuckLakeTableColumn {
                 column_id: 6,
@@ -1375,6 +1471,10 @@ mod tests {
                     false,
                 )),
                 nested_column_ids: vec![7, 8],
+                initial_default: None,
+                default_value: None,
+                default_value_type: None,
+                default_value_dialect: None,
             },
             DuckLakeTableColumn {
                 column_id: 9,
@@ -1387,6 +1487,10 @@ mod tests {
                     true,
                 )))),
                 nested_column_ids: vec![10, 11],
+                initial_default: None,
+                default_value: None,
+                default_value_type: None,
+                default_value_dialect: None,
             },
         ]
     }
@@ -1528,6 +1632,104 @@ mod tests {
         }
     }
 
+    #[test]
+    fn ducklake_primitive_literals_decode_exactly() {
+        let cases = vec![
+            ("boolean", "1", ScalarValue::Boolean(Some(true))),
+            ("int8", "-8", ScalarValue::Int8(Some(-8))),
+            ("int16", "-1600", ScalarValue::Int16(Some(-1600))),
+            ("int32", "-3200", ScalarValue::Int32(Some(-3200))),
+            ("int64", "-6400", ScalarValue::Int64(Some(-6400))),
+            ("uint8", "8", ScalarValue::UInt8(Some(8))),
+            ("uint16", "1600", ScalarValue::UInt16(Some(1600))),
+            ("uint32", "3200", ScalarValue::UInt32(Some(3200))),
+            ("uint64", "6400", ScalarValue::UInt64(Some(6400))),
+            ("float32", "3.5", ScalarValue::Float32(Some(3.5))),
+            ("float64", "7.25", ScalarValue::Float64(Some(7.25))),
+            (
+                "decimal(10,2)",
+                "123.45",
+                ScalarValue::Decimal128(Some(12_345), 10, 2),
+            ),
+            (
+                "time",
+                "00:00:01.000002",
+                ScalarValue::Time64Microsecond(Some(1_000_002)),
+            ),
+            ("date", "1970-01-02", ScalarValue::Date32(Some(1))),
+            (
+                "timestamp",
+                "1970-01-01 00:00:01.000002",
+                ScalarValue::TimestampMicrosecond(Some(1_000_002), None),
+            ),
+            (
+                "timestamptz",
+                "1970-01-01 00:00:01.000002+00",
+                ScalarValue::TimestampMicrosecond(Some(1_000_002), Some("UTC".into())),
+            ),
+            (
+                "timestamp_s",
+                "1970-01-01 00:00:01",
+                ScalarValue::TimestampSecond(Some(1), None),
+            ),
+            (
+                "timestamp_ms",
+                "1970-01-01 00:00:00.001",
+                ScalarValue::TimestampMillisecond(Some(1), None),
+            ),
+            (
+                "timestamp_ns",
+                "1970-01-01 00:00:00.000000001",
+                ScalarValue::TimestampNanosecond(Some(1), None),
+            ),
+            (
+                "interval",
+                "1 month 2 days 3 seconds",
+                ScalarValue::new_interval_mdn(1, 2, 3_000_000_000),
+            ),
+            (
+                "varchar",
+                "hello",
+                ScalarValue::Utf8View(Some("hello".to_string())),
+            ),
+            (
+                "json",
+                r#"{"key":"value"}"#,
+                ScalarValue::Utf8View(Some(r#"{"key":"value"}"#.to_string())),
+            ),
+            (
+                "blob",
+                r"\x68656C6C6F",
+                ScalarValue::BinaryView(Some(b"hello".to_vec())),
+            ),
+            (
+                "uuid",
+                "550e8400-e29b-41d4-a716-446655440000",
+                ScalarValue::FixedSizeBinary(
+                    16,
+                    Some(vec![
+                        0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66,
+                        0x55, 0x44, 0x00, 0x00,
+                    ]),
+                ),
+            ),
+            (
+                "timetz",
+                "12:30:00+02",
+                ScalarValue::Utf8View(Some("12:30:00+02".to_string())),
+            ),
+        ];
+
+        for (ducklake_type, encoded, expected) in cases {
+            let data_type = ducklake_to_arrow_type(ducklake_type).unwrap();
+            assert_eq!(
+                parse_ducklake_scalar(encoded, &data_type),
+                Some(expected),
+                "DuckLake {ducklake_type} literal {encoded}"
+            );
+        }
+    }
+
     /// An external / legacy file whose nested nodes carry no field ids is matched
     /// structurally. Declaring ids the file does not have would be the same
     /// divergence in the opposite direction, so nothing is stamped.
@@ -1618,6 +1820,41 @@ mod tests {
         let error = ducklake_to_arrow_type(&nested).unwrap_err();
 
         assert!(error.to_string().contains("maximum nesting depth"));
+    }
+
+    #[test]
+    fn ducklake_blob_defaults_preserve_text_and_decode_escapes() {
+        assert_eq!(
+            parse_ducklake_default_scalar("abcd", &DataType::BinaryView),
+            Some(ScalarValue::BinaryView(Some(b"abcd".to_vec())))
+        );
+        assert_eq!(
+            parse_ducklake_default_scalar(r"\xAB\xCD", &DataType::BinaryView),
+            Some(ScalarValue::BinaryView(Some(vec![0xab, 0xcd])))
+        );
+        assert_eq!(
+            parse_ducklake_default_scalar("abc", &DataType::BinaryView),
+            Some(ScalarValue::BinaryView(Some(b"abc".to_vec())))
+        );
+    }
+
+    #[test]
+    fn ducklake_primitive_literals_reject_invalid_encodings() {
+        for (ducklake_type, encoded) in [
+            ("boolean", "yes"),
+            ("int32", "3.5"),
+            ("uint8", "256"),
+            ("date", "not-a-date"),
+            ("blob", "ABC"),
+            ("uuid", "550e8400-e29b-41d4-a716"),
+        ] {
+            let data_type = ducklake_to_arrow_type(ducklake_type).unwrap();
+            assert_eq!(
+                parse_ducklake_scalar(encoded, &data_type),
+                None,
+                "DuckLake {ducklake_type} literal {encoded} must be rejected"
+            );
+        }
     }
 
     #[test]
@@ -2239,22 +2476,8 @@ mod tests {
     #[test]
     fn test_build_schema_with_list_type() {
         let columns = vec![
-            DuckLakeTableColumn {
-                column_id: 1,
-                column_name: "id".to_string(),
-                column_type: "int32".to_string(),
-                is_nullable: true,
-                data_type: None,
-                nested_column_ids: Vec::new(),
-            },
-            DuckLakeTableColumn {
-                column_id: 2,
-                column_name: "tags".to_string(),
-                column_type: "list<varchar>".to_string(),
-                is_nullable: true,
-                data_type: None,
-                nested_column_ids: Vec::new(),
-            },
+            DuckLakeTableColumn::new(1, "id".to_string(), "int32".to_string(), true),
+            DuckLakeTableColumn::new(2, "tags".to_string(), "list<varchar>".to_string(), true),
         ];
 
         let schema = build_arrow_schema(&columns).unwrap();
@@ -2267,16 +2490,12 @@ mod tests {
 
     #[test]
     fn test_build_schema_with_struct_type() {
-        let columns = vec![DuckLakeTableColumn {
-            column_id: 1,
-            column_name: "data".to_string(),
-            column_type: "struct<a:int32>".to_string(),
-            is_nullable: true,
-            data_type: Some(DataType::Struct(
-                vec![Arc::new(Field::new("a", DataType::Int32, false))].into(),
-            )),
-            nested_column_ids: Vec::new(),
-        }];
+        let columns = vec![DuckLakeTableColumn::new(
+            1,
+            "data".to_string(),
+            "struct<a:int32>".to_string(),
+            true,
+        )];
 
         let schema = build_arrow_schema(&columns).unwrap();
         assert_eq!(
@@ -2287,14 +2506,12 @@ mod tests {
 
     #[test]
     fn test_column_id_i32_max_succeeds() {
-        let columns = vec![DuckLakeTableColumn {
-            column_id: i32::MAX as i64,
-            column_name: "id".to_string(),
-            column_type: "int32".to_string(),
-            is_nullable: true,
-            data_type: None,
-            nested_column_ids: Vec::new(),
-        }];
+        let columns = vec![DuckLakeTableColumn::new(
+            i32::MAX as i64,
+            "id".to_string(),
+            "int32".to_string(),
+            true,
+        )];
 
         let mut parquet_field_ids = HashMap::new();
         parquet_field_ids.insert(i32::MAX, "id".to_string());
@@ -2305,14 +2522,12 @@ mod tests {
 
     #[test]
     fn test_column_id_overflow_returns_error() {
-        let columns = vec![DuckLakeTableColumn {
-            column_id: i32::MAX as i64 + 1, // 2147483648, exceeds i32 range
-            column_name: "id".to_string(),
-            column_type: "int32".to_string(),
-            is_nullable: true,
-            data_type: None,
-            nested_column_ids: Vec::new(),
-        }];
+        let columns = vec![DuckLakeTableColumn::new(
+            i32::MAX as i64 + 1, // 2147483648, exceeds i32 range
+            "id".to_string(),
+            "int32".to_string(),
+            true,
+        )];
 
         let parquet_field_ids = HashMap::new();
 
@@ -2337,14 +2552,8 @@ mod tests {
 
     #[test]
     fn test_column_id_negative_within_i32_range_succeeds() {
-        let columns = vec![DuckLakeTableColumn {
-            column_id: -1,
-            column_name: "id".to_string(),
-            column_type: "int32".to_string(),
-            is_nullable: true,
-            data_type: None,
-            nested_column_ids: Vec::new(),
-        }];
+        let columns =
+            vec![DuckLakeTableColumn::new(-1, "id".to_string(), "int32".to_string(), true)];
 
         let mut parquet_field_ids = HashMap::new();
         parquet_field_ids.insert(-1_i32, "id".to_string());
@@ -2618,6 +2827,10 @@ mod tests {
                 .into(),
             )),
             nested_column_ids: vec![2, 3],
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         }];
         let parquet_field_ids =
             HashMap::from([(1, "s".to_string()), (2, "a".to_string()), (3, "b".to_string())]);
@@ -2664,6 +2877,10 @@ mod tests {
             is_nullable: true,
             data_type: Some(DataType::Map(Arc::new(entries), false)),
             nested_column_ids: vec![2, 3],
+            initial_default: None,
+            default_value: None,
+            default_value_type: None,
+            default_value_dialect: None,
         }];
         let parquet_field_ids =
             HashMap::from([(1, "m".to_string()), (2, "key".to_string()), (3, "value".to_string())]);

--- a/tests/it/column_defaults_tests.rs
+++ b/tests/it/column_defaults_tests.rs
@@ -1,0 +1,189 @@
+//! Differential and write-path tests for DuckLake column defaults.
+
+#![cfg(all(feature = "metadata-duckdb", feature = "write-sqlite"))]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use arrow::array::{Array, Int32Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use datafusion_ducklake::metadata_provider::MetadataProvider;
+use datafusion_ducklake::{
+    ColumnDef, DuckLakeCatalog, DuckLakeTableWriter, DuckdbMetadataProvider, MetadataWriter,
+    SqliteMetadataProvider, SqliteMetadataWriter, WriteMode,
+};
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+
+use super::common::ensure_ducklake_installed;
+
+fn create_official_default_catalog(path: &Path) -> Result<Vec<(i32, i32)>> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    ensure_ducklake_installed();
+    conn.execute("LOAD ducklake", [])?;
+    conn.execute(
+        &format!("ATTACH 'ducklake:{}' AS official", path.display()),
+        [],
+    )?;
+    conn.execute("CREATE TABLE official.items (id INTEGER)", [])?;
+    conn.execute("INSERT INTO official.items VALUES (1), (2)", [])?;
+    conn.execute(
+        "ALTER TABLE official.items ADD COLUMN priority INTEGER DEFAULT 7",
+        [],
+    )?;
+    conn.execute("INSERT INTO official.items (id) VALUES (3)", [])?;
+
+    let mut statement = conn.prepare("SELECT id, priority FROM official.items ORDER BY id")?;
+    let rows = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+fn collect_rows(batches: &[RecordBatch]) -> Vec<(i32, String)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let labels = arrow::compute::cast(batch.column(1), &DataType::Utf8).unwrap();
+        let labels = labels.as_any().downcast_ref::<StringArray>().unwrap();
+        rows.extend((0..batch.num_rows()).map(|index| {
+            assert!(ids.is_valid(index));
+            assert!(labels.is_valid(index));
+            (ids.value(index), labels.value(index).to_string())
+        }));
+    }
+    rows
+}
+
+#[tokio::test]
+async fn duckdb_added_default_matches_official_rows() -> Result<()> {
+    let temp = TempDir::new()?;
+    let catalog_path = temp.path().join("column_defaults.ducklake");
+    let official_rows = create_official_default_catalog(&catalog_path)?;
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+
+    let batches = context
+        .sql("SELECT id, priority FROM ducklake.main.items ORDER BY id")
+        .await?
+        .collect()
+        .await?;
+    let datafusion_rows = batches
+        .iter()
+        .flat_map(|batch| {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let priorities = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            (0..batch.num_rows()).map(|index| (ids.value(index), priorities.value(index)))
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(official_rows, vec![(1, 7), (2, 7), (3, 7)]);
+    assert_eq!(datafusion_rows, official_rows);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rust_added_default_fills_old_and_omitted_rows() -> Result<()> {
+    let temp = TempDir::new()?;
+    let db_path = temp.path().join("column_defaults.sqlite");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path)?;
+    let connection = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let writer = Arc::new(SqliteMetadataWriter::new_with_init(&connection).await?);
+    writer.set_data_path(data_path.to_str().unwrap())?;
+    let object_store = Arc::new(LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(writer.clone(), object_store)?;
+    let initial_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let initial_batch =
+        RecordBatch::try_new(initial_schema, vec![Arc::new(Int32Array::from(vec![1]))])?;
+    let result = table_writer
+        .write_table("main", "items", &[initial_batch])
+        .await?;
+
+    let columns = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false)?,
+        ColumnDef::from_arrow("label", &DataType::Utf8, true)?.with_default("new")?,
+    ];
+    let setup = writer.begin_write_transaction("main", "items", &columns, WriteMode::Append)?;
+    let committed = writer.publish_snapshot(
+        result.table_id,
+        "main",
+        "items",
+        setup.snapshot_id,
+        WriteMode::Append,
+        setup.base_snapshot_id,
+        &columns,
+        &setup.column_ids,
+    )?;
+
+    let provider = SqliteMetadataProvider::new(&connection).await?;
+    let snapshot = provider.get_current_snapshot()?;
+    let stored = provider.get_table_structure(committed.table_id, snapshot)?;
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored[1].column_name, "label");
+    assert_eq!(stored[1].initial_default.as_deref(), Some("new"));
+    assert_eq!(stored[1].default_value.as_deref(), Some("new"));
+    assert_eq!(stored[1].default_value_type.as_deref(), Some("literal"));
+    assert_eq!(stored[1].default_value_dialect.as_deref(), Some("duckdb"));
+    let listed = provider.list_all_columns(snapshot)?;
+    let listed_label = listed
+        .iter()
+        .find(|entry| entry.table_name == "items" && entry.column.column_name == "label")
+        .unwrap();
+    assert_eq!(listed_label.column.initial_default.as_deref(), Some("new"));
+    assert_eq!(listed_label.column.default_value.as_deref(), Some("new"));
+    assert_eq!(
+        listed_label.column.default_value_type.as_deref(),
+        Some("literal")
+    );
+    assert_eq!(
+        listed_label.column.default_value_dialect.as_deref(),
+        Some("duckdb")
+    );
+
+    let provider = SqliteMetadataProvider::new(&connection).await?;
+    let writer = SqliteMetadataWriter::new(&connection).await?;
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer))?;
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+    context
+        .sql("INSERT INTO ducklake.main.items (id) VALUES (2)")
+        .await?
+        .collect()
+        .await?;
+
+    let provider = SqliteMetadataProvider::new(&connection).await?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+    let batches = context
+        .sql("SELECT id, label FROM ducklake.main.items ORDER BY id")
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(
+        collect_rows(&batches),
+        vec![(1, "new".to_string()), (2, "new".to_string())]
+    );
+    Ok(())
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -20,6 +20,7 @@ mod append_with_deletes_tests;
 mod cdc_cumulative_delete_tests;
 mod cdc_differential_tests;
 mod cdc_rowid_tests;
+mod column_defaults_tests;
 mod column_stats_tests;
 mod common;
 mod compaction_postgres_tests;

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -4582,7 +4582,19 @@ async fn multicatalog_migrates_legacy_single_pk_to_composite_with_data() {
     .unwrap();
     assert_eq!(pk_len, 1, "downgrade produced the legacy single-column PK");
 
-    // Re-run the multicatalog bootstrap → the migration converts the PK.
+    sqlx::query(
+        "ALTER TABLE ducklake_column
+         DROP COLUMN initial_default,
+         DROP COLUMN default_value,
+         DROP COLUMN default_value_type,
+         DROP COLUMN default_value_dialect",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Re-run the multicatalog bootstrap: the migrations convert the PK and add
+    // the nullable default metadata without changing existing rows.
     initialize_multicatalog_schema(&pool).await.unwrap();
     let pk_len_after: i32 = sqlx::query_scalar(
         "SELECT array_length(conkey, 1) FROM pg_constraint
@@ -4594,6 +4606,24 @@ async fn multicatalog_migrates_legacy_single_pk_to_composite_with_data() {
     assert_eq!(
         pk_len_after, 3,
         "bootstrap migrated the legacy PK to the composite PK"
+    );
+    let default_columns: Vec<String> = sqlx::query_scalar(
+        "SELECT column_name
+         FROM information_schema.columns
+         WHERE table_name = 'ducklake_column'
+           AND column_name IN (
+               'initial_default', 'default_value',
+               'default_value_type', 'default_value_dialect'
+           )
+         ORDER BY column_name",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        default_columns,
+        vec!["default_value", "default_value_dialect", "default_value_type", "initial_default",],
+        "bootstrap restored all DuckLake default metadata columns"
     );
 
     // Data preserved — reads through the provider return the original values.


### PR DESCRIPTION
### Summary

Read and write DuckLake literal column defaults instead of replacing every physically absent
column with NULL. Metadata providers now carry `initial_default`, `default_value`,
`default_value_type`, and `default_value_dialect`. Parquet scans materialize a typed
`initial_default` for files that predate an added column, while DataFusion uses `default_value`
when an `INSERT` omits that column.

The Rust `ColumnDef::with_default` API records the same literal as both the initial and operational
default. DuckLake expression defaults remain readable metadata but are not evaluated by DataFusion;
write callers must supply those columns explicitly.

### Default flow

```mermaid
flowchart LR
    Catalog["ducklake_column<br/>default metadata"] --> Provider["Metadata providers<br/>all four backends"]
    Provider --> Normalize{"stored default"}
    Normalize -->|"literal"| ReadSchema["Typed logical read schema"]
    ReadSchema --> Adapter["Parquet expression adapter"]
    Adapter --> OldRows["Missing field -> initial_default"]
    Normalize -->|"NULL or expression"| MetadataOnly["Readable metadata only"]
    Normalize -->|"literal default_value"| InsertPlan["DataFusion INSERT planning"]
    InsertPlan --> NewRows["Omitted field -> default_value"]
    RustAPI["ColumnDef::with_default"] --> Catalog
```

### Contract

- Carry all four default fields through table and bulk column queries on DuckDB, SQLite,
  PostgreSQL, MySQL, and multicatalog PostgreSQL providers.
- Decode supported DuckLake primitive literals into exact Arrow `ScalarValue` types.
- Fill only a field that is physically absent from a Parquet file and has `initial_default`.
- Preserve the prior NULL fill when no initial default exists.
- Return `default_value` through `TableProvider::get_column_default` for omitted SQL insert
  columns.
- Persist defaults on new columns for every writer backend and preserve them through SQLite and
  PostgreSQL type promotion.
- Read legacy DuckDB catalogs that lack any default-metadata column by projecting NULL for each
  missing field. Treat a catalog without `default_value_type` or `default_value_dialect` as a
  literal-default catalog while continuing to read both fields when present.
- Normalize DuckLake's `"NULL"` operational-default sentinel without changing
  `initial_default`, and keep expression defaults readable without evaluating them.
- Decode printable BLOB defaults as bytes and DuckDB `\xNN` escapes as their encoded byte.
- Migrate missing default-metadata columns during SQLite, MySQL, and PostgreSQL writer
  initialization without replacing existing catalog rows.

### DuckLake semantics

`initial_default` and `default_value` serve different rows. The first supplies a value when an old
file has no physical field for an added column. The second supplies a value while planning a new
write that omits the column. Keeping both on `DuckLakeTableColumn` avoids conflating schema
evolution with insert planning.

Literal parsing follows the DuckLake string encodings for booleans, signed and unsigned integers,
floating-point numbers, decimals, temporal values, intervals, strings, JSON, blobs, and UUIDs.
Nested-child defaults and default filling in change feeds remain follow-up work. Read-only legacy
SQLite, MySQL, and PostgreSQL catalogs must run writer initialization before providers query the
four default fields.

### Commit and branch

- Branch: `ducklake-column-defaults-pr`.
- Base: `2b2c122e09b72ffd9e3c585ed4e4de69f687a111` (`origin/main`).
- Commit: `bc0f4fbc6dd3c9449fa9beb2efaa47310add1f6c feat: apply DuckLake column defaults on reads and
  writes`.
- Prerequisite PRs: none.
- Remote: `ata/ducklake-column-defaults-pr`.
- Pull request: [#259](https://github.com/datafusion-contrib/datafusion-ducklake/pull/259).

### Verification

- 2026-08-29 review gate after rebasing onto DataFusion 55: formatting, strict
  all-target/all-feature Clippy, all-target/all-feature check, and the full feature test matrix
  passed. The matrix ran 385 unit tests, 411 integration tests with 15 ignored service tests, and
  8 doc tests.
- Focused regressions passed for the `"NULL"` sentinel, expression-default table reads, DuckDB BLOB
  decoding, literal defaults, and lossless SQLite legacy-schema migration.
- `markdownlint-cli2` and `mermaid-lint` passed for this summary. Repository-wide Markdown linting
  of `CHANGELOG.md` and `COMPATIBILITY.md` still reports pre-existing historical errors.
- 2026-08-25 rebase gate: formatting, all-target/all-feature compile, strict Clippy, and
  `cargo test --all-features column_defaults` passed.
- `cargo fmt --all -- --check`: passed.
- `CARGO_BUILD_JOBS=8 cargo clippy --all-targets --all-features --no-deps -- -D warnings`: passed.
- `CARGO_BUILD_JOBS=8 cargo check --all-targets --all-features`: passed.
- `cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres
  metadata-sqlite write-sqlite"`: passed, 369 unit tests, 391 integration tests, and 8 doc tests;
  15 integration tests were ignored. This is the exact feature set from the previously failed CI
  job.
- `cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres
  metadata-sqlite write-sqlite" legacy_columns_without_defaults_are_null_projected`: passed,
  1 test.
- `cargo test --features "skip-tests-with-docker write-sqlite" ducklake_primitive_literals`: passed,
  2 tests.
- `cargo test --features "skip-tests-with-docker write-sqlite" expression_column_default_does_not_block_table_reads`: passed, 1 test.
- `cargo test --features "skip-tests-with-docker write-sqlite" column_defaults_tests`: passed,
  2 tests.
- `cargo test --features "skip-tests-with-docker write-sqlite" --test it renamed_columns_tests`:
  passed, 13 tests.
- `cargo test --features "skip-tests-with-docker write-sqlite" --test it sqlite_metadata_provider_test`:
  passed, 19 tests.
- `CARGO_BUILD_JOBS=8 cargo test --all-features --test it
  multicatalog_migrates_legacy_single_pk_to_composite_with_data -- --ignored --nocapture`: passed
  against PostgreSQL. The migration restored all four default‑metadata columns and preserved the
  existing rows.
- `git diff --check`: passed.

### Specification proof

| DuckLake rule                                                                                                                                                                                | Implementation invariant                                                                                                                                                                              | Discriminating proof                                                                                                                                                                                                                                                       |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`ducklake_column`](https://ducklake.select/docs/stable/specification/tables/ducklake_column) stores `initial_default`, `default_value`, `default_value_type`, and `default_value_dialect`.  | Every provider returns all four fields, and every writer persists them. SQLite, MySQL, and PostgreSQL writer initialization migrates missing fields in place.                                         | `rust_added_default_fills_old_and_omitted_rows` checks both SQLite query paths. The SQLite migration regression preserves an existing row while adding all four fields.                                                                                                    |
| A missing field ID in an older file uses [`initial_default`](https://ducklake.select/docs/stable/duckdb/usage/schema_evolution), not NULL.                                                   | The logical file schema marks only physically absent fields with an initial-default literal, and the Parquet expression adapter substitutes the typed scalar before the standard schema adapter runs. | `duckdb_added_default_matches_official_rows` creates two rows before `ALTER TABLE ... ADD COLUMN ... DEFAULT 7`; DataFusion and the official extension both return `(1, 7)` and `(2, 7)`.                                                                                  |
| [`default_value`](https://ducklake.select/docs/stable/specification/tables/ducklake_column) is the operational default for inserts and updates.                                              | `DuckLakeTable` exposes decoded literal defaults through DataFusion's `TableProvider::get_column_default`.                                                                                            | `rust_added_default_fills_old_and_omitted_rows` executes `INSERT INTO ... (id) VALUES (2)` and reads the exact row `(2, 'new')`.                                                                                                                                           |
| Default values are strings interpreted as the declared [DuckLake data type](https://ducklake.select/docs/stable/specification/data_types).                                                   | Default decoding preserves DuckDB BLOB text and escapes while statistics and inlined-row decoders retain their hexadecimal encodings.                                                                 | `ducklake_primitive_literals_decode_exactly` covers every supported primitive type; `ducklake_blob_defaults_preserve_text_and_decode_escapes` distinguishes the BLOB encodings.                                                                                            |
| [`default_value_type` and `default_value_dialect`](https://ducklake.select/docs/stable/specification/tables/ducklake_column) distinguish literal defaults from dialect-specific expressions. | Literals are decoded locally. Expressions stay readable metadata but are not exposed as DataFusion insert defaults.                                                                                   | `expression_column_default_does_not_block_table_reads` proves an expression default does not prevent table construction.                                                                                                                                                   |
| [Schema evolution](https://ducklake.select/docs/stable/duckdb/usage/schema_evolution) keeps a column's field identifier stable across versions.                                              | SQLite and PostgreSQL promotion copy all four default fields into the new version while retaining the existing column ID.                                                                             | The all-target, all-feature Clippy gate compiles both promotion transactions, and the existing type-promotion path remains unchanged except for exact default-field carry-forward.                                                                                         |

### Reference implementation

Literal defaults match the official DuckLake extension:

- [`CreateColumnFromFieldId`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_multi_file_reader.cpp#L189-L202)
  uses the typed `initial_default` when a physical file lacks the field.
- [`TransformColumnType`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_catalog.cpp#L390-L411)
  casts the initial value and reconstructs the operational default from its encoding type.
- [Table reconstruction](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_catalog.cpp#L545-L565)
  installs that operational default on the column definition used by inserts.
- [`ColumnToSQLRecursive`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L2639-L2682)
  writes the initial value, operational value, encoding type, and `duckdb` dialect token.

The extension evaluates expression defaults with DuckDB's parser. This crate leaves those
expressions unevaluated so DataFusion cannot change their meaning. Reads remain available; inserts
must provide an explicit value for those columns.

### Upstream readiness

The patch uses DataFusion's public `PhysicalExprAdapterFactory` and `TableProvider` default API. It
adds no Nautilus-specific behavior, no catalog extension, and no new dependency. The only explicit
limit is expression evaluation: the error is stable and leaves room for a later dialect-aware
implementation without changing literal semantics. The amended source is one commit above
`origin/main`; no declared DuckLake branch depends on Group 1. The aggregate retains the same
migration and records its focused regression at `9bfdc709a444cd05d4c212a52b74c09a6b0c44e2`.
