### PR TITLE
Apply DuckLake inlined deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the error (#280).
 - `files_matching` no longer stops pruning a data file once that file carries a delete
   file (#276).
+- Inlined positions remain in metadata during `DELETE` and `UPDATE`;
+  replacement Parquet delete files contain only Parquet-owned and newly matched
+  live positions (#262).
+- Unqualified `DELETE` and metadata row counts subtract visible inline
+  positions; `rewrite_data_files` includes them in automatic delete-ratio
+  selection (#262).
+- Delete-file and compaction commits abort when a source file gains a distinct
+  inline position after planning, instead of duplicating or resurrecting the
+  deleted row (#262).
+- `merge_adjacent_files` skips data files masked by inline positions, preserving
+  historical rows and valid metadata references (#262).
 - Table scans and `COUNT(*)` include scalar rows inlined in SQLite, DuckDB, PostgreSQL and
   MySQL catalogs; unsupported non-scalar inline values report how to flush or disable
   inlining (#261).

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -325,7 +325,14 @@ Known edges:
 - **Data inlining: scalar rows are read on every metadata backend.** DuckLake
   inlines `INSERT`s of up to 10 rows into the catalog by default. SQLite,
   DuckDB, PostgreSQL, and MySQL scans honor their snapshot visibility, so
-  `SELECT` and `COUNT(*)` include them. Inlined *Parquet‑row* deletes and the
-  `rowid` path remain unsupported. Non‑scalar inlined columns fail with an
+  `SELECT` and `COUNT(*)` include them. Inlined *Parquet‑row* deletes
+  (`ducklake_inlined_delete_<table_id>`) are applied by scans, `UPDATE`,
+  `DELETE`, and compaction on all four backends; the `rowid` path remains
+  unsupported for inlined rows. Non‑scalar inlined columns fail with an
   error that directs users to flush the rows to Parquet or disable inlining at
   write time.
+- **The change feed does not surface inlined deletes.** `ducklake_table_changes`
+  and `ducklake_table_deletions` read delete *files* added in the window; a
+  snapshot whose only change is an inlined Parquet‑row delete emits no `delete`
+  rows even though scans at the window's two ends differ. Flush or avoid
+  inlined deletes on tables consumed through the change feed.

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -716,10 +716,14 @@ impl DuckLakeTable {
         // output on a table taking appends between merge passes, leaving each
         // partition a floor of files nothing can reduce.
         let table_files = self.files()?;
+        let inlined_deletes = self.inlined_deletes_by_file()?;
         let mut candidates: Vec<&DuckLakeTableFile> = table_files
             .iter()
             .filter(|f| {
                 f.delete_file_id.is_none()
+                    // Removing a source with inlined deletes would erase its masked rows
+                    // from every snapshot while leaving metadata that points at the file.
+                    && !inlined_deletes.contains_key(&f.data_file_id)
                     && f.begin_snapshot.is_some()
                     && f.schema_version.is_some()
                     && (f.file.file_size_bytes as u64) >= opts.min_file_size
@@ -943,7 +947,12 @@ impl DuckLakeTable {
                     OriginSource::Constant(*begin)
                 });
                 let scan = self
-                    .build_update_scan_with_snapshot(state, tf, source_embeds_origins)
+                    .build_update_scan_with_snapshot(
+                        state,
+                        tf,
+                        source_embeds_origins,
+                        inlined_deletes.get(&tf.data_file_id),
+                    )
                     .await?;
                 leaves.push(Arc::new(CompactionSourceExec::new(
                     Arc::new(scan),
@@ -1077,17 +1086,21 @@ impl DuckLakeTable {
             .data_file_ids
             .map(|ids| ids.into_iter().collect::<HashSet<_>>());
         let table_files = self.files()?;
+        let inlined_deletes = self.inlined_deletes_by_file()?;
         let candidates: Vec<&DuckLakeTableFile> = table_files
             .iter()
             .filter(|tf| match &selected_ids {
                 Some(selected_ids) => selected_ids.contains(&tf.data_file_id),
-                // Threshold selection only applies to files with live deletes.
+                // Automatic selection counts both Parquet and inlined deletes.
                 None => {
                     let record_count = tf.max_row_count.unwrap_or(0);
-                    tf.delete_file_id.is_some()
+                    let inlined_count = inlined_deletes
+                        .get(&tf.data_file_id)
+                        .map_or(0, |positions| positions.len() as i64);
+                    let delete_count = tf.delete_count.unwrap_or(0) + inlined_count;
+                    delete_count > 0
                         && record_count > 0
-                        && tf.delete_count.unwrap_or(0) as f64 / record_count as f64
-                            >= opts.delete_threshold
+                        && delete_count as f64 / record_count as f64 >= opts.delete_threshold
                 },
             })
             .collect();
@@ -1114,7 +1127,9 @@ impl DuckLakeTable {
             // parallel. Rowid lineage rides out of the scan as a column, so the
             // sort and the parquet write consume the plan directly instead of a
             // fully collected `Vec<RecordBatch>`.
-            let scan = self.build_update_scan(state, tf).await?;
+            let scan = self
+                .build_update_scan(state, tf, inlined_deletes.get(&tf.data_file_id))
+                .await?;
             let sorted = sorted_rewrite_output(
                 state.task_ctx(),
                 Arc::new(CompactionSourceExec::new(

--- a/src/delete_exec.rs
+++ b/src/delete_exec.rs
@@ -298,6 +298,7 @@ async fn run_delete(
 
     let mut entries: Vec<DeleteFileEntry> = Vec::new();
     let mut total_deleted: u64 = 0;
+    let inlined_deletes = table.inlined_deletes_by_file()?;
 
     for tf in &table_files {
         // A file rewritten by an UPDATE or by compaction is handled here like any
@@ -316,22 +317,28 @@ async fn run_delete(
             continue;
         }
 
-        // Already-deleted positions for this file (if a delete file is live).
-        // Rows already deleted are neither re-counted nor re-deleted.
+        // Already-deleted positions for this file: the live delete file plus any
+        // inlined deletes. Rows already deleted are neither re-counted nor
+        // re-deleted, and a predicate matching only such rows commits nothing.
         let existing = match tf.delete_file {
             Some(ref df) => table.read_delete_file_positions(state, df).await?,
             None => HashSet::new(),
         };
+        let mut already_deleted = existing.clone();
+        if let Some(inlined) = inlined_deletes.get(&tf.data_file_id) {
+            already_deleted.extend(inlined);
+        }
 
-        let newly_deleted = matched.difference(&existing).count() as u64;
-        if newly_deleted == 0 {
+        let newly_deleted: HashSet<i64> = matched.difference(&already_deleted).copied().collect();
+        if newly_deleted.is_empty() {
             // Every matched row was already deleted: nothing changes here.
             continue;
         }
 
-        // Cumulative (prior ∪ new) still-deleted set: at most one delete file is
-        // live per data file, so each write carries the full set.
-        let mut cumulative: Vec<i64> = existing.union(&matched).copied().collect();
+        // Carry forward prior Parquet positions and add only newly matched live
+        // rows. Inlined positions stay in their metadata table until a dedicated
+        // flush materializes and retires them.
+        let mut cumulative: Vec<i64> = existing.union(&newly_deleted).copied().collect();
         cumulative.sort_unstable();
 
         let delete_info = table_writer
@@ -344,7 +351,7 @@ async fn run_delete(
             expected_prev_delete_file: tf.delete_file_id,
             delete: delete_info,
         });
-        total_deleted += newly_deleted;
+        total_deleted += newly_deleted.len() as u64;
     }
 
     if entries.is_empty() {

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -586,6 +586,15 @@ pub struct DuckLakeTableColumn {
     pub default_value_dialect: Option<String>,
 }
 
+/// A positional deletion stored directly in a DuckLake metadata catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DuckLakeInlinedDelete {
+    /// Catalog id of the Parquet data file containing the deleted row.
+    pub data_file_id: i64,
+    /// Zero-based physical row position within the Parquet data file.
+    pub row_id: i64,
+}
+
 pub(crate) fn is_inlined_data_table(name: &str) -> bool {
     name.starts_with("ducklake_inlined_data_")
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
@@ -593,6 +602,21 @@ pub(crate) fn is_inlined_data_table(name: &str) -> bool {
 
 pub(crate) const INLINED_DATA_REMEDIATION: &str =
     "flush inlined data to Parquet (or disable data inlining at write time)";
+
+/// Return the specification-defined physical table name for a table's inlined
+/// Parquet-row deletions.
+///
+/// External metadata providers can use this helper to implement
+/// [`MetadataProvider::get_inlined_deletes`] without duplicating identifier
+/// validation.
+pub fn inlined_delete_table_name(table_id: i64) -> Result<String> {
+    if table_id < 0 {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "DuckLake table id must be non-negative, was {table_id}"
+        )));
+    }
+    Ok(format!("ducklake_inlined_delete_{table_id}"))
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum InlinedDataBackend {
@@ -1359,11 +1383,25 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         Ok(Vec::new())
     }
 
+    /// Read positional deletions stored in `ducklake_inlined_delete_<table_id>`
+    /// that are visible at `snapshot_id`.
+    ///
+    /// The default keeps legacy catalogs and providers without deletion inlining
+    /// source-compatible. Implementations return an empty vector when the
+    /// physical table does not exist.
+    fn get_inlined_deletes(
+        &self,
+        _table_id: i64,
+        _snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeInlinedDelete>> {
+        Ok(Vec::new())
+    }
+
     /// Net number of live rows in a table at a snapshot, accounting for delete
-    /// files: `SUM(record_count) - SUM(delete_count)` over the files visible at
-    /// `snapshot_id`. This matches a `SELECT COUNT(*)` against the table at that
-    /// snapshot without scanning any data — the counts come from catalog
-    /// metadata.
+    /// files and inlined positions: `SUM(record_count) - SUM(delete_count) -
+    /// distinct inlined positions` over the files visible at `snapshot_id`.
+    /// This matches a `SELECT COUNT(*)` against the table at that snapshot
+    /// without scanning any data — the counts come from catalog metadata.
     ///
     /// The default implementation derives the count from
     /// [`get_table_files_for_select`](Self::get_table_files_for_select), so it
@@ -1373,10 +1411,22 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
     /// contributes 0 and cannot be counted from metadata alone.
     fn get_table_row_count(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
         let files = self.get_table_files_for_select(table_id, snapshot_id)?;
+        let visible_file_ids = files
+            .iter()
+            .map(|file| file.data_file_id)
+            .collect::<std::collections::HashSet<_>>();
+        let inlined_count = self
+            .get_inlined_deletes(table_id, snapshot_id)?
+            .into_iter()
+            .filter(|delete| visible_file_ids.contains(&delete.data_file_id))
+            .map(|delete| (delete.data_file_id, delete.row_id))
+            .collect::<std::collections::HashSet<_>>()
+            .len() as i64;
         let net: i64 = files
             .iter()
             .map(|f| f.max_row_count.unwrap_or(0) - f.delete_count.unwrap_or(0))
-            .sum();
+            .sum::<i64>()
+            - inlined_count;
         Ok(net.max(0) as u64)
     }
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -1,9 +1,9 @@
 use crate::DuckLakeError;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
-    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
-    INLINED_DATA_REMEDIATION, MetadataProvider, SQL_GET_DATA_FILES,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
+    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    FileWithTable, INLINED_DATA_REMEDIATION, MetadataProvider, SQL_GET_DATA_FILES,
     SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_DATA_PATH,
     SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
     SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT, SQL_GET_PARTITION_SPEC,
@@ -11,8 +11,8 @@ use crate::metadata_provider::{
     SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES,
     SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS,
     SQL_TABLE_EXISTS, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
-    ViewMetadata, ViewWithSchema, build_inlined_batch, is_inlined_data_table, reconstruct_columns,
-    reconstruct_columns_with_table,
+    ViewMetadata, ViewWithSchema, build_inlined_batch, inlined_delete_table_name,
+    is_inlined_data_table, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -1073,6 +1073,32 @@ impl MetadataProvider for DuckdbMetadataProvider {
             }
         }
         Ok(batches)
+    }
+
+    fn get_inlined_deletes(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> crate::Result<Vec<DuckLakeInlinedDelete>> {
+        let conn = self.connection();
+        let table = inlined_delete_table_name(table_id)?;
+        let sql = format!(
+            "SELECT file_id, row_id FROM {} WHERE begin_snapshot <= ? ORDER BY file_id, row_id",
+            quote_ident(&table)
+        );
+        let mut statement = match conn.prepare(&sql) {
+            Ok(statement) => statement,
+            Err(error) if is_missing_statistics_table(&error) => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        Ok(statement
+            .query_map([snapshot_id], |row| {
+                Ok(DuckLakeInlinedDelete {
+                    data_file_id: row.get(0)?,
+                    row_id: row.get(1)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?)
     }
 
     fn get_schema_by_name(

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -3,12 +3,13 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
-    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
-    InlinedDataBackend, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC,
-    SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
-    ViewMetadata, ViewWithSchema, block_on, inlined_text_projection, is_inlined_data_table,
-    parse_inlined_rows, reconstruct_columns, reconstruct_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
+    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    FileWithTable, InlinedDataBackend, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES,
+    SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata,
+    TableWithSchema, ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name,
+    inlined_text_projection, is_inlined_data_table, parse_inlined_rows, reconstruct_columns,
+    reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -921,6 +922,37 @@ impl MetadataProvider for MySqlMetadataProvider {
                 batches.push(parse_inlined_rows(schema.clone(), columns, rows)?);
             }
             Ok(batches)
+        })
+    }
+
+    fn get_inlined_deletes(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeInlinedDelete>> {
+        block_on(async {
+            let table = inlined_delete_table_name(table_id)?;
+            let sql = format!(
+                "SELECT file_id, row_id FROM {} WHERE begin_snapshot <= ? ORDER BY file_id, row_id",
+                quote_ident(&table)
+            );
+            match sqlx::query(AssertSqlSafe(sql.as_str()))
+                .bind(snapshot_id)
+                .fetch_all(&self.pool)
+                .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeInlinedDelete {
+                            data_file_id: row.try_get(0)?,
+                            row_id: row.try_get(1)?,
+                        })
+                    })
+                    .collect(),
+                Err(error) if is_missing_statistics_table(&error) => Ok(Vec::new()),
+                Err(error) => Err(error.into()),
+            }
         })
     }
 

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -3,11 +3,12 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
-    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
-    InlinedDataBackend, MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata,
-    TableWithSchema, ViewMetadata, ViewWithSchema, block_on, inlined_text_projection,
-    is_inlined_data_table, parse_inlined_rows, reconstruct_columns, reconstruct_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
+    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    FileWithTable, InlinedDataBackend, MetadataProvider, SchemaMetadata, SnapshotMetadata,
+    TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
+    inlined_delete_table_name, inlined_text_projection, is_inlined_data_table, parse_inlined_rows,
+    reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -1080,6 +1081,37 @@ impl MetadataProvider for PostgresMetadataProvider {
                 batches.push(parse_inlined_rows(schema.clone(), columns, rows)?);
             }
             Ok(batches)
+        })
+    }
+
+    fn get_inlined_deletes(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeInlinedDelete>> {
+        block_on(async {
+            let table = inlined_delete_table_name(table_id)?;
+            let sql = format!(
+                "SELECT file_id, row_id FROM {} WHERE begin_snapshot <= $1 ORDER BY file_id, row_id",
+                quote_ident(&table)
+            );
+            match sqlx::query(AssertSqlSafe(sql.as_str()))
+                .bind(snapshot_id)
+                .fetch_all(&self.pool)
+                .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeInlinedDelete {
+                            data_file_id: row.try_get(0)?,
+                            row_id: row.try_get(1)?,
+                        })
+                    })
+                    .collect(),
+                Err(error) if is_missing_statistics_table(&error) => Ok(Vec::new()),
+                Err(error) => Err(error.into()),
+            }
         })
     }
 

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -3,11 +3,12 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
-    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
-    MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
-    block_on, reconstruct_columns, reconstruct_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
+    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    FileWithTable, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC,
+    SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
+    ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name, reconstruct_columns,
+    reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -1134,6 +1135,37 @@ impl MetadataProvider for SqliteMetadataProvider {
                 batches.push(build_inlined_batch(&schema, columns, &present, &rows)?);
             }
             Ok(batches)
+        })
+    }
+
+    fn get_inlined_deletes(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeInlinedDelete>> {
+        block_on(async {
+            let table = inlined_delete_table_name(table_id)?;
+            let sql = format!(
+                "SELECT file_id, row_id FROM {} WHERE begin_snapshot <= ? ORDER BY file_id, row_id",
+                quote_ident(&table)
+            );
+            match sqlx::query(AssertSqlSafe(sql.as_str()))
+                .bind(snapshot_id)
+                .fetch_all(&self.pool)
+                .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeInlinedDelete {
+                            data_file_id: row.try_get(0)?,
+                            row_id: row.try_get(1)?,
+                        })
+                    })
+                    .collect(),
+                Err(error) if is_missing_statistics_table(&error) => Ok(Vec::new()),
+                Err(error) => Err(error.into()),
+            }
         })
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -1608,13 +1608,14 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     ///
     /// Compaction changes the physical file layout, not the logical rows, so the
     /// commit is designed NOT to conflict with a concurrent append (which adds
-    /// unrelated files): the only conflict checks are, for each `source`, that
-    /// its data file is still live and that its live delete file still matches
-    /// [`CompactionSourceFile::delete_file_id`] (a compare-and-swap). Either
-    /// mismatch — a concurrent Replace/compaction that retired the file, or a
-    /// concurrent DELETE/UPDATE that changed its live rows since they were read —
-    /// aborts with [`crate::DuckLakeError::Conflict`] so retired rows can never
-    /// be resurrected into an output. The new snapshot carries `schema_version`
+    /// unrelated files): for each `source`, the data file must still be live,
+    /// the live delete file must still match
+    /// [`CompactionSourceFile::delete_file_id`] (a compare-and-swap), and no new
+    /// distinct inlined-delete position may have appeared after `base_snapshot`.
+    /// A concurrent Replace/compaction that retired the file or a concurrent
+    /// DELETE/UPDATE (positional or inlined) that changed its live rows since
+    /// they were read — aborts with [`crate::DuckLakeError::Conflict`] so
+    /// retired rows can never be resurrected into an output. The new snapshot carries `schema_version`
     /// forward (compaction is not DDL). `base_snapshot` is the catalog head the
     /// sources were read at, used only for the conflict diagnostic.
     ///

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -647,6 +647,64 @@ async fn detect_replace_conflict(
     Ok(())
 }
 
+// The SHARE lock orders inserts from other PostgreSQL clients with the
+// source-file check and surrounding metadata commit.
+async fn detect_new_inlined_deletes(
+    table_id: i64,
+    base_snapshot: i64,
+    data_file_ids: &[i64],
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    if data_file_ids.is_empty() {
+        return Ok(());
+    }
+
+    let table = crate::metadata_provider::inlined_delete_table_name(table_id)?;
+    let exists: bool = sqlx::query_scalar("SELECT to_regclass($1) IS NOT NULL")
+        .bind(&table)
+        .fetch_one(&mut **tx)
+        .await?;
+    if !exists {
+        return Ok(());
+    }
+
+    sqlx::query(AssertSqlSafe(format!(
+        "LOCK TABLE \"{table}\" IN SHARE MODE"
+    )))
+    .execute(&mut **tx)
+    .await?;
+    let file_ids = data_file_ids
+        .iter()
+        .map(i64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let conflict = sqlx::query(AssertSqlSafe(format!(
+        "SELECT 1 FROM \"{table}\" newer
+         WHERE newer.file_id IN ({file_ids})
+           AND (newer.begin_snapshot IS NULL OR (
+             newer.begin_snapshot > $1
+             AND (newer.row_id IS NULL OR NOT EXISTS (
+               SELECT 1 FROM \"{table}\" prior
+               WHERE prior.file_id = newer.file_id
+                 AND prior.row_id = newer.row_id
+                 AND prior.begin_snapshot <= $2
+             ))
+           ))
+         LIMIT 1"
+    )))
+    .bind(base_snapshot)
+    .bind(base_snapshot)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if conflict.is_some() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "table {table_id} gained an inlined delete on a source file since snapshot \
+             {base_snapshot}; re-open the catalog and re-plan"
+        )));
+    }
+    Ok(())
+}
+
 /// Retire the generation preceding `snapshot_id` for a Replace: end-snapshot
 /// every still-live file from an earlier snapshot and zero the visible
 /// record/byte totals. The `begin_snapshot < snapshot_id` guard leaves the
@@ -1818,13 +1876,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
-
             if mode != WriteMode::Replace
                 && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
             {
                 detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
             }
-
             let (snapshot_id, schema_id, table_id) = finalize_snapshot(
                 self.catalog_id,
                 schema_name,
@@ -2917,6 +2973,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             {
                 detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
             }
+            if !deletes.is_empty() {
+                let file_ids = deletes
+                    .iter()
+                    .map(|entry| entry.data_file_id)
+                    .collect::<Vec<_>>();
+                detect_new_inlined_deletes(table_id, base_snapshot, &file_ids, &mut tx).await?;
+            }
 
             let (snapshot_id, schema_id, table_id) = finalize_snapshot(
                 self.catalog_id,
@@ -3172,6 +3235,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             {
                 detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
             }
+            if !deletes.is_empty() {
+                let file_ids = deletes
+                    .iter()
+                    .map(|entry| entry.data_file_id)
+                    .collect::<Vec<_>>();
+                detect_new_inlined_deletes(table_id, base_snapshot, &file_ids, &mut tx).await?;
+            }
 
             let (snapshot_id, schema_id, table_id) = finalize_snapshot(
                 self.catalog_id,
@@ -3384,6 +3454,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let file_ids = deletes
+                .iter()
+                .map(|entry| entry.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(table_id, base_snapshot, &file_ids, &mut tx).await?;
 
             // Allocate the snapshot (commit-ordered IDENTITY). A delete is
             // non-DDL, so carry the per-catalog schema_version forward.
@@ -3528,6 +3603,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let source_data_ids = sources
+                .iter()
+                .map(|source| source.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(table_id, base_snapshot, &source_data_ids, &mut tx).await?;
 
             let snapshot_id: i64 = sqlx::query(
                 "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
@@ -3588,8 +3668,6 @@ impl MetadataWriter for PostgresMetadataWriter {
                     )));
                 }
             }
-
-            let source_data_ids: Vec<i64> = sources.iter().map(|s| s.data_file_id).collect();
 
             match retirement {
                 SourceRetirement::Remove => {
@@ -3827,7 +3905,34 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .fetch_one(&mut *tx)
             .await?;
-            let live_rows = (gross.unwrap_or(0) - deleted).max(0) as u64;
+            let inlined_table = crate::metadata_provider::inlined_delete_table_name(table_id)?;
+            let inlined_exists: bool = sqlx::query_scalar("SELECT to_regclass($1) IS NOT NULL")
+                .bind(&inlined_table)
+                .fetch_one(&mut *tx)
+                .await?;
+            let inlined_deleted: i64 = if inlined_exists {
+                sqlx::query(AssertSqlSafe(format!(
+                    "LOCK TABLE \"{inlined_table}\" IN SHARE MODE"
+                )))
+                .execute(&mut *tx)
+                .await?;
+                sqlx::query_scalar(AssertSqlSafe(format!(
+                    "SELECT COUNT(*)::BIGINT FROM (
+                       SELECT DISTINCT d.file_id, d.row_id
+                       FROM \"{inlined_table}\" d
+                       JOIN ducklake_data_file f ON f.data_file_id = d.file_id
+                       WHERE f.table_id = $1 AND f.end_snapshot IS NULL
+                         AND d.begin_snapshot <= $2
+                     ) counted"
+                )))
+                .bind(table_id)
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?
+            } else {
+                0
+            };
+            let live_rows = (gross.unwrap_or(0) - deleted - inlined_deleted).max(0) as u64;
 
             sqlx::query(
                 "UPDATE ducklake_data_file SET end_snapshot = $1

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1079,6 +1079,56 @@ async fn detect_replace_conflict(
     Ok(())
 }
 
+// The caller holds SQLite's write lock, so the source-file check is ordered
+// with publication.
+async fn detect_new_inlined_deletes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    base_snapshot: i64,
+    data_file_ids: &[i64],
+) -> Result<()> {
+    if data_file_ids.is_empty() {
+        return Ok(());
+    }
+
+    let table = crate::metadata_provider::inlined_delete_table_name(table_id)?;
+    let exists: Option<i64> =
+        sqlx::query_scalar("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+            .bind(&table)
+            .fetch_optional(&mut **tx)
+            .await?;
+    if exists.is_none() {
+        return Ok(());
+    }
+
+    let conflict: Option<i64> = sqlx::query_scalar(AssertSqlSafe(format!(
+        "SELECT 1 FROM \"{table}\" newer
+         WHERE newer.file_id IN ({})
+           AND (newer.begin_snapshot IS NULL OR (
+             newer.begin_snapshot > ?
+             AND (newer.row_id IS NULL OR NOT EXISTS (
+               SELECT 1 FROM \"{table}\" prior
+               WHERE prior.file_id = newer.file_id
+                 AND prior.row_id = newer.row_id
+                 AND prior.begin_snapshot <= ?
+             ))
+           ))
+         LIMIT 1",
+        id_list(data_file_ids),
+    )))
+    .bind(base_snapshot)
+    .bind(base_snapshot)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if conflict.is_some() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "table {table_id} gained an inlined delete on a source file since snapshot \
+             {base_snapshot}; re-open the catalog and re-plan"
+        )));
+    }
+    Ok(())
+}
+
 /// Retire the prior generation's still-visible data files at `snapshot_id` and
 /// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard
 /// spares files registered for *this* snapshot, so a multi-file write does not
@@ -2855,6 +2905,13 @@ impl MetadataWriter for SqliteMetadataWriter {
             {
                 detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
             }
+            if !deletes.is_empty() {
+                let file_ids = deletes
+                    .iter()
+                    .map(|entry| entry.data_file_id)
+                    .collect::<Vec<_>>();
+                detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &file_ids).await?;
+            }
 
             // Partition-spec fence: the new row versions are a NEW write, so they
             // must agree with the table's live partition generation exactly as
@@ -3106,6 +3163,13 @@ impl MetadataWriter for SqliteMetadataWriter {
             {
                 detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
             }
+            if !deletes.is_empty() {
+                let file_ids = deletes
+                    .iter()
+                    .map(|entry| entry.data_file_id)
+                    .collect::<Vec<_>>();
+                detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &file_ids).await?;
+            }
 
             // Partition-spec fence (both directions, every file): the new row
             // versions are a NEW write, so each must agree with the table's live
@@ -3315,6 +3379,11 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Write-lock-first: the MAX+1 insert takes the SQLite write lock up
             // front, so concurrent writers can't collide or deadlock.
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let file_ids = deletes
+                .iter()
+                .map(|entry| entry.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &file_ids).await?;
 
             for entry in deletes {
                 // Target-file fence: abort iff the data file is no longer live (a
@@ -3435,6 +3504,11 @@ impl MetadataWriter for SqliteMetadataWriter {
             // (MAX(snapshot_id)) only ever resolves to the fully-applied layout.
             let mut tx = self.pool.begin().await?;
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let source_data_ids = sources
+                .iter()
+                .map(|source| source.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &source_data_ids).await?;
 
             // Conflict fence per source: the data file must still be live, and its
             // live delete file must still match what the caller read the source's
@@ -3479,8 +3553,6 @@ impl MetadataWriter for SqliteMetadataWriter {
                     )));
                 }
             }
-
-            let source_data_ids: Vec<i64> = sources.iter().map(|s| s.data_file_id).collect();
 
             match retirement {
                 SourceRetirement::Remove => {
@@ -3832,7 +3904,30 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(table_id)
             .fetch_one(&mut *tx)
             .await?;
-            let live_rows = (gross.unwrap_or(0) - deleted).max(0) as u64;
+            let inlined_table = crate::metadata_provider::inlined_delete_table_name(table_id)?;
+            let inlined_exists: Option<i64> =
+                sqlx::query_scalar("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+                    .bind(&inlined_table)
+                    .fetch_optional(&mut *tx)
+                    .await?;
+            let inlined_deleted: i64 = if inlined_exists.is_some() {
+                sqlx::query_scalar(AssertSqlSafe(format!(
+                    "SELECT COUNT(*) FROM (
+                       SELECT DISTINCT d.file_id, d.row_id
+                       FROM \"{inlined_table}\" d
+                       JOIN ducklake_data_file f ON f.data_file_id = d.file_id
+                       WHERE f.table_id = ? AND f.end_snapshot IS NULL
+                         AND d.begin_snapshot <= ?
+                     )"
+                )))
+                .bind(table_id)
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?
+            } else {
+                0
+            };
+            let live_rows = (gross.unwrap_or(0) - deleted - inlined_deleted).max(0) as u64;
 
             sqlx::query(
                 "UPDATE ducklake_data_file SET end_snapshot = ?

--- a/src/table.rs
+++ b/src/table.rs
@@ -1840,6 +1840,40 @@ impl DuckLakeTable {
         Ok(positions)
     }
 
+    pub(crate) fn inlined_deletes_by_file(&self) -> DataFusionResult<HashMap<i64, HashSet<i64>>> {
+        let deletes = self
+            .provider
+            .get_inlined_deletes(self.table_id, self.snapshot_id)
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut by_file: HashMap<i64, HashSet<i64>> = HashMap::new();
+        for delete in deletes {
+            if delete.data_file_id < 0 || delete.row_id < 0 {
+                return Err(DataFusionError::Execution(format!(
+                    "inlined delete has invalid file_id {} and row_id {}",
+                    delete.data_file_id, delete.row_id
+                )));
+            }
+            by_file
+                .entry(delete.data_file_id)
+                .or_default()
+                .insert(delete.row_id);
+        }
+        Ok(by_file)
+    }
+
+    async fn deleted_positions_for_file(
+        &self,
+        state: &dyn Session,
+        table_file: &DuckLakeTableFile,
+        inlined_positions: Option<&HashSet<i64>>,
+    ) -> DataFusionResult<HashSet<i64>> {
+        let mut positions = inlined_positions.cloned().unwrap_or_default();
+        if let Some(delete_file) = &table_file.delete_file {
+            positions.extend(self.read_delete_file_positions(state, delete_file).await?);
+        }
+        Ok(positions)
+    }
+
     /// Whether `file` was rewritten — by an UPDATE or by compaction — rather
     /// than only ever inserted. A rewritten file embeds its rows' original row
     /// ids as a reserved parquet column (tagged with
@@ -2036,6 +2070,7 @@ impl DuckLakeTable {
         &self,
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
+        inlined_positions: Option<&HashSet<i64>>,
         file_statistics: &HashMap<i64, Arc<Statistics>>,
         projection: Option<&Vec<usize>>,
         limit: Option<usize>,
@@ -2045,12 +2080,10 @@ impl DuckLakeTable {
         // Deletes filter by physical row position, so this is a positional path:
         // it must read the file in row-group-aligned, non-repartitionable,
         // non-pruning partitions and synthesize positions before filtering.
-        let deleted_positions = if let Some(ref delete_file) = table_file.delete_file {
-            let p = self.read_delete_file_positions(state, delete_file).await?;
-            (!p.is_empty()).then_some(p)
-        } else {
-            None
-        };
+        let deleted_positions = self
+            .deleted_positions_for_file(state, table_file, inlined_positions)
+            .await?;
+        let deleted_positions = (!deleted_positions.is_empty()).then_some(deleted_positions);
 
         let output_schema = match projection {
             Some(indices) => Arc::new(self.schema.project(indices)?),
@@ -2292,10 +2325,12 @@ impl DuckLakeTable {
     ///   DataSourceExec → FileRowNumberExec → DeleteFilterExec(?) → RowIdExec(?)
     ///   → ColumnRenameExec. Embedded-rowid files with no deletes keep a plain
     ///   DataSourceExec → ColumnRenameExec (rowid read from the file).
+    #[allow(clippy::too_many_arguments, reason = "per-file row-lineage scan inputs stay explicit")]
     async fn build_exec_for_file_with_rowid(
         &self,
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
+        inlined_positions: Option<&HashSet<i64>>,
         file_statistics: &HashMap<i64, Arc<Statistics>>,
         user_proj: &[usize],
         rowid_idx: usize,
@@ -2323,12 +2358,10 @@ impl DuckLakeTable {
         }
 
         // Resolve deletes once.
-        let deleted_positions = if let Some(ref delete_file) = table_file.delete_file {
-            let p = self.read_delete_file_positions(state, delete_file).await?;
-            (!p.is_empty()).then_some(p)
-        } else {
-            None
-        };
+        let deleted_positions = self
+            .deleted_positions_for_file(state, table_file, inlined_positions)
+            .await?;
+        let deleted_positions = (!deleted_positions.is_empty()).then_some(deleted_positions);
         let has_deletes = deleted_positions.is_some();
 
         // We need synthesized physical positions when rowid must be synthesized
@@ -2474,6 +2507,7 @@ impl DuckLakeTable {
         &self,
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
+        inlined_positions: Option<&HashSet<i64>>,
         output_schema: SchemaRef,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         // This path applies no delete filtering, and that has been safe only
@@ -2519,22 +2553,50 @@ impl DuckLakeTable {
         let read_schema = Arc::new(Schema::new(fields));
         let projection: Vec<usize> = (0..read_schema.fields().len()).collect();
 
-        let resolved_path = self.resolve_file_path(&table_file.file)?;
-        let mut pf = PartitionedFile::new(
-            &resolved_path,
-            validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
-        );
-        if let Some(footer_size) = table_file.file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
-            pf = pf.with_metadata_size_hint(hint);
-        }
-        let builder = self
-            .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
-            .with_file_group(FileGroup::new(vec![pf]))
-            .with_projection_indices(Some(projection))?;
-        let scan = DataSourceExec::from_data_source(builder.build());
+        let deleted_positions = self
+            .deleted_positions_for_file(state, table_file, inlined_positions)
+            .await?;
+        let scan: Arc<dyn ExecutionPlan> = if deleted_positions.is_empty() {
+            let resolved_path = self.resolve_file_path(&table_file.file)?;
+            let mut pf = PartitionedFile::new(
+                &resolved_path,
+                validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
+            );
+            if let Some(footer_size) = table_file.file.footer_size
+                && footer_size > 0
+                && let Ok(hint) = usize::try_from(footer_size)
+            {
+                pf = pf.with_metadata_size_hint(hint);
+            }
+            let builder = self
+                .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
+                .with_file_group(FileGroup::new(vec![pf]))
+                .with_projection_indices(Some(projection))?;
+            DataSourceExec::from_data_source(builder.build())
+        } else {
+            let target_partitions = state.config().target_partitions();
+            let (file_groups, partition_starts) =
+                self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?;
+            let source = PositionalFileSource::wrap(Arc::new(
+                self.create_parquet_source(read_schema.clone()),
+            ));
+            let num_file_groups = file_groups.len();
+            let builder = self
+                .scan_config_builder(source)
+                .with_file_groups(file_groups)
+                .with_output_partitioning(Some(
+                    datafusion::physical_expr::Partitioning::UnknownPartitioning(num_file_groups),
+                ))
+                .with_projection_indices(Some(projection))?;
+            let scan = DataSourceExec::from_data_source(builder.build());
+            let with_positions: Arc<dyn ExecutionPlan> =
+                Arc::new(FileRowNumberExec::new(scan, partition_starts));
+            Arc::new(DeleteFilterExec::try_new(
+                with_positions,
+                table_file.file.path.clone(),
+                Arc::new(deleted_positions),
+            )?)
+        };
 
         // Drop rows newer than the read snapshot, then present the catalog schema.
         let filtered: Arc<dyn ExecutionPlan> = Arc::new(SnapshotFilterExec::try_new(
@@ -2701,8 +2763,9 @@ impl DuckLakeTable {
         &self,
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
+        inlined_positions: Option<&HashSet<i64>>,
     ) -> DataFusionResult<UpdateSourceScan> {
-        self.build_update_scan_with_snapshot(state, table_file, false)
+        self.build_update_scan_with_snapshot(state, table_file, false, inlined_positions)
             .await
     }
 
@@ -2725,6 +2788,7 @@ impl DuckLakeTable {
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
         want_snapshot_id: bool,
+        inlined_positions: Option<&HashSet<i64>>,
     ) -> DataFusionResult<UpdateSourceScan> {
         let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
         let has_embedded = file_cfg.embedded_rowid_parquet_name.is_some();
@@ -2737,13 +2801,17 @@ impl DuckLakeTable {
             )));
         }
 
-        // Rows already masked by a live delete file must not be re-updated, and
-        // must remain masked in the file's new cumulative delete.
-        let existing_deleted: HashSet<i64> = if let Some(ref delete_file) = table_file.delete_file {
-            self.read_delete_file_positions(state, delete_file).await?
-        } else {
-            HashSet::new()
+        // Both delete sources mask the scan, but only prior Parquet positions are
+        // carried into the replacement Parquet delete file. Inlined positions
+        // remain owned by their metadata table until an explicit flush.
+        let existing_parquet_deleted = match &table_file.delete_file {
+            Some(delete_file) => self.read_delete_file_positions(state, delete_file).await?,
+            None => HashSet::new(),
         };
+        let mut deleted_positions = existing_parquet_deleted.clone();
+        if let Some(inlined) = inlined_positions {
+            deleted_positions.extend(inlined);
+        }
 
         // The scan schema is the cached per-file one, plus the embedded
         // snapshot-id column when this caller asked for it. Appending here (and
@@ -2803,11 +2871,11 @@ impl DuckLakeTable {
         );
         let mut plan: Arc<dyn ExecutionPlan> =
             Arc::new(FileRowNumberExec::new(scan, partition_starts));
-        if !existing_deleted.is_empty() {
+        if !deleted_positions.is_empty() {
             plan = Arc::new(DeleteFilterExec::try_new(
                 plan,
                 table_file.file.path.clone(),
-                Arc::new(existing_deleted.clone()),
+                Arc::new(deleted_positions),
             )?);
         }
         let pos_index = plan.schema().index_of(ROW_POS_COLUMN_NAME)?;
@@ -2819,7 +2887,7 @@ impl DuckLakeTable {
             embedded_snapshot_batch_idx,
             pos_index,
             row_id_start: table_file.row_id_start,
-            existing_deleted,
+            existing_parquet_deleted,
             data_file_id: table_file.data_file_id,
             delete_file_id: table_file.delete_file_id,
             source_path: table_file.file.path.clone(),
@@ -2873,7 +2941,7 @@ impl DuckLakeTable {
         }
 
         let matched_count = new_positions.len();
-        let mut cumulative = scan.existing_deleted.clone();
+        let mut cumulative = scan.existing_parquet_deleted.clone();
         cumulative.extend(new_positions);
         let mut cumulative_positions: Vec<i64> = cumulative.into_iter().collect();
         cumulative_positions.sort_unstable();
@@ -3094,9 +3162,9 @@ pub(crate) struct UpdateSourceScan {
     /// The source file's catalog `row_id_start` (used to synthesize rowids for a
     /// non-embedded file).
     pub(crate) row_id_start: Option<i64>,
-    /// Positions already masked by the file's live delete file, carried forward
-    /// into the new cumulative delete.
-    pub(crate) existing_deleted: HashSet<i64>,
+    /// Positions already masked by the live Parquet delete file, carried into
+    /// the replacement Parquet delete file.
+    pub(crate) existing_parquet_deleted: HashSet<i64>,
     /// Catalog id of the source data file (the positional delete's target).
     pub(crate) data_file_id: i64,
     /// Catalog id of the file's currently-live delete file (compare-and-swap
@@ -3185,6 +3253,7 @@ impl TableProvider for DuckLakeTable {
         };
 
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
+        let inlined_deletes = self.inlined_deletes_by_file()?;
         let pruning = match self.file_pruning_predicates(state, filters) {
             Ok(pruning) => pruning,
             Err(error) => {
@@ -3209,12 +3278,18 @@ impl TableProvider for DuckLakeTable {
                     let exec = if self.needs_snapshot_filter(table_file) {
                         let output_schema =
                             self.output_schema_for_projection(&user_proj, rowid_idx);
-                        self.build_exec_for_partial_file(state, table_file, output_schema)
-                            .await?
+                        self.build_exec_for_partial_file(
+                            state,
+                            table_file,
+                            inlined_deletes.get(&table_file.data_file_id),
+                            output_schema,
+                        )
+                        .await?
                     } else {
                         self.build_exec_for_file_with_rowid(
                             state,
                             table_file,
+                            inlined_deletes.get(&table_file.data_file_id),
                             &file_statistics,
                             &user_proj,
                             rowid_idx,
@@ -3230,9 +3305,11 @@ impl TableProvider for DuckLakeTable {
             let (needs_filter, rest): (Vec<_>, Vec<_>) = table_files
                 .into_iter()
                 .partition(|table_file| self.needs_snapshot_filter(table_file));
-            let (files_with_deletes, files_without_deletes): (Vec<_>, Vec<_>) = rest
-                .into_iter()
-                .partition(|table_file| table_file.delete_file.is_some());
+            let (files_with_deletes, files_without_deletes): (Vec<_>, Vec<_>) =
+                rest.into_iter().partition(|table_file| {
+                    table_file.delete_file.is_some()
+                        || inlined_deletes.contains_key(&table_file.data_file_id)
+                });
 
             if !files_without_deletes.is_empty() {
                 execs.push(
@@ -3251,6 +3328,7 @@ impl TableProvider for DuckLakeTable {
                     self.build_exec_for_file_with_deletes(
                         state,
                         table_file,
+                        inlined_deletes.get(&table_file.data_file_id),
                         &file_statistics,
                         projection,
                         limit,
@@ -3264,8 +3342,13 @@ impl TableProvider for DuckLakeTable {
                     None => self.schema.clone(),
                 };
                 execs.push(
-                    self.build_exec_for_partial_file(state, table_file, output_schema)
-                        .await?,
+                    self.build_exec_for_partial_file(
+                        state,
+                        table_file,
+                        inlined_deletes.get(&table_file.data_file_id),
+                        output_schema,
+                    )
+                    .await?,
                 );
             }
         }
@@ -3482,9 +3565,13 @@ impl TableProvider for DuckLakeTable {
         let table_files = self
             .files()
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let inlined_deletes = self.inlined_deletes_by_file()?;
         let mut scans = Vec::with_capacity(table_files.len());
         for tf in &table_files {
-            scans.push(self.build_update_scan(state, tf).await?);
+            scans.push(
+                self.build_update_scan(state, tf, inlined_deletes.get(&tf.data_file_id))
+                    .await?,
+            );
         }
 
         Ok(Arc::new(DuckLakeUpdateExec::new(
@@ -3492,6 +3579,7 @@ impl TableProvider for DuckLakeTable {
             Arc::clone(writer),
             schema_name.clone(),
             self.table_name.clone(),
+            self.snapshot_id,
             scans,
             phys_assignments,
             predicate,

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -1329,7 +1329,9 @@ impl TableProvider for TableChangesTable {
         // Deletes applied in the window surface as `delete` rows (and pair into
         // update preimages), so they participate in both the empty check and
         // the path decision — a delete-only window is NOT empty. The insertions
-        // feed never reads the delete side.
+        // feed never reads the delete side. Inlined deletes
+        // (ducklake_inlined_delete_<table_id>) are not read here: a window whose
+        // only change is an inlined delete emits no rows (see COMPATIBILITY.md).
         let delete_files = if self.insertions_only {
             Vec::new()
         } else {

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -1995,6 +1995,13 @@ pub struct TableWriteSession {
 }
 
 impl TableWriteSession {
+    // Keep the read plan's snapshot for source-scoped conflict checks without
+    // enabling the broader table-generation precondition.
+    pub(crate) const fn with_base_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.base_snapshot_id = snapshot_id;
+        self
+    }
+
     /// Applies snapshot metadata and an optional table-state precondition.
     #[must_use]
     pub fn with_options(mut self, options: &TableWriteOptions) -> Self {

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -86,6 +86,7 @@ pub struct DuckLakeUpdateExec {
     writer: Arc<dyn MetadataWriter>,
     schema_name: String,
     table_name: String,
+    base_snapshot: i64,
     /// Per-source-file positional read plans (built at plan time).
     scans: Vec<UpdateSourceScan>,
     /// `(physical_column_index, new_value_expr)` for each assigned column.
@@ -104,6 +105,7 @@ impl DuckLakeUpdateExec {
         writer: Arc<dyn MetadataWriter>,
         schema_name: String,
         table_name: String,
+        base_snapshot: i64,
         scans: Vec<UpdateSourceScan>,
         assignments: Vec<(usize, Arc<dyn PhysicalExpr>)>,
         predicate: Option<Arc<dyn PhysicalExpr>>,
@@ -115,6 +117,7 @@ impl DuckLakeUpdateExec {
             writer,
             schema_name,
             table_name,
+            base_snapshot,
             scans,
             assignments,
             predicate,
@@ -219,6 +222,7 @@ impl ExecutionPlan for DuckLakeUpdateExec {
         let writer = Arc::clone(&self.writer);
         let schema_name = self.schema_name.clone();
         let table_name = self.table_name.clone();
+        let base_snapshot = self.base_snapshot;
         let scans = self.scans.clone();
         let assignments = self.assignments.clone();
         let predicate = self.predicate.clone();
@@ -300,6 +304,7 @@ impl ExecutionPlan for DuckLakeUpdateExec {
                     physical_schema.as_ref(),
                     WriteMode::Append,
                 )
+                .map(|session| session.with_base_snapshot_id(base_snapshot))
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
             while let Some(batch) = updated_batches.try_next().await? {
                 session

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -875,6 +875,142 @@ async fn rewrite_can_target_explicit_data_files_without_deletes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn rewrite_does_not_resurrect_inlined_deletes() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2, 3], vec![10, 20, 30]).await;
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp.path().join("test.db"),
+        &[1],
+    )
+    .await;
+    assert_eq!(read_rows(&temp).await, vec![(1, 10), (3, 30)]);
+
+    assert_eq!(
+        run_rewrite(
+            &temp,
+            RewriteOptions {
+                delete_threshold: 0.3,
+                ..RewriteOptions::default()
+            },
+        )
+        .await,
+        CompactionResult {
+            files_processed: 1,
+            files_created: 1,
+            rows_written: 2,
+        },
+    );
+    assert_eq!(read_rows(&temp).await, vec![(1, 10), (3, 30)]);
+}
+
+/// An inlined DELETE that lands between a compaction's plan and commit trips the
+/// source-file fence instead of resurrecting the concurrently deleted row.
+#[tokio::test(flavor = "multi_thread")]
+async fn compaction_conflicts_with_a_concurrent_inlined_delete() {
+    use datafusion_ducklake::metadata_writer::SourceRetirement;
+    use datafusion_ducklake::{CompactionSourceFile, DuckLakeError};
+
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2, 3], vec![10, 20, 30]).await;
+    // The plan observed no inlined deletes; a concurrent writer then inlines one.
+    let p = pool(&temp).await;
+    let base_snapshot = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version)
+         VALUES (?, CURRENT_TIMESTAMP, 1)",
+    )
+    .bind(base_snapshot + 1)
+    .execute(&p)
+    .await
+    .unwrap();
+    let data_file_id = crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp.path().join("test.db"),
+        &[1],
+    )
+    .await;
+
+    let writer = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+    let table_id = scalar_i64(
+        &p,
+        "SELECT table_id FROM ducklake_table WHERE table_name = 't'",
+    )
+    .await;
+    let error = writer
+        .commit_compaction(
+            table_id,
+            base_snapshot,
+            &[CompactionSourceFile {
+                data_file_id,
+                delete_file_id: None,
+            }],
+            &[],
+            SourceRetirement::Retire,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(error, DuckLakeError::Conflict(_)),
+        "expected Conflict, got {error:?}"
+    );
+}
+
+/// A file whose rows are masked only by inlined deletes has `delete_file_id = NULL`,
+/// but merging it with `SourceRetirement::Remove` would erase the masked rows from
+/// every snapshot and leave `ducklake_inlined_delete_<id>` rows pointing at a removed
+/// file. Such a file must not be a merge candidate; unaffected files still merge.
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_skips_files_masked_by_inlined_deletes() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2], vec![10, 20]).await;
+    let p = pool(&temp).await;
+    let seed_snapshot = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    append(&temp, vec![3, 4], vec![30, 40]).await;
+    append(&temp, vec![5, 6], vec![50, 60]).await;
+    let masked_file_id = crate::inlined_delete_fixture::insert_inlined_deletes_for_first_file(
+        &temp.path().join("test.db"),
+        &[0],
+    )
+    .await;
+    assert_eq!(
+        read_rows(&temp).await,
+        vec![(2, 20), (3, 30), (4, 40), (5, 50), (6, 60)]
+    );
+
+    assert_eq!(
+        run_merge(&temp, MergeOptions::default()).await,
+        CompactionResult {
+            files_processed: 2,
+            files_created: 1,
+            rows_written: 4,
+        },
+    );
+
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let table_id = scalar_i64(
+        &p,
+        "SELECT table_id FROM ducklake_table WHERE table_name = 't'",
+    )
+    .await;
+    let files = provider
+        .get_table_file_metadata_page(table_id, snapshot, None, 10)
+        .unwrap();
+    assert!(
+        files
+            .iter()
+            .any(|metadata| metadata.file.data_file_id == masked_file_id),
+        "the masked file must survive the merge",
+    );
+    assert_eq!(
+        read_rows(&temp).await,
+        vec![(2, 20), (3, 30), (4, 40), (5, 50), (6, 60)]
+    );
+    assert_eq!(
+        read_rows_at(&temp, seed_snapshot).await,
+        vec![(1, 10), (2, 20)]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn sorted_merge_under_memory_limit_preserves_rowids_and_snapshot_lineage() {
     const MEMORY_LIMIT: usize = 256 * 1024;
     const ROWS_PER_SNAPSHOT: i32 = 16_384;

--- a/tests/it/inlined_delete_fixture.rs
+++ b/tests/it/inlined_delete_fixture.rs
@@ -1,0 +1,78 @@
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::path::Path;
+
+use sqlx::sqlite::SqlitePool;
+use sqlx::{AssertSqlSafe, Row};
+
+pub(crate) async fn insert_inlined_deletes_for_first_file(db_path: &Path, row_ids: &[i64]) -> i64 {
+    let pool = SqlitePool::connect(&format!("sqlite:{}?mode=rwc", db_path.display()))
+        .await
+        .unwrap();
+    let row = sqlx::query(
+        "SELECT t.table_id, MIN(f.data_file_id), MAX(s.snapshot_id) \
+         FROM ducklake_table t \
+         JOIN ducklake_data_file f ON f.table_id = t.table_id \
+         CROSS JOIN ducklake_snapshot s \
+         WHERE t.table_name = 't' AND t.end_snapshot IS NULL AND f.end_snapshot IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let table_id: i64 = row.try_get(0).unwrap();
+    let data_file_id: i64 = row.try_get(1).unwrap();
+    let snapshot_id: i64 = row.try_get(2).unwrap();
+    insert_inlined_deletes(&pool, table_id, data_file_id, snapshot_id, row_ids).await;
+    data_file_id
+}
+
+pub(crate) async fn insert_inlined_deletes_for_only_file(db_path: &Path, row_ids: &[i64]) -> i64 {
+    let pool = SqlitePool::connect(&format!("sqlite:{}?mode=rwc", db_path.display()))
+        .await
+        .unwrap();
+    let rows = sqlx::query(
+        "SELECT t.table_id, f.data_file_id, max(s.snapshot_id) \
+         FROM ducklake_table t \
+         JOIN ducklake_data_file f ON f.table_id = t.table_id \
+         CROSS JOIN ducklake_snapshot s \
+         WHERE t.table_name = 't' AND t.end_snapshot IS NULL AND f.end_snapshot IS NULL \
+         GROUP BY t.table_id, f.data_file_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    let table_id: i64 = row.try_get(0).unwrap();
+    let data_file_id: i64 = row.try_get(1).unwrap();
+    let snapshot_id: i64 = row.try_get(2).unwrap();
+    insert_inlined_deletes(&pool, table_id, data_file_id, snapshot_id, row_ids).await;
+    data_file_id
+}
+
+async fn insert_inlined_deletes(
+    pool: &SqlitePool,
+    table_id: i64,
+    data_file_id: i64,
+    snapshot_id: i64,
+    row_ids: &[i64],
+) {
+    let table = format!("ducklake_inlined_delete_{table_id}");
+
+    let create_sql =
+        format!("CREATE TABLE {table}(file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT)");
+    sqlx::query(AssertSqlSafe(create_sql.as_str()))
+        .execute(pool)
+        .await
+        .unwrap();
+    for row_id in row_ids {
+        let insert_sql = format!("INSERT INTO {table} VALUES (?, ?, ?)");
+        sqlx::query(AssertSqlSafe(insert_sql.as_str()))
+            .bind(data_file_id)
+            .bind(row_id)
+            .bind(snapshot_id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+}

--- a/tests/it/inlined_delete_tests.rs
+++ b/tests/it/inlined_delete_tests.rs
@@ -1,0 +1,361 @@
+//! Integration tests for positional deletes stored in metadata catalog tables.
+
+use datafusion_ducklake::MetadataProvider;
+use datafusion_ducklake::metadata_provider::DuckLakeInlinedDelete;
+
+#[cfg(feature = "metadata-duckdb")]
+mod duckdb_oracle {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use arrow::array::{Int32Array, Int64Array};
+    use datafusion::prelude::*;
+    use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+    use tempfile::TempDir;
+
+    use super::{DuckLakeInlinedDelete, MetadataProvider};
+    use crate::common;
+
+    fn escaped_path(path: &Path) -> String {
+        path.to_string_lossy().replace('\'', "''")
+    }
+
+    async fn ids(ctx: &SessionContext) -> Vec<i32> {
+        let batches = ctx
+            .sql("SELECT id FROM lake.main.items ORDER BY id")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    async fn rowids(ctx: &SessionContext) -> Vec<(i64, i32)> {
+        let batches = ctx
+            .sql("SELECT rowid, id FROM lake.main.items ORDER BY id")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+        for batch in batches {
+            let rowids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let ids = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            rows.extend(
+                rowids
+                    .values()
+                    .iter()
+                    .copied()
+                    .zip(ids.values().iter().copied()),
+            );
+        }
+        rows
+    }
+
+    async fn count(ctx: &SessionContext) -> i64 {
+        let batches = ctx
+            .sql("SELECT COUNT(*) FROM lake.main.items")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0)
+    }
+
+    #[tokio::test]
+    async fn inlined_delete_matches_duckdb_select_count_rowid_and_time_travel() {
+        let temp = TempDir::new().unwrap();
+        let catalog_path = temp.path().join("deletes.ducklake");
+        let data_path = temp.path().join("data");
+        let expected = {
+            common::ensure_ducklake_installed();
+            let conn = duckdb::Connection::open_in_memory().unwrap();
+            conn.execute("LOAD ducklake", []).unwrap();
+            conn.execute(
+                &format!(
+                    "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 10)",
+                    escaped_path(&catalog_path),
+                    escaped_path(&data_path)
+                ),
+                [],
+            )
+            .unwrap();
+            conn.execute("CREATE TABLE lake.items(id INTEGER)", [])
+                .unwrap();
+            conn.execute("INSERT INTO lake.items SELECT i FROM range(20) t(i)", [])
+                .unwrap();
+            conn.execute("DELETE FROM lake.items WHERE id IN (3, 7)", [])
+                .unwrap();
+
+            let mut statement = conn
+                .prepare("SELECT id FROM lake.main.items ORDER BY id")
+                .unwrap();
+            statement
+                .query_map([], |row| row.get::<_, i32>(0))
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap()
+        };
+
+        // DuckDB 1.5 creates this table directly. The 1.4.1 library pinned by
+        // this crate emits a regular positional delete, so normalize only that
+        // metadata row into the current specification's equivalent encoding.
+        let metadata = duckdb::Connection::open(&catalog_path).unwrap();
+        let table_id: i64 = metadata
+            .query_row(
+                "SELECT table_id FROM ducklake_table WHERE table_name = 'items'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let current_snapshot: i64 = metadata
+            .query_row(
+                "SELECT max(snapshot_id) FROM ducklake_snapshot",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let inlined_delete_table = format!("ducklake_inlined_delete_{table_id}");
+        let has_inlined_deletes: bool = metadata
+            .query_row(
+                "SELECT count(*) = 1 FROM information_schema.tables WHERE table_schema = 'main' AND table_name = ?",
+                [&inlined_delete_table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if !has_inlined_deletes {
+            metadata
+                .execute(
+                    &format!(
+                        "CREATE TABLE {inlined_delete_table}(\
+                         file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT)"
+                    ),
+                    [],
+                )
+                .unwrap();
+            let data_file_id: i64 = metadata
+                .query_row(
+                    "SELECT data_file_id FROM ducklake_data_file \
+                     WHERE table_id = ? AND end_snapshot IS NULL",
+                    [table_id],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            let inserted = metadata
+                .execute(
+                    &format!("INSERT INTO {inlined_delete_table} VALUES (?, 3, ?), (?, 7, ?)"),
+                    duckdb::params![data_file_id, current_snapshot, data_file_id, current_snapshot],
+                )
+                .unwrap();
+            assert_eq!(inserted, 2);
+            let removed = metadata
+                .execute(
+                    "DELETE FROM ducklake_delete_file WHERE begin_snapshot = ?",
+                    [current_snapshot],
+                )
+                .unwrap();
+            assert_eq!(removed, 1);
+        }
+        drop(metadata);
+
+        let path = catalog_path.to_string_lossy().to_string();
+        let provider = DuckdbMetadataProvider::new(&path).unwrap();
+        assert_eq!(provider.get_current_snapshot().unwrap(), current_snapshot);
+        let schema = provider
+            .get_schema_by_name("main", current_snapshot)
+            .unwrap()
+            .unwrap();
+        let table = provider
+            .get_table_by_name(schema.schema_id, "items", current_snapshot)
+            .unwrap()
+            .unwrap();
+        let deletes = provider
+            .get_inlined_deletes(table.table_id, current_snapshot)
+            .unwrap();
+        let data_file_id = deletes[0].data_file_id;
+        assert_eq!(
+            deletes,
+            vec![
+                DuckLakeInlinedDelete {
+                    data_file_id,
+                    row_id: 3,
+                },
+                DuckLakeInlinedDelete {
+                    data_file_id,
+                    row_id: 7,
+                },
+            ]
+        );
+
+        let catalog = DuckLakeCatalog::new(provider)
+            .unwrap()
+            .with_row_lineage(true);
+        let current = SessionContext::new();
+        current.register_catalog("lake", Arc::new(catalog));
+        assert_eq!(ids(&current).await, expected);
+        assert_eq!(count(&current).await, expected.len() as i64);
+        assert_eq!(
+            rowids(&current).await,
+            expected
+                .iter()
+                .map(|id| (i64::from(*id), *id))
+                .collect::<Vec<_>>()
+        );
+
+        let previous_provider = Arc::new(DuckdbMetadataProvider::new(&path).unwrap());
+        let previous_catalog = DuckLakeCatalog::with_snapshot(
+            previous_provider,
+            current_snapshot.checked_sub(1).unwrap(),
+        )
+        .unwrap();
+        let previous = SessionContext::new();
+        previous.register_catalog("lake", Arc::new(previous_catalog));
+        assert_eq!(ids(&previous).await, (0..20).collect::<Vec<_>>());
+        assert_eq!(count(&previous).await, 20);
+    }
+}
+
+#[cfg(feature = "metadata-sqlite")]
+#[tokio::test(flavor = "multi_thread")]
+async fn sqlite_inlined_delete_lookup_is_snapshot_aware_and_optional() {
+    use datafusion_ducklake::SqliteMetadataProvider;
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let url = format!(
+        "sqlite:{}?mode=rwc",
+        temp.path().join("catalog.db").display()
+    );
+    let pool = SqlitePool::connect(&url).await.unwrap();
+    let provider = SqliteMetadataProvider::new(&url).await.unwrap();
+    assert!(provider.get_inlined_deletes(5, 2).unwrap().is_empty());
+    assert_eq!(
+        provider.get_inlined_deletes(-1, 2).unwrap_err().to_string(),
+        "Invalid configuration: DuckLake table id must be non-negative, was -1"
+    );
+
+    sqlx::query(
+        "CREATE TABLE ducklake_inlined_delete_5(
+             file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO ducklake_inlined_delete_5 VALUES (9, 3, 1), (9, 7, 3)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let deletes = provider.get_inlined_deletes(5, 2).unwrap();
+    assert_eq!(
+        deletes,
+        vec![DuckLakeInlinedDelete {
+            data_file_id: 9,
+            row_id: 3,
+        }]
+    );
+}
+
+#[cfg(feature = "metadata-postgres")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+#[tokio::test(flavor = "multi_thread")]
+async fn postgres_inlined_delete_lookup_reads_native_bigints() {
+    use datafusion_ducklake::PostgresMetadataProvider;
+    use sqlx::PgPool;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let pool = PgPool::connect(&url).await.unwrap();
+    let provider = PostgresMetadataProvider::new(&url).await.unwrap();
+    assert!(provider.get_inlined_deletes(5, 2).unwrap().is_empty());
+    sqlx::query(
+        "CREATE TABLE ducklake_inlined_delete_5(
+             file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO ducklake_inlined_delete_5 VALUES (9, 3, 1), (9, 7, 3)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let deletes = provider.get_inlined_deletes(5, 2).unwrap();
+    assert_eq!(
+        deletes,
+        vec![DuckLakeInlinedDelete {
+            data_file_id: 9,
+            row_id: 3,
+        }]
+    );
+}
+
+#[cfg(feature = "metadata-mysql")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+#[tokio::test(flavor = "multi_thread")]
+async fn mysql_inlined_delete_lookup_reads_native_bigints() {
+    use datafusion_ducklake::MySqlMetadataProvider;
+    use sqlx::MySqlPool;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::mysql::Mysql;
+
+    let container = Mysql::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(3306).await.unwrap();
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+    let pool = MySqlPool::connect(&url).await.unwrap();
+    let provider = MySqlMetadataProvider::new(&url).await.unwrap();
+    assert!(provider.get_inlined_deletes(5, 2).unwrap().is_empty());
+    sqlx::query(
+        "CREATE TABLE ducklake_inlined_delete_5(
+             file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO ducklake_inlined_delete_5 VALUES (9, 3, 1), (9, 7, 3)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let deletes = provider.get_inlined_deletes(5, 2).unwrap();
+    assert_eq!(
+        deletes,
+        vec![DuckLakeInlinedDelete {
+            data_file_id: 9,
+            row_id: 3,
+        }]
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -36,6 +36,8 @@ mod hybrid_asyncdb;
 mod information_schema_test;
 mod inlined_data_backends_tests;
 mod inlined_data_sqlite_tests;
+mod inlined_delete_fixture;
+mod inlined_delete_tests;
 mod insert_partitioning_tests;
 mod keyed_mutation_after_compaction_tests;
 mod maintenance_sqlite_tests;

--- a/tests/it/sql_delete_tests.rs
+++ b/tests/it/sql_delete_tests.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 
 use datafusion_ducklake::types::extract_parquet_field_ids;
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, SqliteMetadataProvider,
     SqliteMetadataWriter,
 };
 use sqlx::sqlite::SqlitePool;
@@ -244,6 +244,169 @@ async fn delete_already_deleted_is_noop() {
         "a no-op DELETE creates no snapshot"
     );
     assert_eq!(read_ids(&temp).await, vec![1, 3, 4]);
+}
+
+/// Rows already removed by INLINED deletes are neither re-counted nor
+/// re-committed: a DELETE matching only such rows is a no-op, and a mixed
+/// predicate counts only the still-live rows.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_of_inline_deleted_rows_is_noop() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+    // id = 2 sits at physical position 1 of the only data file.
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp.path().join("test.db"),
+        &[1],
+    )
+    .await;
+    assert_eq!(
+        read_ids(&temp).await,
+        vec![1, 3, 4],
+        "inline delete applied"
+    );
+
+    let snaps = snapshot_count(&temp).await;
+    let ctx1 = writable_ctx(&temp).await;
+    assert_eq!(
+        run_delete(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await,
+        0,
+        "the inline-deleted row is not re-counted"
+    );
+    assert_eq!(
+        snapshot_count(&temp).await,
+        snaps,
+        "a DELETE matching only inline-deleted rows creates no snapshot"
+    );
+
+    let ctx2 = writable_ctx(&temp).await;
+    assert_eq!(
+        run_delete(&ctx2, "DELETE FROM ducklake.main.t WHERE id IN (2, 3)").await,
+        1,
+        "only the live row counts"
+    );
+    assert_eq!(read_ids(&temp).await, vec![1, 4]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_keeps_inline_and_parquet_positions_in_separate_stores() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    let first = writable_ctx(&temp).await;
+    assert_eq!(
+        run_delete(&first, "DELETE FROM ducklake.main.t WHERE id = 1").await,
+        1
+    );
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp.path().join("test.db"),
+        &[1],
+    )
+    .await;
+
+    let second = writable_ctx(&temp).await;
+    assert_eq!(
+        run_delete(&second, "DELETE FROM ducklake.main.t WHERE id = 3").await,
+        1
+    );
+    let pool = SqlitePool::connect(&format!("sqlite:{}", temp.path().join("test.db").display()))
+        .await
+        .unwrap();
+    let delete_count: i64 = sqlx::query_scalar(
+        "SELECT delete_count FROM ducklake_delete_file WHERE end_snapshot IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        delete_count, 2,
+        "the Parquet file contains positions 0 and 2"
+    );
+    assert_eq!(read_ids(&temp).await, vec![4]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn truncate_and_metadata_count_subtract_inlined_deletes() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp.path().join("test.db"),
+        &[1],
+    )
+    .await;
+
+    let url = format!("sqlite:{}", temp.path().join("test.db").display());
+    let provider = SqliteMetadataProvider::new(&url).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let schema = provider
+        .get_schema_by_name("main", snapshot)
+        .unwrap()
+        .unwrap();
+    let table = provider
+        .get_table_by_name(schema.schema_id, "t", snapshot)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        provider
+            .get_table_row_count(table.table_id, snapshot)
+            .unwrap(),
+        3
+    );
+
+    let ctx = writable_ctx(&temp).await;
+    assert_eq!(run_delete(&ctx, "DELETE FROM ducklake.main.t").await, 3);
+    assert!(read_ids(&temp).await.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inlined_delete_uses_physical_position_with_nonzero_row_id_start() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3])])
+        .await
+        .unwrap();
+    let ctx = writable_ctx(&temp).await;
+    assert_eq!(run_delete(&ctx, "DELETE FROM ducklake.main.t").await, 3);
+
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .append_table("main", "t", &[id_batch(&[4, 5, 6])])
+        .await
+        .unwrap();
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp.path().join("test.db"),
+        &[1],
+    )
+    .await;
+
+    let pool = SqlitePool::connect(&format!("sqlite:{}", temp.path().join("test.db").display()))
+        .await
+        .unwrap();
+    let row_id_start: i64 = sqlx::query_scalar(
+        "SELECT row_id_start FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row_id_start, 3);
+    assert_eq!(read_ids(&temp).await, vec![4, 6]);
 }
 
 /// A DELETE matching no rows deletes nothing and reports 0.

--- a/tests/it/sql_update_tests.rs
+++ b/tests/it/sql_update_tests.rs
@@ -527,6 +527,81 @@ async fn update_expression_referencing_column() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn update_does_not_resurrect_inlined_deletes() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3], vec![10, 20, 30]).await;
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp_dir.path().join("test.db"),
+        &[1],
+    )
+    .await;
+    assert_eq!(read_pairs(&temp_dir).await, vec![(1, 10), (3, 30)]);
+
+    let ctx = writable_ctx(&temp_dir).await;
+    let count = run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = val + 1").await;
+    assert_eq!(count, 2);
+    assert_eq!(read_pairs(&temp_dir).await, vec![(1, 11), (3, 31)]);
+
+    let pool = SqlitePool::connect(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let delete_count: i64 = sqlx::query_scalar(
+        "SELECT delete_count FROM ducklake_delete_file WHERE end_snapshot IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        delete_count, 2,
+        "the inline position is not copied to Parquet"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_conflicts_with_a_concurrent_inlined_delete() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3], vec![10, 20, 30]).await;
+    let ctx = writable_ctx(&temp_dir).await;
+
+    let pool = SqlitePool::connect(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let base_snapshot: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version)
+         VALUES (?, CURRENT_TIMESTAMP, 1)",
+    )
+    .bind(base_snapshot + 1)
+    .execute(&pool)
+    .await
+    .unwrap();
+    crate::inlined_delete_fixture::insert_inlined_deletes_for_only_file(
+        &temp_dir.path().join("test.db"),
+        &[1],
+    )
+    .await;
+
+    let error = ctx
+        .sql("UPDATE ducklake.main.t SET val = val + 1")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect_err("the stale update must conflict");
+    assert!(error.to_string().contains("gained an inlined delete"));
+    assert_eq!(read_pairs(&temp_dir).await, vec![(1, 10), (3, 30)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_multi_row_multi_file_is_one_snapshot() {
     let temp_dir = TempDir::new().unwrap();
     // Two data files: A=(1,10),(2,20); B=(3,30),(4,40).


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary

Read positional deletes stored in `ducklake_inlined_delete_<table_id>` through every metadata
provider that reads inlined data. The table scan groups visible `(file_id, row_id)` entries by data
file and unions them with positions from any live Parquet delete file before the existing
`DeleteFilterExec` runs.

The same live‑row rule now applies to ordinary scans, row‑lineage scans, time‑travel reads of
partial files, `UPDATE`, `DELETE`, and compaction. Updates and rewrites therefore cannot restore a
row that the metadata catalog already deleted inline, `DELETE` treats inline‑deleted positions as
already deleted, and `merge_adjacent_files` never removes a file whose rows an inlined delete
still masks.

The review follow-up keeps the two delete stores separate: `DELETE` and `UPDATE` use inline
positions to mask scans and count newly affected rows but write only Parquet-owned positions to
replacement delete files. Source-scoped commit fences reject a distinct inline position added
after planning, metadata counts and truncate results subtract inline positions, and automatic
`rewrite_data_files` selection includes inline-only delete ratios.

### Inlined delete flow

```mermaid
flowchart LR
    Snapshot["Requested snapshot"] --> Inline["Visible inline positions<br/>begin_snapshot <= snapshot"]
    Catalog["ducklake_inlined_delete_N"] --> Inline
    Inline --> Group["Group by data_file_id"]
    Parquet["Live Parquet delete file"] --> Union["Union positional deletes"]
    Group --> Union
    Union --> Position["Synthesize physical row position"]
    Position --> Filter["DeleteFilterExec"]
    Filter --> Select["SELECT / COUNT / rowid"]
    Filter --> Update["UPDATE source scan"]
    Filter --> Compact["Merge / rewrite source scan"]
```

### Contract

- Return no inlined deletes when the per‑table physical table does not exist.
- Reject negative table IDs before they can become dynamic identifiers.
- Read only entries whose `begin_snapshot` is at or before the requested snapshot.
- Keep `(file_id, row_id)` ordered and preserve both values as signed 64‑bit catalog fields.
- Group and deduplicate inline positions by data file before planning scans.
- Reject negative file IDs and row positions as corrupt metadata.
- Union inline positions with a live Parquet positional delete file for the same data file.
- Apply the union before projections, filters, row‑lineage synthesis, updates, and rewrites.
- Subtract inline-deleted positions from SQL `DELETE`'s already-deleted set, so a predicate that
  matches only inline-deleted rows is a no-op that commits no snapshot and no delete file.
- Keep inline positions out of replacement Parquet delete files during `DELETE` and `UPDATE`;
  only `flush_inlined_data` materializes and retires inline metadata.
- Subtract distinct visible inline positions from metadata row counts and unqualified `DELETE`
  results.
- Include inline positions in automatic `rewrite_data_files` delete-ratio selection, including
  files without a live Parquet delete file.
- Exclude files masked by inlined deletes from `merge_adjacent_files` candidates, so
  `SourceRetirement::Remove` keeps its every‑snapshot contract: time travel to snapshots before
  the inline delete keeps its rows, and no `ducklake_inlined_delete_<id>` row ever references a
  removed file.
- Fence delete-file and compaction commits on each source file. A new distinct inline position
  after the planning snapshot aborts with `Conflict` instead of resurrecting or duplicating the
  deleted row; duplicate metadata for an already-visible position does not false-conflict.
- Preserve the existing `end_snapshot` visibility rule for deletes targeting inlined insert rows.
- Leave the change feed's inlined‑delete gap explicit: `ducklake_table_changes` reads delete
  files only, and `COMPATIBILITY.md` documents that a window whose only change is an inlined
  delete emits no `delete` rows.
- Leave providers that do not implement data inlining source-compatible through the empty trait
  default.
- Export the validated inlined-delete table-name helper without adding a required field to public
  `CompactionSourceFile` struct literals.

### DuckLake semantics

`ducklake_inlined_delete_<table_id>` contains `file_id`, zero‑based physical `row_id`, and the
`begin_snapshot` that makes the deletion visible. It has no `end_snapshot`: once visible, that
position stays deleted for the lifetime of the referenced data file. A delete against a row stored
in `ducklake_inlined_data_*` instead sets that row's `end_snapshot`, so no positional entry exists.

The crate is pinned to DuckDB 1.4.1. Its core extension emits a regular Parquet delete for the
Parquet‑resident test case, while an isolated DuckDB v1.5.5 run with core extension `d8a1881e`
creates `ducklake_inlined_delete_1` with rows `(0, 3, 3)` and `(0, 7, 3)` and no delete file. The
integration test keeps the official DuckDB result as its row oracle. When running under the pinned
1.4.1 library, it converts only the official delete metadata to the stable specification's exact
inline table shape before checking the DataFusion read path.

### Commit and branch

- Branch: `ducklake-inlined-deletes-pr`.
- Base: `746b084394e91358b5ebbd8916ee05295a5b92f4` (`origin/main`), which includes
  merged [PR #259](https://github.com/datafusion-contrib/datafusion-ducklake/pull/259) and the
  concise CHANGELOG convention from PR #283.
- Commit: `7a50ba1821051007165c228679a98de4ca69c67e feat: apply DuckLake inlined deletes`.
- Shape: first commit in the remaining shared PR stack after the merged defaults commit was dropped.
- Remote: `ata/ducklake-inlined-deletes-pr`.
- Pull request: [#262](https://github.com/datafusion-contrib/datafusion-ducklake/pull/262).

### Verification

- 2026-08-31 review-follow-up gate on rebased head `7a50ba1821051007165c228679a98de4ca69c67e`:
  `cargo fmt --all -- --check`, all-target/all-feature
  compilation, and strict all-target/all-feature Clippy passed. `cargo test --all-features`
  passed 396 unit tests, 398 integration tests with 200 expected service-gated ignores, and 8
  doctests. Focused SQL delete (13), SQL update (19), SQLite compaction (25), and DuckDB/SQLite
  inlined-delete oracle groups passed.

- 2026-08-29 cumulative rebase gate at `976ded1873c7d6877c7138ff63aa8c3143035aa2`:
  formatting, all-target/all-feature workspace check, strict Clippy, 391 library tests,
  405 integration tests with 3 expected ignores, and 8 doctests passed.
- 2026-08-25 rebase gate: formatting, strict all-target/all-feature Clippy, and
  `cargo test --all-features` passed on this exact head.

- Branch focused groups (all through `cargo test --all-features` filters): the `inlined_delete`
  unit and integration tests, including the DuckDB row oracle and the snapshot‑aware SQLite
  lookup; the live PostgreSQL and MySQL `--ignored` lookup tests in containers;
  `delete_of_inline_deleted_rows_is_noop`; `update_does_not_resurrect_inlined_deletes`;
  `rewrite_does_not_resurrect_inlined_deletes`; `merge_skips_files_masked_by_inlined_deletes`;
  and `compaction_conflicts_with_a_concurrent_inlined_delete`.
- Existing split‑file row lineage, `COUNT(*)`, SQL update lineage, delete rewrite, and partial‑file
  time‑travel regressions: passed through their focused test filters.
- At the rebuilt integration head (`ducklake-inlined-coverage-integration`):
  `cargo test --all-features` passed with 397 unit tests, 401 integration tests (206 ignored by
  the Docker gate), and 8 doc tests; `cargo fmt --all -- --check` clean; strict
  `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `git diff --check`: passed.

### Specification proof

| DuckLake rule                                                                                                                                                                                                         | Implementation invariant                                                                                                                                                                                                                                     | Discriminating proof                                                                                                                                                                                                                                                                                                                        |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [Deletion inlining](https://ducklake.select/docs/stable/duckdb/advanced_features/data_inlining) stores a small delete from a Parquet data file in `ducklake_inlined_delete_<table_id>` rather than a new delete file. | DuckDB, SQLite, PostgreSQL, and MySQL providers read the physical table through safely quoted identifiers; a missing table returns an empty result.                                                                                                          | `inlined_delete_matches_duckdb_select_count_rowid_and_time_travel` compares exact survivor rows with DuckDB, while the isolated v1.5.5 oracle proves the official extension creates the inline rows and no delete file.                                                                                                                     |
| Each [inlined deletion](https://ducklake.select/docs/stable/duckdb/advanced_features/data_inlining) carries `file_id`, physical `row_id`, and `begin_snapshot`.                                                       | Providers filter `begin_snapshot <= requested_snapshot`; the table scan groups by file ID and feeds zero‑based positions to the same physical delete filter as Parquet deletes.                                                                              | The DuckDB test asserts exact positions `3` and `7`, exact `data_file_id`, current `SELECT`, `COUNT(*)`, and rowids, plus all 20 rows at the preceding snapshot. The SQLite test proves the snapshot boundary and negative‑ID rejection.                                                                                                    |
| Deletes of [inlined insert rows](https://ducklake.select/docs/stable/duckdb/advanced_features/data_inlining) set `end_snapshot` instead of creating an inlined deletion entry.                                        | Existing inlined‑data readers on all implemented backends retain the inclusive‑begin, exclusive‑end predicate; the new positional lookup applies only to Parquet file IDs.                                                                                   | The full `inlined_` filter keeps the schema‑version and time‑travel inlined‑row tests green while adding Parquet‑row deletion coverage.                                                                                                                                                                                                     |
| [Rewriting deleted files](https://ducklake.select/docs/stable/duckdb/maintenance/rewrite_data_files) must materialize only live rows.                                                                                 | Update, merge, and rewrite source scans union inline and Parquet positions before collecting rows, while replacement Parquet delete files retain only Parquet-owned and newly matched live positions. Automatic rewrite selection counts both delete stores. | `update_does_not_resurrect_inlined_deletes` proves the replacement file excludes the inline position; `rewrite_does_not_resurrect_inlined_deletes` is selected by inline delete ratio without explicit IDs and writes exactly two survivors; `delete_keeps_inline_and_parquet_positions_in_separate_stores` covers both stores on one file. |
| [Merged adjacent files](https://ducklake.select/docs/stable/duckdb/maintenance/merge_adjacent_files) replace their sources for every snapshot, so time travel must survive the merge.                                 | `merge_adjacent_files` excludes files masked by inlined deletes from its candidates, so `SourceRetirement::Remove` never discards rows a pre‑delete snapshot still needs and no stale `ducklake_inlined_delete_<id>` row outlives its file.                  | `merge_skips_files_masked_by_inlined_deletes` asserts the masked file survives the merge and time travel to the pre‑delete snapshot returns its full rows.                                                                                                                                                                                  |
| [Concurrent logical conflicts must abort](https://ducklake.select/docs/stable/duckdb/advanced_features/conflict_resolution).                                                                                          | SQLite and PostgreSQL order a source-scoped distinct-position fence with the delete-file or compaction commit. A new inline position after planning aborts with `Conflict`; a duplicate of an already-visible position does not change the logical set.      | `update_conflicts_with_a_concurrent_inlined_delete` and `compaction_conflicts_with_a_concurrent_inlined_delete` add an inline position after planning and assert rejection before publication.                                                                                                                                              |

### Reference implementation

The inlined‑delete path matches the official DuckLake extension:

- [`InlinedFileDeletionTableName`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L3101-L3103)
  uses the same deterministic `ducklake_inlined_delete_<table_id>` name.
- [`WriteNewInlinedFileDeletesSql`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L3105-L3135)
  defines and writes the same `file_id`, `row_id`, and `begin_snapshot` row shape.
- [`ReadInlinedFileDeletions`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L3165-L3188)
  applies `begin_snapshot <= snapshot`, groups by file, and deduplicates row positions.
- [`DuckLakeDeleteFilter::Initialize`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_delete_filter.cpp#L310-L351)
  merges inlined positions with an existing delete file before the scan emits rows.
- [`GetNetDataFileRowCountSql`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L612-L650)
  subtracts visible inlined deletions from the live Parquet row count.
- [`GetFilesForCompaction`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L2433-L2470)
  adds inline positions to the `REWRITE_DELETES` ratio.
- [`FlushInlinedFileDeletions`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/functions/ducklake_flush_inlined_data.cpp#L430-L590)
  owns the later conversion from inline metadata to a Parquet delete file.

This crate adds backend-specific missing-table classification and identifier validation around the
same metadata and filtering semantics.

### Upstream readiness

The review follow-up preserves existing `CompactionSourceFile` struct literals and writer trait
signatures. It adds only the validated public table-name helper; source-file fencing remains an
internal responsibility of the built-in SQLite and PostgreSQL writers.

The patch adds one defaulted `MetadataProvider` method and reuses the existing positional scan and
`DeleteFilterExec` machinery. It adds no Nautilus‑specific behavior, dependency, file format, or
catalog mutation. Backend differences remain limited to placeholder syntax and missing‑table error
classification. The dependent branch is one commit above the inlined‑data prerequisite and can be
rebased onto `main` after that prerequisite merges.
