### PR TITLE
Resolve DuckLake name mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set how many finished data files a rolling or partitioned write uploads at once, default 4.
   Written output is identical at any setting (#280).
 - Read-only DuckLake views across metadata backends, with writer-compatible view metadata (#264).
+- Per-file DuckLake `map_by_name` mappings across scans, predicate-based mutations,
+  compaction rewrites, and change feeds, including typed Hive partition constants (#263).
 - Literal column defaults for schema evolution and omitted `INSERT` fields, across metadata
   backends (#259).
 - Row lineage and positional deletes take the physical row position from the Parquet reader's
@@ -25,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / rewrite paths explicitly (#130).
 
 ### Changed
+
+- **BREAKING**: `DuckLakeFileData` and `DataFileChange` are now non-exhaustive and
+  implement `Default`; `DataFileChange` gains `mapping_id`. Downstream metadata
+  providers must preserve the per-file mapping identifier so change feeds adapt
+  physical columns correctly (#263).
 
 - **BREAKING**: `FileRowNumberExec` and `row_id::row_pos_field` are removed, and
   `DeleteFilterExec::try_new` / `RowIdExec::try_new` take a trailing `pos_index: usize` naming a
@@ -59,6 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The internal physical-position column could bind to a catalog column of the same name in the
   CDC feeds, making them report the wrong rows (#130).
 - `NULL` sentinels, BLOB decoding, expression-default reads, and legacy schema migration (#259).
+- Name-mapped Hive columns retain values through `DELETE`, `UPDATE`, and compaction;
+  mapped CDC reads no longer return NULL after column renames. Map keys and nested
+  nullability also match Arrow's read-compatible schema requirements (#263).
+- Name-mapped Hive paths follow DuckDB's raw segment parser, including backslash
+  separators and invalid multiple-`=` segments. Hexadecimal integers and exponent-form
+  decimals read with DuckDB-compatible values (#263).
+- Field-ID-less Parquet files and inlined rows apply `initial_default` values, and
+  read schemas retain the default metadata needed for missing-field adaptation (#263).
 - An upload whose final flush failed panicked with "Already shut down" instead of returning
   the error (#280).
 - `files_matching` no longer stops pruning a data file once that file carries a delete

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -277,6 +277,19 @@ Known edges:
   in DuckDB. This is inherited from arrow and affects results, not just pruning; float
   min/max statistics are gated on `contains_nan` in **both** directions to stay consistent
   with it, where official DuckLake gates only the max.
+- **Mapped Hive partition paths follow DuckDB 1.5.5 parsing.** The raw object key is
+  split on `/` and `\`; a query marker, newline, or second `=` invalidates that path
+  segment. Keys are compared without percent decoding, while values are decoded.
+- **Reachable mapped numeric literals match DuckDB.** Hexadecimal integers and
+  exponent-form decimals are normalized before Arrow parsing. DuckDB rejects boolean
+  words such as `on` and compact dates such as `20240102` while registering a file, so
+  this crate's acceptance of those forms cannot affect an official-produced catalog.
+  Timestamp-offset comparison remains blocked by the percent-encoded object-key issue
+  tracked in #288.
+- **Nested mapped Hive partition fields are rejected.** Top-level `is_partition`
+  fields are materialized on every read path. DuckDB's writer does not produce nested
+  partition mappings, but a hand-written or third-party catalog can; this crate returns
+  an explicit error instead of reading a physical value or NULL under that shape.
 - **No `AS OF` syntax:** select a catalog snapshot by ID with
   `DuckLakeCatalog::with_snapshot`, by UTC timestamp with
   `DuckLakeCatalog::with_snapshot_at`, or select one table per query with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,7 @@ dependencies = [
  "parquet",
  "percent-encoding",
  "regex",
+ "rstest",
  "sqllogictest",
  "sqlx",
  "tempfile",
@@ -2819,6 +2820,12 @@ name = "futures-task"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -4541,6 +4548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4661,6 +4674,35 @@ dependencies = [
  "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ testcontainers-modules = { version = "0.11", features = ["minio", "postgres", "m
 tempfile = "3.14"
 anyhow = "1.0"
 regex = "1"
+rstest = "0.26"
 aws-sdk-s3 = "1.75"
 aws-credential-types = "1.2"
 sqllogictest = "0.23"

--- a/src/column_rename.rs
+++ b/src/column_rename.rs
@@ -12,6 +12,7 @@ use std::task::{Context, Poll};
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion::common::ScalarValue;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::common::tree_node::{Transformed, TreeNode};
@@ -40,6 +41,8 @@ pub struct ColumnRenameExec {
     name_mapping: HashMap<String, String>,
     /// Reverse mapping: new name -> old name, for looking up input columns
     reverse_mapping: Arc<HashMap<String, String>>,
+    /// Per-file values synthesized from Hive path segments.
+    constants: Arc<HashMap<String, ScalarValue>>,
     /// Cached plan properties with updated schema
     properties: Arc<PlanProperties>,
 }
@@ -49,6 +52,15 @@ impl ColumnRenameExec {
         input: Arc<dyn ExecutionPlan>,
         output_schema: SchemaRef,
         name_mapping: HashMap<String, String>,
+    ) -> Self {
+        Self::new_with_constants(input, output_schema, name_mapping, HashMap::new())
+    }
+
+    pub fn new_with_constants(
+        input: Arc<dyn ExecutionPlan>,
+        output_schema: SchemaRef,
+        name_mapping: HashMap<String, String>,
+        constants: HashMap<String, ScalarValue>,
     ) -> Self {
         // PlanProperties must use output schema for DataFusion schema validation
         let eq_props = EquivalenceProperties::new(Arc::clone(&output_schema));
@@ -70,6 +82,7 @@ impl ColumnRenameExec {
             output_schema,
             name_mapping,
             reverse_mapping: Arc::new(reverse_mapping),
+            constants: Arc::new(constants),
             properties,
         }
     }
@@ -85,7 +98,8 @@ impl ColumnRenameExec {
     /// pushdown.
     pub fn is_pure_type_preserving_rename(&self) -> bool {
         let input_schema = self.input.schema();
-        input_schema.fields().len() == self.output_schema.fields().len()
+        self.constants.is_empty()
+            && input_schema.fields().len() == self.output_schema.fields().len()
             && input_schema
                 .fields()
                 .iter()
@@ -178,7 +192,11 @@ impl ColumnRenameExec {
 
 impl DisplayAs for ColumnRenameExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "ColumnRenameExec: renames={}", self.name_mapping.len())
+        write!(f, "ColumnRenameExec: renames={}", self.name_mapping.len())?;
+        if !self.constants.is_empty() {
+            write!(f, ", constants={}", self.constants.len())?;
+        }
+        Ok(())
     }
 }
 
@@ -213,10 +231,11 @@ impl ExecutionPlan for ColumnRenameExec {
         }
 
         // Must call new() to rebuild properties from new child's partitioning
-        Ok(Arc::new(ColumnRenameExec::new(
+        Ok(Arc::new(ColumnRenameExec::new_with_constants(
             Arc::clone(&children[0]),
             Arc::clone(&self.output_schema),
             self.name_mapping.clone(),
+            self.constants.as_ref().clone(),
         )))
     }
 
@@ -257,6 +276,7 @@ impl ExecutionPlan for ColumnRenameExec {
             input: input_stream,
             output_schema: Arc::clone(&self.output_schema),
             reverse_mapping: Arc::clone(&self.reverse_mapping),
+            constants: Arc::clone(&self.constants),
         }))
     }
 }
@@ -267,6 +287,7 @@ struct ColumnRenameStream {
     output_schema: SchemaRef,
     /// Mapping from output column name -> input column name (for renamed columns only)
     reverse_mapping: Arc<HashMap<String, String>>,
+    constants: Arc<HashMap<String, ScalarValue>>,
 }
 
 impl Stream for ColumnRenameStream {
@@ -299,6 +320,9 @@ impl Stream for ColumnRenameStream {
                             .fields()
                             .iter()
                             .map(|output_field| {
+                                if let Some(value) = self.constants.get(output_field.name()) {
+                                    return value.to_array_of_size(batch.num_rows());
+                                }
                                 // Check if this column was renamed (new_name -> old_name)
                                 let input_name = self
                                     .reverse_mapping
@@ -541,6 +565,7 @@ mod tests {
             input: Box::pin(EmptyRecordBatchStream::new(input_schema)),
             output_schema: Arc::clone(&output_schema),
             reverse_mapping: Arc::new(reverse_mapping),
+            constants: Arc::new(HashMap::new()),
         };
 
         // The stream should report the output schema

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -61,7 +61,8 @@ pub const SQL_GET_DATA_FILES: &str = "
         del.file_size_bytes AS delete_file_size,
         del.footer_size AS delete_footer_size,
         del.encryption_key AS delete_encryption_key,
-        del.delete_count
+        del.delete_count,
+        data.mapping_id
     FROM ducklake_data_file AS data
     LEFT JOIN ducklake_delete_file AS del
         ON data.data_file_id = del.data_file_id
@@ -71,6 +72,18 @@ pub const SQL_GET_DATA_FILES: &str = "
     WHERE data.table_id = ?
       AND ? >= data.begin_snapshot
       AND (? < data.end_snapshot OR data.end_snapshot IS NULL)";
+
+/// Read one name mapping and its recursively-linked entries. The mapping id is
+/// globally unique within a DuckLake catalog.
+pub const SQL_GET_NAME_MAPPING: &str = "
+    SELECT mapping.mapping_id, mapping.table_id, mapping.type,
+           name.column_id, name.source_name, name.target_field_id,
+           name.parent_column, name.is_partition
+    FROM ducklake_column_mapping AS mapping
+    JOIN ducklake_name_mapping AS name
+      ON name.mapping_id = mapping.mapping_id
+    WHERE mapping.mapping_id = ?
+    ORDER BY name.parent_column NULLS FIRST, name.column_id";
 
 /// Read a table's active partition spec (partition_info joined to its key
 /// columns) visible at a snapshot. `?` placeholders (duckdb/sqlite/mysql style):
@@ -171,7 +184,8 @@ pub const SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS: &str = "
         data.footer_size,
         data.encryption_key,
         data.row_id_start,
-        data.partial_max
+        data.partial_max,
+        data.mapping_id
     FROM ducklake_data_file AS data
     WHERE data.table_id = $1
       AND data.begin_snapshot <= $3
@@ -684,10 +698,20 @@ pub(crate) fn build_inlined_batch(
     Ok(RecordBatch::try_new(schema, arrays)?)
 }
 
+#[cfg(test)]
 pub(crate) fn parse_inlined_rows(
     schema: SchemaRef,
     columns: &[DuckLakeTableColumn],
     rows: Vec<Vec<Option<String>>>,
+) -> Result<RecordBatch> {
+    parse_inlined_rows_with_present(schema, columns, rows, None)
+}
+
+pub(crate) fn parse_inlined_rows_with_present(
+    schema: SchemaRef,
+    columns: &[DuckLakeTableColumn],
+    rows: Vec<Vec<Option<String>>>,
+    present: Option<&HashSet<String>>,
 ) -> Result<RecordBatch> {
     let rows = rows
         .into_iter()
@@ -701,6 +725,11 @@ pub(crate) fn parse_inlined_rows(
                 .enumerate()
                 .map(|(index, value)| {
                     let field = schema.field(index);
+                    if present.is_some_and(|present| {
+                        !present.contains(columns[index].column_name.as_str())
+                    }) {
+                        return inlined_missing_scalar(&columns[index], field.data_type());
+                    }
                     match value {
                         Some(value) => crate::types::parse_ducklake_scalar(
                             &value,
@@ -722,6 +751,75 @@ pub(crate) fn parse_inlined_rows(
         })
         .collect::<Result<Vec<_>>>()?;
     build_inlined_batch(schema, columns, &rows)
+}
+
+pub(crate) fn inlined_missing_scalar(
+    column: &DuckLakeTableColumn,
+    data_type: &DataType,
+) -> Result<ScalarValue> {
+    let Some(value) = column
+        .initial_default
+        .as_deref()
+        .filter(|value| !value.eq_ignore_ascii_case("NULL"))
+    else {
+        return Ok(ScalarValue::try_from(data_type)?);
+    };
+    crate::types::parse_ducklake_scalar(value, data_type).ok_or_else(|| {
+        crate::DuckLakeError::InvalidConfig(format!(
+            "Cannot decode initial_default '{value}' for inlined column '{}' as {data_type}",
+            column.column_name,
+        ))
+    })
+}
+
+/// One row from `ducklake_column`, including its place in the nested field tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuckLakeTableField {
+    pub column_id: i64,
+    pub column_name: String,
+    pub column_type: String,
+    pub is_nullable: bool,
+    pub parent_column: Option<i64>,
+}
+
+impl DuckLakeTableField {
+    pub fn top_level(column: DuckLakeTableColumn) -> Self {
+        Self {
+            column_id: column.column_id,
+            column_name: column.column_name,
+            column_type: column.column_type,
+            is_nullable: column.is_nullable,
+            parent_column: None,
+        }
+    }
+
+    pub fn column(&self) -> DuckLakeTableColumn {
+        DuckLakeTableColumn::new(
+            self.column_id,
+            self.column_name.clone(),
+            self.column_type.clone(),
+            self.is_nullable,
+        )
+    }
+}
+
+/// A flattened row from `ducklake_name_mapping`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuckLakeNameMappingEntry {
+    pub column_id: i64,
+    pub source_name: String,
+    pub target_field_id: i64,
+    pub parent_column: Option<i64>,
+    pub is_partition: bool,
+}
+
+/// One `ducklake_column_mapping` and all of its name-mapping rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuckLakeNameMapping {
+    pub mapping_id: i64,
+    pub table_id: i64,
+    pub mapping_type: String,
+    pub entries: Vec<DuckLakeNameMappingEntry>,
 }
 
 impl DuckLakeTableColumn {
@@ -982,7 +1080,8 @@ pub fn reconstruct_columns_with_table(
 }
 
 /// Metadata for a data file or delete file in DuckLake
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct DuckLakeFileData {
     /// Path to the file (may be relative or absolute)
     pub path: String,
@@ -994,6 +1093,9 @@ pub struct DuckLakeFileData {
     pub file_size_bytes: i64,
     /// Size of the Parquet footer in bytes (optional optimization hint)
     pub footer_size: Option<i64>,
+    /// Name mapping used to adapt this data file's physical columns.
+    /// Delete files do not use column mappings.
+    pub mapping_id: Option<i64>,
 }
 
 impl DuckLakeFileData {
@@ -1004,6 +1106,7 @@ impl DuckLakeFileData {
             encryption_key: None,
             file_size_bytes,
             footer_size: None,
+            mapping_id: None,
         }
     }
 }
@@ -1168,7 +1271,8 @@ impl DuckLakeTableFile {
 
 // Change tracking structures for table_changes (CDC) functionality
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct DataFileChange {
     pub begin_snapshot: i64,
     pub path: String,
@@ -1176,6 +1280,8 @@ pub struct DataFileChange {
     pub file_size_bytes: i64,
     pub footer_size: Option<i64>,
     pub encryption_key: Option<String>,
+    /// Name mapping used to adapt the data file's physical columns.
+    pub mapping_id: Option<i64>,
     /// First rowid assigned to this file (`row_id_start` in the catalog), or
     /// `None` when the catalog does not carry one (e.g. an embedded-rowid
     /// compaction/rewrite output, or an older catalog). Required only to
@@ -1256,6 +1362,28 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         table_id: i64,
         snapshot_id: i64,
     ) -> Result<Vec<DuckLakeTableColumn>>;
+
+    /// Get the complete nested field tree visible at `snapshot_id`.
+    ///
+    /// External providers that only expose top-level fields retain their
+    /// existing behavior through this default. Built-in providers override it
+    /// with the raw `ducklake_column.parent_column` rows.
+    fn get_table_fields(&self, table_id: i64, snapshot_id: i64) -> Result<Vec<DuckLakeTableField>> {
+        self.get_table_structure(table_id, snapshot_id)
+            .map(|columns| {
+                columns
+                    .into_iter()
+                    .map(DuckLakeTableField::top_level)
+                    .collect()
+            })
+    }
+
+    /// Load a data file's `map_by_name` mapping.
+    fn get_name_mapping(&self, mapping_id: i64) -> Result<DuckLakeNameMapping> {
+        Err(crate::DuckLakeError::Unsupported(format!(
+            "metadata provider does not support DuckLake name mapping {mapping_id}"
+        )))
+    }
 
     /// Get table files for a specific snapshot
     fn get_table_files_for_select(

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -1,18 +1,20 @@
 use crate::DuckLakeError;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
-    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
+    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, INLINED_DATA_REMEDIATION, MetadataProvider, SQL_GET_DATA_FILES,
     SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_DATA_PATH,
     SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
-    SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT, SQL_GET_PARTITION_SPEC,
-    SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS,
-    SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES,
-    SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS,
-    SQL_TABLE_EXISTS, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
-    ViewMetadata, ViewWithSchema, build_inlined_batch, inlined_delete_table_name,
-    is_inlined_data_table, reconstruct_columns, reconstruct_columns_with_table,
+    SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT, SQL_GET_NAME_MAPPING,
+    SQL_GET_PARTITION_SPEC, SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME,
+    SQL_GET_TABLE_COLUMN_STATS, SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_FILES,
+    SQL_LIST_ALL_TABLES, SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES,
+    SQL_LIST_VIEWS, SQL_TABLE_EXISTS, SchemaMetadata, SnapshotMetadata, TableMetadata,
+    TableWithSchema, ViewMetadata, ViewWithSchema, build_inlined_batch, inlined_delete_table_name,
+    inlined_missing_scalar, is_inlined_data_table, reconstruct_columns,
+    reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -545,6 +547,62 @@ impl MetadataProvider for DuckdbMetadataProvider {
         reconstruct_columns(raw_columns)
     }
 
+    fn get_table_fields(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> crate::Result<Vec<DuckLakeTableField>> {
+        let conn = self.connection();
+        let sql = get_table_columns_sql(self.schema_capabilities(&conn)?);
+        let mut stmt = conn.prepare(&sql)?;
+        Ok(stmt
+            .query_map(params![table_id, snapshot_id, snapshot_id], |row| {
+                Ok(DuckLakeTableField {
+                    column_id: row.get(0)?,
+                    column_name: row.get(1)?,
+                    column_type: row.get(2)?,
+                    is_nullable: row.get::<_, Option<bool>>(3)?.unwrap_or(true),
+                    parent_column: row.get(4)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+
+    fn get_name_mapping(&self, mapping_id: i64) -> crate::Result<DuckLakeNameMapping> {
+        let conn = self.connection();
+        let mut stmt = conn.prepare(SQL_GET_NAME_MAPPING)?;
+        let mut rows = stmt.query(params![mapping_id])?;
+        let mut header = None;
+        let mut entries = Vec::new();
+        while let Some(row) = rows.next()? {
+            header.get_or_insert((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ));
+            if let Some(column_id) = row.get::<_, Option<i64>>(3)? {
+                entries.push(DuckLakeNameMappingEntry {
+                    column_id,
+                    source_name: row.get(4)?,
+                    target_field_id: row.get(5)?,
+                    parent_column: row.get(6)?,
+                    is_partition: row.get::<_, Option<bool>>(7)?.unwrap_or(false),
+                });
+            }
+        }
+        let (mapping_id, table_id, mapping_type) = header.ok_or_else(|| {
+            crate::DuckLakeError::InvalidConfig(format!(
+                "DuckLake name mapping {mapping_id} does not exist"
+            ))
+        })?;
+        Ok(DuckLakeNameMapping {
+            mapping_id,
+            table_id,
+            mapping_type,
+            entries,
+        })
+    }
+
     fn get_table_files_for_select(
         &self,
         table_id: i64,
@@ -565,6 +623,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         file_size_bytes: row.get(3)?,
                         footer_size: row.get(4)?,
                         encryption_key: row.get(5)?,
+                        mapping_id: row.get(15)?,
                     };
                     let row_id_start: Option<i64> = row.get(6)?;
                     let record_count: Option<i64> = row.get(7)?;
@@ -579,6 +638,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                                     file_size_bytes: row.get(11)?,
                                     footer_size: row.get(12)?,
                                     encryption_key: row.get(13)?,
+                                    mapping_id: None,
                                 }),
                                 row.get(14)?,
                                 Some(dfid),
@@ -802,6 +862,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                                 file_size_bytes: row.get(11)?,
                                 footer_size: row.get(12)?,
                                 encryption_key: row.get(13)?,
+                                mapping_id: None,
                             }),
                             row.get(14)?,
                         )
@@ -816,6 +877,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                             file_size_bytes: row.get(3)?,
                             footer_size: row.get(4)?,
                             encryption_key: row.get(5)?,
+                            mapping_id: row.get(15)?,
                         },
                         delete_file_id,
                         delete_file,
@@ -1059,6 +1121,9 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     .iter()
                     .enumerate()
                     .map(|(index, field)| {
+                        if !present.contains(&columns[index].column_name) {
+                            return inlined_missing_scalar(&columns[index], field.data_type());
+                        }
                         duckdb_inlined_scalar(
                             row.get_ref(index)?,
                             field.data_type(),
@@ -1311,6 +1376,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         file_size_bytes: row.get(5)?,
                         footer_size: row.get(6)?,
                         encryption_key: row.get(7)?,
+                        mapping_id: None,
                     };
 
                     // Column 8 is delete_file_id (NULL when no live delete file).
@@ -1323,6 +1389,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                                     file_size_bytes: row.get(11)?,
                                     footer_size: row.get(12)?,
                                     encryption_key: row.get(13)?,
+                                    mapping_id: None,
                                 }),
                                 Some(dfid),
                             )
@@ -1384,6 +1451,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         encryption_key: row.get(5)?,
                         row_id_start: row.get(6)?,
                         partial_max: row.get(7)?,
+                        mapping_id: row.get(8)?,
                     })
                 })?
                 .collect::<Result<Vec<_>, _>>()?;
@@ -1401,7 +1469,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
                 data.footer_size,
                 data.encryption_key,
                 data.row_id_start,
-                data.partial_file_info
+                data.partial_file_info,
+                data.mapping_id
             FROM ducklake_data_file AS data
             WHERE data.table_id = $1
               AND data.begin_snapshot <= $3
@@ -1420,6 +1489,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     encryption_key: row.get(5)?,
                     row_id_start: row.get(6)?,
                     partial_max: info.as_deref().and_then(parse_partial_file_info_max),
+                    mapping_id: row.get(8)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -3,13 +3,14 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
-    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
+    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, InlinedDataBackend, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES,
-    SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata,
-    TableWithSchema, ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name,
-    inlined_text_projection, is_inlined_data_table, parse_inlined_rows, reconstruct_columns,
-    reconstruct_columns_with_table,
+    SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SQL_GET_TABLE_COLUMNS, SchemaMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
+    inlined_delete_table_name, inlined_text_projection, is_inlined_data_table,
+    parse_inlined_rows_with_present, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -55,6 +56,7 @@ fn decode_table_file(row: &MySqlRow, snapshot_id: i64) -> Result<DuckLakeTableFi
                 file_size_bytes: row.try_get(11)?,
                 footer_size: row.try_get(12)?,
                 encryption_key: row.try_get(13)?,
+                mapping_id: None,
             }),
             row.try_get(14)?,
         )
@@ -69,6 +71,7 @@ fn decode_table_file(row: &MySqlRow, snapshot_id: i64) -> Result<DuckLakeTableFi
             file_size_bytes: row.try_get(3)?,
             footer_size: row.try_get(4)?,
             encryption_key: row.try_get(5)?,
+            mapping_id: row.try_get(15).unwrap_or(None),
         },
         delete_file_id,
         delete_file,
@@ -329,20 +332,12 @@ impl MetadataProvider for MySqlMetadataProvider {
         snapshot_id: i64,
     ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
-            let rows = sqlx::query(
-                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
-                        initial_default, default_value, default_value_type, default_value_dialect
-                 FROM ducklake_column
-                 WHERE table_id = ?
-                   AND ? >= begin_snapshot
-                   AND (? < end_snapshot OR end_snapshot IS NULL)
-                 ORDER BY column_order",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .bind(snapshot_id)
-            .fetch_all(&self.pool)
-            .await?;
+            let rows = sqlx::query(SQL_GET_TABLE_COLUMNS)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .fetch_all(&self.pool)
+                .await?;
 
             let raw: Result<Vec<(DuckLakeTableColumn, Option<i64>)>> = rows
                 .into_iter()
@@ -370,6 +365,76 @@ impl MetadataProvider for MySqlMetadataProvider {
         })
     }
 
+    fn get_table_fields(&self, table_id: i64, snapshot_id: i64) -> Result<Vec<DuckLakeTableField>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                 FROM ducklake_column
+                 WHERE table_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(DuckLakeTableField {
+                        column_id: row.try_get(0)?,
+                        column_name: row.try_get(1)?,
+                        column_type: row.try_get(2)?,
+                        is_nullable: row.try_get::<Option<bool>, _>(3)?.unwrap_or(true),
+                        parent_column: row.try_get(4)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_name_mapping(&self, mapping_id: i64) -> Result<DuckLakeNameMapping> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT mapping.mapping_id, mapping.table_id, mapping.type,
+                        name.column_id, name.source_name, name.target_field_id,
+                        name.parent_column, name.is_partition
+                 FROM ducklake_column_mapping AS mapping
+                 JOIN ducklake_name_mapping AS name
+                   ON name.mapping_id = mapping.mapping_id
+                 WHERE mapping.mapping_id = ?
+                 ORDER BY name.parent_column IS NOT NULL, name.parent_column, name.column_id",
+            )
+            .bind(mapping_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let first = rows.first().ok_or_else(|| {
+                crate::DuckLakeError::InvalidConfig(format!(
+                    "DuckLake name mapping {mapping_id} does not exist"
+                ))
+            })?;
+            let mut entries = Vec::new();
+            for row in &rows {
+                if let Some(column_id) = row.try_get::<Option<i64>, _>(3)? {
+                    entries.push(DuckLakeNameMappingEntry {
+                        column_id,
+                        source_name: row.try_get(4)?,
+                        target_field_id: row.try_get(5)?,
+                        parent_column: row.try_get(6)?,
+                        is_partition: row.try_get::<Option<bool>, _>(7)?.unwrap_or(false),
+                    });
+                }
+            }
+            Ok(DuckLakeNameMapping {
+                mapping_id: first.try_get(0)?,
+                table_id: first.try_get(1)?,
+                mapping_type: first.try_get(2)?,
+                entries,
+            })
+        })
+    }
+
     fn get_table_files_for_select(
         &self,
         table_id: i64,
@@ -392,7 +457,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                     del.file_size_bytes AS delete_file_size,
                     del.footer_size AS delete_footer_size,
                     del.encryption_key AS delete_encryption_key,
-                    del.delete_count
+                    del.delete_count,
+                    data.mapping_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -511,7 +577,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                         data.row_id_start, data.record_count,
                         del.delete_file_id, del.path, del.path_is_relative,
                         del.file_size_bytes, del.footer_size, del.encryption_key,
-                        del.delete_count
+                        del.delete_count,
+                        data.mapping_id
                  FROM ducklake_data_file AS data
                  LEFT JOIN ducklake_delete_file AS del
                    ON data.data_file_id = del.data_file_id
@@ -919,7 +986,12 @@ impl MetadataProvider for MySqlMetadataProvider {
                             .collect::<std::result::Result<Vec<_>, _>>()
                     })
                     .collect::<std::result::Result<Vec<_>, _>>()?;
-                batches.push(parse_inlined_rows(schema.clone(), columns, rows)?);
+                batches.push(parse_inlined_rows_with_present(
+                    schema.clone(),
+                    columns,
+                    rows,
+                    Some(&present),
+                )?);
             }
             Ok(batches)
         })
@@ -1258,6 +1330,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         file_size_bytes: row.try_get(5)?,
                         footer_size: row.try_get(6)?,
                         encryption_key: row.try_get(7)?,
+                        mapping_id: None,
                     };
 
                     let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
@@ -1267,6 +1340,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             file_size_bytes: row.try_get(11)?,
                             footer_size: row.try_get(12)?,
                             encryption_key: row.try_get(13)?,
+                            mapping_id: None,
                         })
                     } else {
                         None
@@ -1319,7 +1393,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                     data.footer_size,
                     data.encryption_key,
                     data.row_id_start,
-                    {pm}
+                    {pm},
+                    data.mapping_id
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?
                   AND data.begin_snapshot <= ?
@@ -1345,6 +1420,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
                         partial_max: row.try_get(7)?,
+                        mapping_id: row.try_get(8)?,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -3,12 +3,13 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
-    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
+    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, InlinedDataBackend, MetadataProvider, SchemaMetadata, SnapshotMetadata,
     TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
-    inlined_delete_table_name, inlined_text_projection, is_inlined_data_table, parse_inlined_rows,
-    reconstruct_columns, reconstruct_columns_with_table,
+    inlined_delete_table_name, inlined_text_projection, is_inlined_data_table,
+    parse_inlined_rows_with_present, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -52,6 +53,7 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
                 file_size_bytes: row.try_get(11)?,
                 footer_size: row.try_get(12)?,
                 encryption_key: row.try_get(13)?,
+                mapping_id: None,
             }),
             row.try_get(14)?,
         )
@@ -66,6 +68,7 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
             file_size_bytes: row.try_get(3)?,
             footer_size: row.try_get(4)?,
             encryption_key: row.try_get(5)?,
+            mapping_id: row.try_get(19).unwrap_or(None),
         },
         delete_file_id,
         delete_file,
@@ -82,6 +85,35 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
         // pre-partition behaviour. Per-key values are filled in by the caller.
         partition_id: row.try_get(18).unwrap_or(None),
         partition_values: Vec::new(),
+    })
+}
+
+fn decode_name_mapping_rows(
+    requested_mapping_id: i64,
+    rows: &[PgRow],
+) -> Result<DuckLakeNameMapping> {
+    let first = rows.first().ok_or_else(|| {
+        crate::DuckLakeError::InvalidConfig(format!(
+            "DuckLake name mapping {requested_mapping_id} does not exist"
+        ))
+    })?;
+    let mut entries = Vec::new();
+    for row in rows {
+        if let Some(column_id) = row.try_get::<Option<i64>, _>(3)? {
+            entries.push(DuckLakeNameMappingEntry {
+                column_id,
+                source_name: row.try_get(4)?,
+                target_field_id: row.try_get(5)?,
+                parent_column: row.try_get(6)?,
+                is_partition: row.try_get::<Option<bool>, _>(7)?.unwrap_or(false),
+            });
+        }
+    }
+    Ok(DuckLakeNameMapping {
+        mapping_id: first.try_get(0)?,
+        table_id: first.try_get(1)?,
+        mapping_type: first.try_get(2)?,
+        entries,
     })
 }
 
@@ -410,6 +442,54 @@ impl MetadataProvider for PostgresMetadataProvider {
         })
     }
 
+    fn get_table_fields(&self, table_id: i64, snapshot_id: i64) -> Result<Vec<DuckLakeTableField>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                 FROM ducklake_column
+                 WHERE table_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(DuckLakeTableField {
+                        column_id: row.try_get(0)?,
+                        column_name: row.try_get(1)?,
+                        column_type: row.try_get(2)?,
+                        is_nullable: row.try_get::<Option<bool>, _>(3)?.unwrap_or(true),
+                        parent_column: row.try_get(4)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_name_mapping(&self, mapping_id: i64) -> Result<DuckLakeNameMapping> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT mapping.mapping_id, mapping.table_id, mapping.type,
+                        name.column_id, name.source_name, name.target_field_id,
+                        name.parent_column, name.is_partition
+                 FROM ducklake_column_mapping AS mapping
+                 JOIN ducklake_name_mapping AS name
+                   ON name.mapping_id = mapping.mapping_id
+                 WHERE mapping.mapping_id = $1
+                 ORDER BY name.parent_column NULLS FIRST, name.column_id",
+            )
+            .bind(mapping_id)
+            .fetch_all(&self.pool)
+            .await?;
+            decode_name_mapping_rows(mapping_id, &rows)
+        })
+    }
+
     fn get_table_files_for_select(
         &self,
         table_id: i64,
@@ -465,7 +545,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     data.begin_snapshot::bigint AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
                     {schema_version_expr} AS data_schema_version,
-                    {partition_id_expr} AS data_partition_id
+                    {partition_id_expr} AS data_partition_id,
+                    data.mapping_id::bigint AS data_mapping_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -665,7 +746,9 @@ impl MetadataProvider for PostgresMetadataProvider {
                         del.delete_file_id, del.path, del.path_is_relative,
                         del.file_size_bytes, del.footer_size, del.encryption_key,
                         del.delete_count, data.begin_snapshot::bigint,
-                        {partial_max_expr}, {schema_version_expr}
+                        {partial_max_expr}, {schema_version_expr},
+                        NULL::bigint AS data_partition_id,
+                        data.mapping_id::bigint
                  FROM ducklake_data_file AS data
                  LEFT JOIN ducklake_delete_file AS del
                    ON data.data_file_id = del.data_file_id
@@ -1028,6 +1111,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                 if !is_inlined_data_table(&table) {
                     continue;
                 }
+
                 let present = sqlx::query(
                     "SELECT column_name FROM information_schema.columns
                      WHERE table_schema = current_schema() AND table_name = $1",
@@ -1078,7 +1162,12 @@ impl MetadataProvider for PostgresMetadataProvider {
                             .collect::<std::result::Result<Vec<_>, _>>()
                     })
                     .collect::<std::result::Result<Vec<_>, _>>()?;
-                batches.push(parse_inlined_rows(schema.clone(), columns, rows)?);
+                batches.push(parse_inlined_rows_with_present(
+                    schema.clone(),
+                    columns,
+                    rows,
+                    Some(&present),
+                )?);
             }
             Ok(batches)
         })
@@ -1413,6 +1502,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         file_size_bytes: row.try_get(5)?,
                         footer_size: row.try_get(6)?,
                         encryption_key: row.try_get(7)?,
+                        mapping_id: None,
                     };
 
                     let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
@@ -1422,6 +1512,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                             file_size_bytes: row.try_get(11)?,
                             footer_size: row.try_get(12)?,
                             encryption_key: row.try_get(13)?,
+                            mapping_id: None,
                         })
                     } else {
                         None
@@ -1475,7 +1566,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     data.footer_size,
                     data.encryption_key,
                     data.row_id_start,
-                    {pm}
+                    {pm},
+                    data.mapping_id
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
                   AND data.begin_snapshot <= $3
@@ -1500,6 +1592,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
                         partial_max: row.try_get(7)?,
+                        mapping_id: row.try_get(8)?,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -3,11 +3,13 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeStatistics,
-    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics,
-    FileWithTable, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC,
-    SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
-    ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name, reconstruct_columns,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
+    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
+    FileWithTable, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_NAME_MAPPING,
+    SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SQL_GET_TABLE_COLUMNS, SchemaMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
+    inlined_delete_table_name, inlined_missing_scalar, reconstruct_columns,
     reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
@@ -15,7 +17,6 @@ use crate::sort::SortSpec;
 use arrow::array::{
     ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array,
     Int32Array, Int64Array, RecordBatch, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
-    new_null_array,
 };
 use arrow::datatypes::{DataType, SchemaRef};
 use sqlx::AssertSqlSafe;
@@ -50,6 +51,7 @@ fn decode_table_file(row: &SqliteRow, snapshot_id: i64) -> Result<DuckLakeTableF
         file_size_bytes: row.try_get(3)?,
         footer_size: row.try_get(4)?,
         encryption_key: row.try_get(5)?,
+        mapping_id: row.try_get(19).unwrap_or(None),
     };
     let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some() {
         (
@@ -59,6 +61,7 @@ fn decode_table_file(row: &SqliteRow, snapshot_id: i64) -> Result<DuckLakeTableF
                 file_size_bytes: row.try_get(11)?,
                 footer_size: row.try_get(12)?,
                 encryption_key: row.try_get(13)?,
+                mapping_id: None,
             }),
             row.try_get(14)?,
         )
@@ -104,7 +107,7 @@ fn build_inlined_batch(
         let dt = schema.field(i).data_type();
         let name = col.column_name.as_str();
         if !present.contains(name) {
-            arrays.push(new_null_array(dt, n));
+            arrays.push(inlined_missing_scalar(col, dt)?.to_array_of_size(n)?);
             continue;
         }
         // SQLite stores INTEGER as i64 and REAL as f64; read at that width and
@@ -435,20 +438,12 @@ impl MetadataProvider for SqliteMetadataProvider {
         snapshot_id: i64,
     ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
-            let rows = sqlx::query(
-                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column,
-                        initial_default, default_value, default_value_type, default_value_dialect
-                 FROM ducklake_column
-                 WHERE table_id = ?
-                   AND ? >= begin_snapshot
-                   AND (? < end_snapshot OR end_snapshot IS NULL)
-                 ORDER BY column_order",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .bind(snapshot_id)
-            .fetch_all(&self.pool)
-            .await?;
+            let rows = sqlx::query(SQL_GET_TABLE_COLUMNS)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .fetch_all(&self.pool)
+                .await?;
 
             let raw: Result<Vec<(DuckLakeTableColumn, Option<i64>)>> = rows
                 .into_iter()
@@ -473,6 +468,67 @@ impl MetadataProvider for SqliteMetadataProvider {
                 })
                 .collect();
             reconstruct_columns(raw?)
+        })
+    }
+
+    fn get_table_fields(&self, table_id: i64, snapshot_id: i64) -> Result<Vec<DuckLakeTableField>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                 FROM ducklake_column
+                 WHERE table_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(DuckLakeTableField {
+                        column_id: row.try_get(0)?,
+                        column_name: row.try_get(1)?,
+                        column_type: row.try_get(2)?,
+                        is_nullable: row.try_get::<Option<bool>, _>(3)?.unwrap_or(true),
+                        parent_column: row.try_get(4)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_name_mapping(&self, mapping_id: i64) -> Result<DuckLakeNameMapping> {
+        block_on(async {
+            let rows = sqlx::query(SQL_GET_NAME_MAPPING)
+                .bind(mapping_id)
+                .fetch_all(&self.pool)
+                .await?;
+            let first = rows.first().ok_or_else(|| {
+                crate::DuckLakeError::InvalidConfig(format!(
+                    "DuckLake name mapping {mapping_id} does not exist"
+                ))
+            })?;
+            let mut entries = Vec::new();
+            for row in &rows {
+                if let Some(column_id) = row.try_get::<Option<i64>, _>(3)? {
+                    entries.push(DuckLakeNameMappingEntry {
+                        column_id,
+                        source_name: row.try_get(4)?,
+                        target_field_id: row.try_get(5)?,
+                        parent_column: row.try_get(6)?,
+                        is_partition: row.try_get::<Option<bool>, _>(7)?.unwrap_or(false),
+                    });
+                }
+            }
+            Ok(DuckLakeNameMapping {
+                mapping_id: first.try_get(0)?,
+                table_id: first.try_get(1)?,
+                mapping_type: first.try_get(2)?,
+                entries,
+            })
         })
     }
 
@@ -530,7 +586,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     data.begin_snapshot AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
                     {schema_version_expr} AS data_schema_version,
-                    {partition_id_expr} AS data_partition_id
+                    {partition_id_expr} AS data_partition_id,
+                    data.mapping_id AS data_mapping_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -714,7 +771,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     del.delete_file_id, del.path, del.path_is_relative,
                     del.file_size_bytes, del.footer_size, del.encryption_key,
                     del.delete_count, data.begin_snapshot,
-                    {partial_max_expr}, {schema_version_expr}, {partition_id_expr}
+                    {partial_max_expr}, {schema_version_expr}, {partition_id_expr},
+                    data.mapping_id
                  FROM ducklake_data_file AS data
                  LEFT JOIN ducklake_delete_file AS del
                    ON data.data_file_id = del.data_file_id
@@ -1469,6 +1527,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         file_size_bytes: row.try_get(5)?,
                         footer_size: row.try_get(6)?,
                         encryption_key: row.try_get(7)?,
+                        mapping_id: None,
                     };
 
                     let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
@@ -1478,6 +1537,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             file_size_bytes: row.try_get(11)?,
                             footer_size: row.try_get(12)?,
                             encryption_key: row.try_get(13)?,
+                            mapping_id: None,
                         })
                     } else {
                         None
@@ -1531,7 +1591,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     data.footer_size,
                     data.encryption_key,
                     data.row_id_start,
-                    {pm}
+                    {pm},
+                    data.mapping_id
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?1
                   AND data.begin_snapshot <= ?3
@@ -1556,6 +1617,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
                         partial_max: row.try_get(7)?,
+                        mapping_id: row.try_get(8)?,
                     })
                 })
                 .collect()

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -14,10 +14,11 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
-    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
-    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
-    ViewMetadata, ViewWithSchema, block_on, reconstruct_columns, reconstruct_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeNameMapping, DuckLakeNameMappingEntry,
+    DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableField,
+    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, SchemaMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
+    reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -55,6 +56,7 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
                 file_size_bytes: row.try_get(11)?,
                 footer_size: row.try_get(12)?,
                 encryption_key: row.try_get(13)?,
+                mapping_id: None,
             }),
             row.try_get(14)?,
         )
@@ -69,6 +71,7 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
             file_size_bytes: row.try_get(3)?,
             footer_size: row.try_get(4)?,
             encryption_key: row.try_get(5)?,
+            mapping_id: row.try_get(19).unwrap_or(None),
         },
         delete_file_id,
         delete_file,
@@ -424,6 +427,76 @@ impl MetadataProvider for MulticatalogProvider {
         })
     }
 
+    fn get_table_fields(&self, table_id: i64, snapshot_id: i64) -> Result<Vec<DuckLakeTableField>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                 FROM ducklake_column
+                 WHERE table_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(DuckLakeTableField {
+                        column_id: row.try_get(0)?,
+                        column_name: row.try_get(1)?,
+                        column_type: row.try_get(2)?,
+                        is_nullable: row.try_get::<Option<bool>, _>(3)?.unwrap_or(true),
+                        parent_column: row.try_get(4)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_name_mapping(&self, mapping_id: i64) -> Result<DuckLakeNameMapping> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT mapping.mapping_id, mapping.table_id, mapping.type,
+                        name.column_id, name.source_name, name.target_field_id,
+                        name.parent_column, name.is_partition
+                 FROM ducklake_column_mapping AS mapping
+                 JOIN ducklake_name_mapping AS name
+                   ON name.mapping_id = mapping.mapping_id
+                 WHERE mapping.mapping_id = $1
+                 ORDER BY name.parent_column NULLS FIRST, name.column_id",
+            )
+            .bind(mapping_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let first = rows.first().ok_or_else(|| {
+                crate::DuckLakeError::InvalidConfig(format!(
+                    "DuckLake name mapping {mapping_id} does not exist"
+                ))
+            })?;
+            let mut entries = Vec::new();
+            for row in &rows {
+                if let Some(column_id) = row.try_get::<Option<i64>, _>(3)? {
+                    entries.push(DuckLakeNameMappingEntry {
+                        column_id,
+                        source_name: row.try_get(4)?,
+                        target_field_id: row.try_get(5)?,
+                        parent_column: row.try_get(6)?,
+                        is_partition: row.try_get::<Option<bool>, _>(7)?.unwrap_or(false),
+                    });
+                }
+            }
+            Ok(DuckLakeNameMapping {
+                mapping_id: first.try_get(0)?,
+                table_id: first.try_get(1)?,
+                mapping_type: first.try_get(2)?,
+                entries,
+            })
+        })
+    }
+
     fn get_table_files_for_select(
         &self,
         table_id: i64,
@@ -480,7 +553,8 @@ impl MetadataProvider for MulticatalogProvider {
                     data.begin_snapshot::bigint AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
                     {schema_version_expr} AS data_schema_version,
-                    {partition_id_expr} AS data_partition_id
+                    {partition_id_expr} AS data_partition_id,
+                    data.mapping_id::bigint AS data_mapping_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -679,7 +753,9 @@ impl MetadataProvider for MulticatalogProvider {
                         del.delete_file_id, del.path, del.path_is_relative,
                         del.file_size_bytes, del.footer_size, del.encryption_key,
                         del.delete_count, data.begin_snapshot::bigint,
-                        {partial_max_expr}, {schema_version_expr}
+                        {partial_max_expr}, {schema_version_expr},
+                        NULL::bigint AS data_partition_id,
+                        data.mapping_id::bigint
                  FROM ducklake_data_file AS data
                  LEFT JOIN ducklake_delete_file AS del
                    ON data.data_file_id = del.data_file_id
@@ -1338,6 +1414,7 @@ impl MetadataProvider for MulticatalogProvider {
                         file_size_bytes: row.try_get(5)?,
                         footer_size: row.try_get(6)?,
                         encryption_key: row.try_get(7)?,
+                        mapping_id: None,
                     };
                     let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
                         Some(DuckLakeFileData {
@@ -1346,6 +1423,7 @@ impl MetadataProvider for MulticatalogProvider {
                             file_size_bytes: row.try_get(11)?,
                             footer_size: row.try_get(12)?,
                             encryption_key: row.try_get(13)?,
+                            mapping_id: None,
                         })
                     } else {
                         None
@@ -1399,7 +1477,8 @@ impl MetadataProvider for MulticatalogProvider {
                     data.footer_size,
                     data.encryption_key,
                     data.row_id_start,
-                    {pm}
+                    {pm},
+                    data.mapping_id
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
                   AND data.begin_snapshot <= $3
@@ -1424,6 +1503,7 @@ impl MetadataProvider for MulticatalogProvider {
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
                         partial_max: row.try_get(7)?,
+                        mapping_id: row.try_get(8)?,
                     })
                 })
                 .collect()

--- a/src/table.rs
+++ b/src/table.rs
@@ -7,20 +7,22 @@ use crate::Result;
 use crate::column_rename::ColumnRenameExec;
 use crate::delete_filter::DeleteFilterExec;
 use crate::metadata_provider::{
-    DuckLakeFileColumnStatistics, DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics,
-    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile,
-    FILE_METADATA_BATCH_SIZE, MetadataProvider,
+    DuckLakeFileColumnStatistics, DuckLakeFileData, DuckLakeFileMetadata, DuckLakeNameMapping,
+    DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableField,
+    DuckLakeTableFile, FILE_METADATA_BATCH_SIZE, MetadataProvider,
 };
 use crate::nan_pruning_barrier::NanPruningBarrierExec;
 use crate::partition::PartitionSpec;
 use crate::path_resolver::resolve_path;
 use crate::row_id::{
     ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, SNAPSHOT_ID_PARQUET_FIELD_ID,
-    positional_table_schema, rowid_field,
+    positional_table_schema, positional_table_schema_reserving, rowid_field,
 };
 use crate::snapshot_filter::SnapshotFilterExec;
 use crate::types::{
-    DuckLakeDefaultExprAdapterFactory, build_arrow_schema, build_read_schema_with_field_id_mapping,
+    DuckLakeDefaultExprAdapterFactory, INITIAL_DEFAULT_METADATA_KEY,
+    build_arrow_schema_from_fields, build_read_schema_with_field_id_mapping,
+    build_read_schema_with_field_id_mapping_from_schema, build_read_schema_with_name_mapping,
     ducklake_to_arrow_type, extract_parquet_field_ids, parse_ducklake_default_scalar,
     parse_ducklake_scalar,
 };
@@ -74,6 +76,7 @@ use parquet::arrow::ParquetRecordBatchStreamBuilder;
 // See https://github.com/apache/arrow-rs/issues/10308.
 #[allow(deprecated)]
 use parquet::arrow::async_reader::ParquetObjectReader;
+use percent_encoding::percent_decode_str;
 
 #[cfg(feature = "encryption")]
 use datafusion::execution::parquet_encryption::EncryptionFactory;
@@ -295,6 +298,37 @@ fn validate_column_defaults(columns: &[DuckLakeTableColumn]) -> Result<HashMap<S
         }
     }
     Ok(defaults)
+}
+
+pub(crate) fn apply_initial_default_metadata(
+    schema: &Schema,
+    columns: &[DuckLakeTableColumn],
+    name_mapping: &HashMap<String, String>,
+) -> Schema {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let logical_name = name_mapping
+                .get(field.name())
+                .map_or(field.name().as_str(), String::as_str);
+            let Some(initial_default) = columns
+                .iter()
+                .find(|column| column.column_name == logical_name)
+                .and_then(|column| column.initial_default.as_deref())
+                .filter(|value| !value.eq_ignore_ascii_case("NULL"))
+            else {
+                return Arc::clone(field);
+            };
+            let mut metadata = field.metadata().clone();
+            metadata.insert(
+                INITIAL_DEFAULT_METADATA_KEY.to_string(),
+                initial_default.to_string(),
+            );
+            Arc::new(field.as_ref().clone().with_metadata(metadata))
+        })
+        .collect::<Vec<_>>();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
 }
 
 /// Whether a stored float `min_value` / `max_value` is a usable bound.
@@ -697,8 +731,12 @@ pub fn delete_file_schema() -> SchemaRef {
     ]))
 }
 
-/// Cached schema mapping for renamed columns
-type SchemaMapping = (SchemaRef, HashMap<String, String>);
+/// Cached schema mapping for renamed and path-derived columns.
+type SchemaMapping = (
+    SchemaRef,
+    HashMap<String, String>,
+    HashMap<String, ScalarValue>,
+);
 
 /// Per-file read configuration computed for the row-lineage scan path.
 ///
@@ -732,6 +770,8 @@ struct FileReadConfig {
     /// [`DuckLakeTable::predicate_is_prunable`], which rejects only a predicate
     /// that actually references one of these.
     renamed_column_indices: Arc<HashSet<usize>>,
+    /// Logical column name -> value synthesized from this file's Hive path.
+    constants: HashMap<String, ScalarValue>,
     /// `Some(parquet_column_name)` if the file embeds the rowid column
     /// (tagged with [`ROW_ID_PARQUET_FIELD_ID`]); `None` otherwise.
     embedded_rowid_parquet_name: Option<String>,
@@ -779,6 +819,8 @@ pub(crate) struct ParquetFileLayout {
     pub(crate) read_schema: SchemaRef,
     /// `physical name → catalog name`, for the columns whose names differ.
     pub(crate) name_mapping: HashMap<String, String>,
+    /// Logical column values synthesized from Hive path segments.
+    pub(crate) constants: HashMap<String, ScalarValue>,
     /// `Some(parquet_column_name)` if the file embeds the rowid column (tagged
     /// with [`ROW_ID_PARQUET_FIELD_ID`]).
     pub(crate) embedded_rowid_parquet_name: Option<String>,
@@ -898,11 +940,61 @@ pub(crate) async fn read_parquet_file_layout(
     Ok(Arc::new(ParquetFileLayout {
         read_schema,
         name_mapping,
+        constants: HashMap::new(),
         embedded_rowid_parquet_name: facts.field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned(),
         embedded_snapshot_parquet_name: facts.field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned(),
         drops_current_columns,
         row_group_count: facts.row_group_count,
     }))
+}
+
+pub(crate) fn apply_name_mapping_to_layout(
+    provider: &dyn MetadataProvider,
+    table_id: i64,
+    snapshot_id: i64,
+    columns: &[DuckLakeTableColumn],
+    resolved_path: &str,
+    mapping_id: Option<i64>,
+    layout: Arc<ParquetFileLayout>,
+) -> DataFusionResult<Arc<ParquetFileLayout>> {
+    let Some(mapping_id) = mapping_id else {
+        return Ok(layout);
+    };
+    let mapping = provider
+        .get_name_mapping(mapping_id)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    if mapping.table_id != table_id {
+        return Err(DataFusionError::Execution(format!(
+            "DuckLake name mapping {mapping_id} belongs to table {}, not table {table_id}",
+            mapping.table_id
+        )));
+    }
+    let fields = provider
+        .get_table_fields(table_id, snapshot_id)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let mapped = build_read_schema_with_name_mapping(&fields, &mapping)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let constants = mapped
+        .partitions
+        .into_iter()
+        .map(|partition| {
+            DuckLakeTable::hive_partition_value(
+                resolved_path,
+                &partition.source_name,
+                &partition.data_type,
+            )
+            .map(|value| (partition.logical_name, value))
+        })
+        .collect::<DataFusionResult<HashMap<_, _>>>()?;
+    let mut layout = layout.as_ref().clone();
+    layout.read_schema = Arc::new(apply_initial_default_metadata(
+        &mapped.schema,
+        columns,
+        &mapped.names,
+    ));
+    layout.name_mapping = mapped.names;
+    layout.constants = constants;
+    Ok(Arc::new(layout))
 }
 
 /// DuckLake table provider
@@ -942,6 +1034,10 @@ pub struct DuckLakeTable {
     columns: Vec<DuckLakeTableColumn>,
     /// Literal defaults used by DataFusion when an INSERT omits a column
     column_defaults: HashMap<String, Expr>,
+    /// Complete nested `ducklake_column` tree used by name mappings.
+    fields: Vec<DuckLakeTableField>,
+    /// Immutable name mappings cached by `mapping_id` across scans and clones.
+    name_mapping_cache: Arc<std::sync::Mutex<HashMap<i64, Arc<DuckLakeNameMapping>>>>,
     /// Table-level statistics for the physical schema.
     table_statistics: Statistics,
     /// The table's active partition spec at `snapshot_id`, if any. Loaded once at
@@ -995,12 +1091,17 @@ impl DuckLakeTable {
     ) -> Result<Self> {
         // File metadata is deliberately deferred until scan(), where it can be
         // consumed and pruned in bounded pages.
+        let fields = provider.get_table_fields(table_id, snapshot_id)?;
         let columns = provider.get_table_structure(table_id, snapshot_id)?;
         let column_defaults = validate_column_defaults(&columns)?;
         // Active partition spec (if any) for pruning. Loaded once at the bound
         // snapshot; `None` for unpartitioned tables or catalogs without partitions.
         let partition_spec = provider.get_partition_spec(table_id, snapshot_id)?;
-        let physical_schema = Arc::new(build_arrow_schema(&columns)?);
+        let physical_schema = Arc::new(apply_initial_default_metadata(
+            &build_arrow_schema_from_fields(&fields)?,
+            &columns,
+            &HashMap::new(),
+        ));
         let schema = physical_schema.clone();
         let catalog_statistics = provider.get_table_summary_statistics(table_id, snapshot_id)?;
         // `ducklake_table_stats` and `ducklake_table_column_stats` describe the
@@ -1032,6 +1133,8 @@ impl DuckLakeTable {
             row_lineage: false,
             columns,
             column_defaults,
+            fields,
+            name_mapping_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             table_statistics,
             partition_spec,
             #[cfg(feature = "encryption")]
@@ -1222,6 +1325,215 @@ impl DuckLakeTable {
     fn resolve_file_path(&self, file: &DuckLakeFileData) -> DataFusionResult<String> {
         resolve_path(&self.table_path, &file.path, file.path_is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))
+    }
+
+    fn hive_partition_raw_value<'a>(resolved_path: &'a str, source_name: &str) -> Option<&'a str> {
+        // Match DuckDB v1.5.5 HivePartitioning::Parse: scan the raw object key,
+        // compare raw keys, and leave URL decoding to the value conversion
+        // https://github.com/duckdb/duckdb/blob/v1.5.5/src/common/hive_partitioning.cpp
+        let mut partition_start = 0;
+        let mut equality_sign = 0;
+        let mut candidate_partition = true;
+        for (index, byte) in resolved_path.bytes().enumerate() {
+            if matches!(byte, b'?' | b'\n') {
+                candidate_partition = false;
+            }
+            if matches!(byte, b'/' | b'\\') {
+                if candidate_partition && equality_sign > partition_start {
+                    let key = &resolved_path[partition_start..equality_sign];
+                    if key == source_name {
+                        return Some(&resolved_path[equality_sign + 1..index]);
+                    }
+                }
+                partition_start = index + 1;
+                candidate_partition = true;
+            } else if byte == b'=' {
+                if equality_sign > partition_start {
+                    candidate_partition = false;
+                }
+                equality_sign = index;
+            }
+        }
+        None
+    }
+
+    fn normalize_hive_hex_integer(value: &str, data_type: &DataType) -> Option<String> {
+        if !matches!(
+            data_type,
+            DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+        ) {
+            return None;
+        }
+        let digits = value
+            .strip_prefix("0x")
+            .or_else(|| value.strip_prefix("0X"))?;
+        if digits.is_empty()
+            || digits
+                .split('_')
+                .any(|part| part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        {
+            return None;
+        }
+        let digits = digits.replace('_', "");
+        u128::from_str_radix(&digits, 16)
+            .ok()
+            .map(|value| value.to_string())
+    }
+
+    fn normalize_hive_exponent_decimal(value: &str, data_type: &DataType) -> Option<String> {
+        let (precision, scale) = match data_type {
+            DataType::Decimal128(precision, scale) | DataType::Decimal256(precision, scale) => {
+                (*precision, *scale)
+            },
+            _ => return None,
+        };
+        let exponent_index = value.find(['e', 'E'])?;
+        if value[exponent_index + 1..].contains(['e', 'E']) {
+            return None;
+        }
+        let exponent = value[exponent_index + 1..].parse::<i32>().ok()?;
+        let mantissa = &value[..exponent_index];
+        let (negative, mantissa) = if let Some(mantissa) = mantissa.strip_prefix('-') {
+            (true, mantissa)
+        } else if let Some(mantissa) = mantissa.strip_prefix('+') {
+            (false, mantissa)
+        } else {
+            (false, mantissa)
+        };
+        let mut components = mantissa.split('.');
+        let whole = components.next()?;
+        let fraction = components.next().unwrap_or_default();
+        if components.next().is_some()
+            || (whole.is_empty() && fraction.is_empty())
+            || !whole
+                .bytes()
+                .chain(fraction.bytes())
+                .all(|byte| byte.is_ascii_digit())
+        {
+            return None;
+        }
+        let digits = format!("{whole}{fraction}");
+        let decimal_index = i64::try_from(whole.len()).ok()? + i64::from(exponent);
+        let max_expansion = usize::from(precision)
+            .saturating_add(usize::from(scale.unsigned_abs()))
+            .saturating_add(digits.len())
+            .saturating_add(2);
+        let leading_zeros = usize::try_from((-decimal_index).max(0)).ok()?;
+        let trailing_zeros =
+            usize::try_from((decimal_index - i64::try_from(digits.len()).ok()?).max(0)).ok()?;
+        if leading_zeros > max_expansion || trailing_zeros > max_expansion {
+            return None;
+        }
+
+        let mut normalized = String::with_capacity(digits.len() + max_expansion.min(32));
+        if negative {
+            normalized.push('-');
+        }
+        if decimal_index <= 0 {
+            normalized.push_str("0.");
+            normalized.extend(std::iter::repeat_n('0', leading_zeros));
+            normalized.push_str(&digits);
+        } else if usize::try_from(decimal_index).ok()? >= digits.len() {
+            normalized.push_str(&digits);
+            normalized.extend(std::iter::repeat_n('0', trailing_zeros));
+        } else {
+            let decimal_index = usize::try_from(decimal_index).ok()?;
+            normalized.push_str(&digits[..decimal_index]);
+            normalized.push('.');
+            normalized.push_str(&digits[decimal_index..]);
+        }
+        Some(normalized)
+    }
+
+    pub(crate) fn hive_partition_value(
+        resolved_path: &str,
+        source_name: &str,
+        data_type: &DataType,
+    ) -> DataFusionResult<ScalarValue> {
+        let raw_value = Self::hive_partition_raw_value(resolved_path, source_name).ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "column '{source_name}' uses a DuckLake Hive name mapping but is absent from file path '{resolved_path}'"
+            ))
+        })?;
+        let value = percent_decode_str(raw_value).decode_utf8().map_err(|e| {
+            DataFusionError::Execution(format!(
+                "invalid percent encoding in Hive partition value '{raw_value}': {e}"
+            ))
+        })?;
+        let value = value.into_owned();
+        let is_varchar = matches!(
+            data_type,
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+        );
+        if value == "__HIVE_DEFAULT_PARTITION__"
+            || value.eq_ignore_ascii_case("NULL")
+            || (value.is_empty() && !is_varchar)
+        {
+            return ScalarValue::try_from(data_type);
+        }
+        let scalar_input = Self::normalize_hive_hex_integer(&value, data_type)
+            .or_else(|| Self::normalize_hive_exponent_decimal(&value, data_type))
+            .unwrap_or_else(|| value.clone());
+        ScalarValue::try_from_string(scalar_input, data_type).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "failed to parse Hive partition '{source_name}={value}' as {data_type}: {e}"
+            ))
+        })
+    }
+
+    fn mapped_schema(
+        &self,
+        mapping_id: i64,
+        resolved_path: &str,
+    ) -> DataFusionResult<SchemaMapping> {
+        let mapping = {
+            let cached = self.name_mapping_cache.lock().unwrap();
+            cached.get(&mapping_id).cloned()
+        };
+        let mapping = match mapping {
+            Some(mapping) => mapping,
+            None => {
+                let mapping = Arc::new(
+                    self.provider
+                        .get_name_mapping(mapping_id)
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?,
+                );
+                self.name_mapping_cache
+                    .lock()
+                    .unwrap()
+                    .insert(mapping_id, Arc::clone(&mapping));
+                mapping
+            },
+        };
+        if mapping.table_id != self.table_id {
+            return Err(DataFusionError::Execution(format!(
+                "DuckLake name mapping {mapping_id} belongs to table {}, not table {}",
+                mapping.table_id, self.table_id
+            )));
+        }
+        let mapped = build_read_schema_with_name_mapping(&self.fields, mapping.as_ref())
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let constants = mapped
+            .partitions
+            .into_iter()
+            .map(|partition| {
+                Self::hive_partition_value(
+                    resolved_path,
+                    &partition.source_name,
+                    &partition.data_type,
+                )
+                .map(|value| (partition.logical_name, value))
+            })
+            .collect::<DataFusionResult<HashMap<_, _>>>()?;
+        let schema = apply_initial_default_metadata(&mapped.schema, &self.columns, &mapped.names);
+        Ok((Arc::new(schema), mapped.names, constants))
     }
 
     /// Build a DataFusion file descriptor and attach the catalog's file-level
@@ -1647,19 +1959,43 @@ impl DuckLakeTable {
 
         let field_id_map = extract_parquet_field_ids(builder.metadata());
 
-        // No field_ids means external file - use current schema directly
-        if field_id_map.is_empty() {
-            return Ok((self.schema.clone(), HashMap::new()));
+        if let Some(mapping_id) = file.mapping_id {
+            return self.mapped_schema(mapping_id, &resolved_path);
         }
 
-        let (read_schema, name_mapping) = build_read_schema_with_field_id_mapping(
+        // No field_ids means external file - use current schema directly
+        if field_id_map.is_empty() {
+            return Ok((self.schema.clone(), HashMap::new(), HashMap::new()));
+        }
+
+        let (read_schema, name_mapping) = build_read_schema_with_field_id_mapping_from_schema(
             &self.columns,
+            self.physical_schema.as_ref(),
             &field_id_map,
             Some(builder.schema().as_ref()),
         )
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        Ok((Arc::new(read_schema), name_mapping))
+        let read_schema =
+            apply_initial_default_metadata(&read_schema, &self.columns, &name_mapping);
+        Ok((Arc::new(read_schema), name_mapping, HashMap::new()))
+    }
+
+    fn present_file_read_config(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        file_cfg: &FileReadConfig,
+        physical_len: usize,
+    ) -> Arc<dyn ExecutionPlan> {
+        let mut output_fields: Vec<Arc<Field>> =
+            self.physical_schema.fields().iter().cloned().collect();
+        output_fields.extend(plan.schema().fields().iter().skip(physical_len).cloned());
+        Arc::new(ColumnRenameExec::new_with_constants(
+            plan,
+            Arc::new(Schema::new(output_fields)),
+            file_cfg.name_mapping.clone(),
+            file_cfg.constants.clone(),
+        ))
     }
 
     /// Scan `data_file` and return the physical positions of rows matching
@@ -1708,8 +2044,13 @@ impl DuckLakeTable {
         // Physical data columns only (logical order), then the reader-produced
         // position column. Embedded/rowid columns are not needed to evaluate the
         // predicate or read positions.
-        let (table_schema, pos_table_idx, _pos_name) =
-            positional_table_schema(file_cfg.read_schema.clone());
+        let (table_schema, pos_table_idx, _pos_name) = positional_table_schema_reserving(
+            file_cfg.read_schema.clone(),
+            self.physical_schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str()),
+        );
         let mut proj: Vec<usize> = (0..self.physical_schema.fields().len()).collect();
         proj.push(pos_table_idx);
         let pos_idx = proj.len() - 1;
@@ -1731,6 +2072,9 @@ impl DuckLakeTable {
                 .build(),
         );
         let plan = self.split_across_partitions(plan, state, &file_cfg)?;
+
+        let plan =
+            self.present_file_read_config(plan, &file_cfg, self.physical_schema.fields().len());
 
         let batches = datafusion::physical_plan::collect(plan, state.task_ctx()).await?;
 
@@ -1954,7 +2298,7 @@ impl DuckLakeTable {
             let pf = self.partitioned_data_file(table_file, false, file_statistics)?;
 
             // Group key: physical field names + types, then the rename mapping.
-            let (read_schema, name_mapping) = &mapping;
+            let (read_schema, name_mapping, constants) = &mapping;
             let mut key = String::new();
             for f in read_schema.fields() {
                 key.push_str(f.name());
@@ -1969,6 +2313,14 @@ impl DuckLakeTable {
                 key.push('\u{3}');
                 key.push_str(v);
                 key.push('\u{4}');
+            }
+            let mut constants: Vec<_> = constants.iter().collect();
+            constants.sort_by_key(|(name, _)| *name);
+            for (name, value) in constants {
+                key.push_str(name);
+                key.push('\u{5}');
+                key.push_str(&format!("{value:?}"));
+                key.push('\u{6}');
             }
 
             match group_index.get(&key) {
@@ -1993,7 +2345,7 @@ impl DuckLakeTable {
         // Build one scan per physical-schema group; ColumnRenameExec coerces each
         // group to the catalog schema (renamed columns or a differing Arrow type).
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(groups.len());
-        for ((read_schema, name_mapping), partitioned_files) in groups {
+        for ((read_schema, name_mapping, constants), partitioned_files) in groups {
             let mut builder = self
                 .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
                 .with_limit(limit)
@@ -2007,10 +2359,11 @@ impl DuckLakeTable {
                 DataSourceExec::from_data_source(builder.build());
 
             let mut exec = if !name_mapping.is_empty() || parquet_exec.schema() != output_schema {
-                Arc::new(ColumnRenameExec::new(
+                Arc::new(ColumnRenameExec::new_with_constants(
                     parquet_exec,
                     output_schema.clone(),
                     name_mapping,
+                    constants,
                 )) as Arc<dyn ExecutionPlan>
             } else {
                 parquet_exec
@@ -2283,16 +2636,19 @@ impl DuckLakeTable {
 
         // ColumnRenameExec presents the catalog schema and, on the positional
         // path, drops the internal physical-position column.
-        let mut exec: Arc<dyn ExecutionPlan> =
-            if !file_cfg.name_mapping.is_empty() || exec_after_delete.schema() != output_schema {
-                Arc::new(ColumnRenameExec::new(
-                    exec_after_delete,
-                    output_schema,
-                    file_cfg.name_mapping.clone(),
-                ))
-            } else {
-                exec_after_delete
-            };
+        let mut exec: Arc<dyn ExecutionPlan> = if !file_cfg.name_mapping.is_empty()
+            || !file_cfg.constants.is_empty()
+            || exec_after_delete.schema() != output_schema
+        {
+            Arc::new(ColumnRenameExec::new_with_constants(
+                exec_after_delete,
+                output_schema,
+                file_cfg.name_mapping.clone(),
+                file_cfg.constants.clone(),
+            ))
+        } else {
+            exec_after_delete
+        };
 
         // Both branches above can let a predicate reach the parquet reader's
         // pruning, so both need the NaN barrier: footer float bounds exclude
@@ -2341,13 +2697,23 @@ impl DuckLakeTable {
         )
         .await?;
 
-        let mut name_mapping = layout.name_mapping.clone();
+        let (physical_read_schema, mut name_mapping, constants) =
+            if let Some(mapping_id) = file.mapping_id {
+                self.mapped_schema(mapping_id, &resolved_path)?
+            } else {
+                (
+                    layout.read_schema.clone(),
+                    layout.name_mapping.clone(),
+                    HashMap::new(),
+                )
+            };
         let read_schema = if let Some(ref parquet_name) = layout.embedded_rowid_parquet_name {
             // Append the embedded rowid column to read_schema under its
             // parquet name; ParquetExec will project it by name from the
             // file. We add a `parquet_name → "rowid"` rename so the user
             // sees the column as `rowid` (only needed if the names differ).
-            let mut fields: Vec<Arc<Field>> = layout.read_schema.fields().iter().cloned().collect();
+            let mut fields: Vec<Arc<Field>> =
+                physical_read_schema.fields().iter().cloned().collect();
             fields.push(Arc::new(Field::new(
                 parquet_name.clone(),
                 DataType::Int64,
@@ -2358,17 +2724,17 @@ impl DuckLakeTable {
             }
             Arc::new(Schema::new(fields))
         } else {
-            layout.read_schema.clone()
+            physical_read_schema.clone()
         };
 
         // A catalog column reads under a different physical name when the file
-        // renamed it or predates it. `layout.read_schema` is one field per
+        // renamed it or predates it. `physical_read_schema` is one field per
         // current column in catalog order, so the comparison is positional.
         let renamed_column_indices: HashSet<usize> = self
             .physical_schema
             .fields()
             .iter()
-            .zip(layout.read_schema.fields())
+            .zip(physical_read_schema.fields())
             .enumerate()
             .filter(|(_, (catalog, physical))| catalog.name() != physical.name())
             .map(|(index, _)| index)
@@ -2379,6 +2745,7 @@ impl DuckLakeTable {
             row_group_count: layout.row_group_count,
             renamed_column_indices: Arc::new(renamed_column_indices),
             name_mapping,
+            constants,
             embedded_rowid_parquet_name: layout.embedded_rowid_parquet_name.clone(),
             embedded_snapshot_parquet_name: layout.embedded_snapshot_parquet_name.clone(),
             drops_current_columns: layout.drops_current_columns,
@@ -2518,16 +2885,19 @@ impl DuckLakeTable {
         // FixedSizeList vs the catalog's List). Coerces each column to
         // `output_schema`.
         let output_schema = self.output_schema_for_projection(user_proj, rowid_idx);
-        let mut exec =
-            if !file_cfg.name_mapping.is_empty() || after_deletes.schema() != output_schema {
-                Arc::new(ColumnRenameExec::new(
-                    after_deletes,
-                    output_schema,
-                    file_cfg.name_mapping.clone(),
-                )) as Arc<dyn ExecutionPlan>
-            } else {
-                after_deletes
-            };
+        let mut exec = if !file_cfg.name_mapping.is_empty()
+            || !file_cfg.constants.is_empty()
+            || after_deletes.schema() != output_schema
+        {
+            Arc::new(ColumnRenameExec::new_with_constants(
+                after_deletes,
+                output_schema,
+                file_cfg.name_mapping.clone(),
+                file_cfg.constants.clone(),
+            )) as Arc<dyn ExecutionPlan>
+        } else {
+            after_deletes
+        };
         // Every branch here can now let a predicate reach the parquet reader's
         // row-group/page/bloom pruning: the positional branch no longer blocks
         // pushdown, and `DeleteFilterExec` / `RowIdExec` / `ColumnRenameExec`
@@ -2701,10 +3071,11 @@ impl DuckLakeTable {
             snap_name,
             self.snapshot_id,
         )?);
-        Ok(Arc::new(ColumnRenameExec::new(
+        Ok(Arc::new(ColumnRenameExec::new_with_constants(
             filtered,
             output_schema,
             file_cfg.name_mapping.clone(),
+            file_cfg.constants.clone(),
         )))
     }
 
@@ -2727,6 +3098,8 @@ impl DuckLakeTable {
             row_lineage: false,
             columns: self.columns.clone(),
             column_defaults: self.column_defaults.clone(),
+            fields: self.fields.clone(),
+            name_mapping_cache: Arc::clone(&self.name_mapping_cache),
             table_statistics: self.table_statistics.clone(),
             partition_spec: self.partition_spec.clone(),
             // `snapshot_id`/cache match the post-#163 struct (Arc-wrapped cache,
@@ -2937,7 +3310,13 @@ impl DuckLakeTable {
         // physical columns (logical order), then for an embedded file the
         // embedded rowid column, then the position column.
         let physical_len = self.physical_schema.fields().len();
-        let (table_schema, pos_table_idx, _pos_name) = positional_table_schema(read_schema.clone());
+        let (table_schema, pos_table_idx, _pos_name) = positional_table_schema_reserving(
+            read_schema.clone(),
+            self.physical_schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str()),
+        );
         // Built by pushing, so each appended column records the index it actually
         // landed at. Arithmetic off `physical_len` would silently misalign the
         // appended columns for a file that has one but not another, and all are
@@ -2974,6 +3353,8 @@ impl DuckLakeTable {
                 pos_index,
             )?);
         }
+
+        plan = self.present_file_read_config(plan, &file_cfg, physical_len);
 
         Ok(UpdateSourceScan {
             scan: plan,
@@ -4015,8 +4396,84 @@ mod tests {
         SnapshotMetadata, TableMetadata, TableWithSchema,
     };
     use crate::partition::{PartitionSpecColumn, PartitionTransform};
+    use crate::types::build_arrow_schema;
     use datafusion::prelude::{SessionContext, col, lit};
+    use rstest::rstest;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[rstest]
+    #[case("NULL", DataType::Utf8, ScalarValue::Utf8(None))]
+    #[case("null", DataType::Int32, ScalarValue::Int32(None))]
+    #[case("", DataType::Int32, ScalarValue::Int32(None))]
+    #[case("", DataType::Utf8, ScalarValue::Utf8(Some(String::new())))]
+    #[case("__HIVE_DEFAULT_PARTITION__", DataType::Int32, ScalarValue::Int32(None))]
+    #[case("0x10", DataType::Int32, ScalarValue::Int32(Some(16)))]
+    #[case("1e2", DataType::Decimal128(10, 2), ScalarValue::Decimal128(Some(10_000), 10, 2))]
+    #[case("1.25e-1", DataType::Decimal128(10, 3), ScalarValue::Decimal128(Some(125), 10, 3))]
+    fn hive_partition_values_match_duckdb(
+        #[case] encoded: &str,
+        #[case] data_type: DataType,
+        #[case] expected: ScalarValue,
+    ) {
+        let path = format!("file:///tmp/p={encoded}/data.parquet");
+
+        let actual = DuckLakeTable::hive_partition_value(&path, "p", &data_type).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case(
+        "s3://bucket/a=one/../p=7/file.parquet",
+        "a",
+        DataType::Utf8,
+        ScalarValue::Utf8(Some("one".to_string()))
+    )]
+    #[case(
+        "s3://bucket/p=a#b/file.parquet",
+        "p",
+        DataType::Utf8,
+        ScalarValue::Utf8(Some("a#b".to_string()))
+    )]
+    #[case(
+        "s3://bucket/not=a?b/p=7/file.parquet",
+        "p",
+        DataType::Int32,
+        ScalarValue::Int32(Some(7))
+    )]
+    #[case(r"s3:\bucket\p=7\file.parquet", "p", DataType::Int32, ScalarValue::Int32(Some(7)))]
+    #[case(
+        "s3://bucket/p%20q=7/file.parquet",
+        "p%20q",
+        DataType::Int32,
+        ScalarValue::Int32(Some(7))
+    )]
+    #[case(
+        "s3://bucket/p=a%20b/file.parquet",
+        "p",
+        DataType::Utf8,
+        ScalarValue::Utf8(Some("a b".to_string()))
+    )]
+    fn hive_partition_path_parsing_matches_duckdb(
+        #[case] path: &str,
+        #[case] source_name: &str,
+        #[case] data_type: DataType,
+        #[case] expected: ScalarValue,
+    ) {
+        let actual = DuckLakeTable::hive_partition_value(path, source_name, &data_type).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case("s3://bucket/p=7=8/file.parquet", "p")]
+    #[case("s3://bucket/p%20q=7/file.parquet", "p q")]
+    fn hive_partition_path_rejects_non_candidates(#[case] path: &str, #[case] source_name: &str) {
+        let error =
+            DuckLakeTable::hive_partition_value(path, source_name, &DataType::Int32).unwrap_err();
+
+        assert!(error.to_string().contains("absent from file path"));
+    }
 
     #[derive(Debug, Default)]
     struct LazyMillionFileProvider {
@@ -4600,6 +5057,7 @@ mod tests {
                 .into_iter()
                 .map(|(a, b)| (a.to_string(), b.to_string()))
                 .collect(),
+            constants: HashMap::new(),
             row_group_count: 4,
             renamed_column_indices: Arc::new(renamed.into_iter().collect()),
             embedded_rowid_parquet_name: None,

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -42,8 +42,8 @@ use crate::metadata_provider::{DataFileChange, DuckLakeTableColumn, MetadataProv
 use crate::path_resolver::resolve_path;
 use crate::row_id::{SNAPSHOT_ID_PARQUET_FIELD_ID, positional_table_schema_reserving};
 use crate::table::{
-    ParquetFileLayout, delete_file_schema, read_parquet_file_layout, read_parquet_footer_facts,
-    validated_file_size, validated_record_count,
+    ParquetFileLayout, apply_name_mapping_to_layout, delete_file_schema, read_parquet_file_layout,
+    read_parquet_footer_facts, validated_file_size, validated_record_count,
 };
 use crate::types::ABSENT_FIELD_PREFIX;
 
@@ -125,6 +125,7 @@ pub(crate) fn present_catalog_schema(
     scan: Arc<dyn ExecutionPlan>,
     table_fields: &[FieldRef],
     name_mapping: &HashMap<String, String>,
+    constants: &HashMap<String, datafusion::common::ScalarValue>,
 ) -> Arc<dyn ExecutionPlan> {
     let scan_schema = scan.schema();
     debug_assert!(scan_schema.fields().len() >= table_fields.len());
@@ -137,11 +138,12 @@ pub(crate) fn present_catalog_schema(
             .cloned(),
     );
     let output_schema: SchemaRef = Arc::new(Schema::new(fields));
-    if !name_mapping.is_empty() || scan_schema != output_schema {
-        Arc::new(ColumnRenameExec::new(
+    if !name_mapping.is_empty() || !constants.is_empty() || scan_schema != output_schema {
+        Arc::new(ColumnRenameExec::new_with_constants(
             scan,
             output_schema,
             name_mapping.clone(),
+            constants.clone(),
         ))
     } else {
         scan
@@ -541,6 +543,7 @@ impl TableChangesTable {
         columns: &[DuckLakeTableColumn],
         path: &str,
         is_relative: bool,
+        mapping_id: Option<i64>,
     ) -> DataFusionResult<Arc<ParquetFileLayout>> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
@@ -561,6 +564,15 @@ impl TableChangesTable {
             &self.table_schema,
         )
         .await?;
+        let layout = apply_name_mapping_to_layout(
+            self.provider.as_ref(),
+            self.table_id,
+            self.end_snapshot,
+            columns,
+            &resolved,
+            mapping_id,
+            layout,
+        )?;
         self.layout_cache
             .lock()
             .unwrap()
@@ -768,7 +780,9 @@ impl TableChangesTable {
                 .map(|&i| Arc::clone(&self.table_schema.fields()[i]))
                 .collect();
             let name_mapping = layout.map(|l| l.name_mapping.clone()).unwrap_or_default();
-            parquet_exec = present_catalog_schema(parquet_exec, &table_fields, &name_mapping);
+            let constants = layout.map(|l| l.constants.clone()).unwrap_or_default();
+            parquet_exec =
+                present_catalog_schema(parquet_exec, &table_fields, &name_mapping, &constants);
         }
 
         // Build output schema for PrependCDCColumnsExec
@@ -937,6 +951,7 @@ impl TableChangesTable {
             scan,
             &self.catalog_table_fields(),
             &layout.name_mapping,
+            &layout.constants,
         ))
     }
 
@@ -978,6 +993,7 @@ impl TableChangesTable {
             scan,
             &self.catalog_table_fields(),
             &layout.name_mapping,
+            &layout.constants,
         ))
     }
 
@@ -1213,6 +1229,7 @@ impl TableChangesTable {
                         columns,
                         &dfc.data_file_path,
                         dfc.data_file_path_is_relative,
+                        dfc.data_mapping_id,
                     )
                     .await?;
                 let old_embedded = source_layout.embedded_rowid_parquet_name.clone();
@@ -1446,8 +1463,14 @@ impl TableProvider for TableChangesTable {
             let mut layouts: Vec<Arc<ParquetFileLayout>> = Vec::with_capacity(data_files.len());
             for data_file in &data_files {
                 layouts.push(
-                    self.file_layout(state, &columns, &data_file.path, data_file.path_is_relative)
-                        .await?,
+                    self.file_layout(
+                        state,
+                        &columns,
+                        &data_file.path,
+                        data_file.path_is_relative,
+                        data_file.mapping_id,
+                    )
+                    .await?,
                 );
             }
             return self
@@ -1493,8 +1516,14 @@ impl TableProvider for TableChangesTable {
                 None
             } else {
                 Some(
-                    self.file_layout(state, &columns, &data_file.path, data_file.path_is_relative)
-                        .await?,
+                    self.file_layout(
+                        state,
+                        &columns,
+                        &data_file.path,
+                        data_file.path_is_relative,
+                        data_file.mapping_id,
+                    )
+                    .await?,
                 )
             };
             #[cfg(feature = "encryption")]

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -54,8 +54,8 @@ use crate::metadata_provider::{DeleteFileChange, DuckLakeTableColumn, MetadataPr
 use crate::path_resolver::resolve_path;
 use crate::row_id::{SNAPSHOT_ID_PARQUET_FIELD_ID, positional_table_schema_reserving};
 use crate::table::{
-    ParquetFileLayout, read_parquet_file_layout, read_parquet_footer_facts, validated_file_size,
-    validated_record_count,
+    ParquetFileLayout, apply_name_mapping_to_layout, read_parquet_file_layout,
+    read_parquet_footer_facts, validated_file_size, validated_record_count,
 };
 use crate::table_changes::{check_column_count, present_catalog_schema};
 
@@ -166,6 +166,7 @@ impl TableDeletionsTable {
         columns: &[DuckLakeTableColumn],
         path: &str,
         is_relative: bool,
+        mapping_id: Option<i64>,
     ) -> DataFusionResult<Arc<ParquetFileLayout>> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
@@ -184,6 +185,15 @@ impl TableDeletionsTable {
             &self.table_schema,
         )
         .await?;
+        let layout = apply_name_mapping_to_layout(
+            self.provider.as_ref(),
+            self.table_id,
+            self.end_snapshot,
+            columns,
+            &resolved,
+            mapping_id,
+            layout,
+        )?;
         self.layout_cache
             .lock()
             .unwrap()
@@ -282,6 +292,7 @@ impl TableDeletionsTable {
                 columns,
                 &delete_file.data_file_path,
                 delete_file.data_file_path_is_relative,
+                delete_file.data_mapping_id,
             )
             .await?;
 
@@ -465,6 +476,7 @@ impl TableDeletionsTable {
             scan,
             &table_fields,
             &layout.name_mapping,
+            &layout.constants,
         ))
     }
 }

--- a/src/table_functions.rs
+++ b/src/table_functions.rs
@@ -15,7 +15,6 @@ use crate::path_resolver::{parse_object_store_url, resolve_path};
 use crate::table::DuckLakeTable;
 use crate::table_changes::{TableChangesTable, TableInsertionsTable};
 use crate::table_deletions::TableDeletionsTable;
-use crate::types::build_arrow_schema;
 
 #[derive(Debug)]
 pub struct DucklakeSnapshotsFunction {
@@ -343,11 +342,13 @@ fn parse_cdc_args(
         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let table_path = resolve_path(&schema_path, &table.path, table.path_is_relative)
         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-    let columns = provider
-        .get_table_structure(table.table_id, end_snapshot)
+    let fields = provider
+        .get_table_fields(table.table_id, end_snapshot)
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let columns = crate::types::top_level_columns(&fields)
         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let table_schema = Arc::new(
-        build_arrow_schema(&columns)
+        crate::types::build_arrow_schema_from_fields(&fields)
             .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?,
     );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,9 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use crate::metadata_provider::DuckLakeTableColumn;
+use crate::metadata_provider::{
+    DuckLakeNameMapping, DuckLakeNameMappingEntry, DuckLakeTableColumn, DuckLakeTableField,
+};
 use crate::{DuckLakeError, Result};
 use arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
 use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
@@ -18,7 +20,7 @@ use parquet::file::metadata::ParquetMetaData;
 
 pub(crate) const MAX_NESTED_TYPE_DEPTH: usize = 128;
 
-const INITIAL_DEFAULT_METADATA_KEY: &str = "ducklake.initial_default";
+pub(crate) const INITIAL_DEFAULT_METADATA_KEY: &str = "ducklake.initial_default";
 
 #[derive(Debug)]
 pub(crate) struct DuckLakeDefaultExprAdapterFactory;
@@ -820,6 +822,404 @@ fn read_compatible_data_type(data_type: &DataType, nullable_struct_fields: bool)
     }
 }
 
+#[derive(Debug)]
+struct TableFieldTree<'a> {
+    fields: &'a [DuckLakeTableField],
+    children: HashMap<Option<i64>, Vec<usize>>,
+}
+
+impl<'a> TableFieldTree<'a> {
+    fn new(fields: &'a [DuckLakeTableField]) -> Result<Self> {
+        let mut by_id = HashMap::with_capacity(fields.len());
+        let mut children: HashMap<Option<i64>, Vec<usize>> = HashMap::new();
+        for (index, field) in fields.iter().enumerate() {
+            if by_id.insert(field.column_id, index).is_some() {
+                return Err(DuckLakeError::InvalidConfig(format!(
+                    "duplicate DuckLake column_id {}",
+                    field.column_id
+                )));
+            }
+            children.entry(field.parent_column).or_default().push(index);
+        }
+        for field in fields {
+            if let Some(parent) = field.parent_column
+                && !by_id.contains_key(&parent)
+            {
+                return Err(DuckLakeError::InvalidConfig(format!(
+                    "DuckLake column {} references missing parent_column {}",
+                    field.column_id, parent
+                )));
+            }
+            let mut ancestors = HashSet::new();
+            let mut ancestor = Some(field.column_id);
+            while let Some(column_id) = ancestor {
+                if !ancestors.insert(column_id) {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "cycle in DuckLake column tree at column_id {column_id}"
+                    )));
+                }
+                ancestor = fields[by_id[&column_id]].parent_column;
+            }
+        }
+        Ok(Self {
+            fields,
+            children,
+        })
+    }
+
+    fn roots(&self) -> impl Iterator<Item = usize> + '_ {
+        self.children.get(&None).into_iter().flatten().copied()
+    }
+
+    fn children(&self, column_id: i64) -> impl Iterator<Item = usize> + '_ {
+        self.children
+            .get(&Some(column_id))
+            .into_iter()
+            .flatten()
+            .copied()
+    }
+
+    fn arrow_field(&self, index: usize, visiting: &mut HashSet<i64>) -> Result<Field> {
+        let field = &self.fields[index];
+        if !visiting.insert(field.column_id) {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "cycle in DuckLake column tree at column_id {}",
+                field.column_id
+            )));
+        }
+        let child_indices: Vec<_> = self.children(field.column_id).collect();
+        let normalized = field.column_type.trim().to_ascii_lowercase();
+        let data_type = match normalized.as_str() {
+            "struct" => {
+                let children = child_indices
+                    .into_iter()
+                    .map(|child| self.arrow_field(child, visiting).map(Arc::new))
+                    .collect::<Result<Vec<_>>>()?;
+                DataType::Struct(children.into())
+            },
+            "list" | "array" => {
+                if child_indices.len() != 1 {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "DuckLake list column {} has {} children; expected 1",
+                        field.column_id,
+                        child_indices.len()
+                    )));
+                }
+                let mut child = self.arrow_field(child_indices[0], visiting)?;
+                child = child.with_name("item");
+                DataType::List(Arc::new(child))
+            },
+            "map" => {
+                if child_indices.len() != 2 {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "DuckLake map column {} has {} children; expected key and value",
+                        field.column_id,
+                        child_indices.len()
+                    )));
+                }
+                let key = self
+                    .arrow_field(child_indices[0], visiting)?
+                    .with_nullable(false);
+                let value = self.arrow_field(child_indices[1], visiting)?;
+                if key.name() != "key" || value.name() != "value" {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "DuckLake map column {} children must be named key and value",
+                        field.column_id
+                    )));
+                }
+                DataType::Map(
+                    Arc::new(Field::new(
+                        "entries",
+                        DataType::Struct(vec![Arc::new(key), Arc::new(value)].into()),
+                        false,
+                    )),
+                    false,
+                )
+            },
+            _ => {
+                if !child_indices.is_empty() {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "DuckLake scalar column {} has nested children",
+                        field.column_id
+                    )));
+                }
+                ducklake_to_arrow_type(&field.column_type)?
+            },
+        };
+        visiting.remove(&field.column_id);
+        Ok(Field::new(
+            &field.column_name,
+            read_compatible_data_type(&data_type, true),
+            field.is_nullable,
+        ))
+    }
+}
+
+/// Build an Arrow schema from the complete `ducklake_column` field tree.
+pub fn build_arrow_schema_from_fields(fields: &[DuckLakeTableField]) -> Result<Schema> {
+    build_arrow_schema(&top_level_columns(fields)?)
+}
+
+/// Return the top-level column records in catalog order.
+pub fn top_level_columns(fields: &[DuckLakeTableField]) -> Result<Vec<DuckLakeTableColumn>> {
+    crate::metadata_provider::reconstruct_columns(
+        fields
+            .iter()
+            .map(|field| (field.column(), field.parent_column))
+            .collect(),
+    )
+}
+
+#[derive(Debug)]
+struct NameMappingTree<'a> {
+    entries: &'a [DuckLakeNameMappingEntry],
+    children: HashMap<Option<i64>, Vec<usize>>,
+}
+
+impl<'a> NameMappingTree<'a> {
+    fn new(mapping: &'a DuckLakeNameMapping) -> Result<Self> {
+        if mapping.mapping_type != "map_by_name" {
+            return Err(DuckLakeError::Unsupported(format!(
+                "DuckLake column mapping type '{}'",
+                mapping.mapping_type
+            )));
+        }
+        let mut by_id = HashMap::with_capacity(mapping.entries.len());
+        let mut children: HashMap<Option<i64>, Vec<usize>> = HashMap::new();
+        for (index, entry) in mapping.entries.iter().enumerate() {
+            if by_id.contains_key(&entry.column_id) {
+                continue;
+            }
+            by_id.insert(entry.column_id, index);
+            children.entry(entry.parent_column).or_default().push(index);
+        }
+        for index in by_id.values() {
+            let entry = &mapping.entries[*index];
+            if let Some(parent) = entry.parent_column
+                && !by_id.contains_key(&parent)
+            {
+                return Err(DuckLakeError::InvalidConfig(format!(
+                    "name-mapping column {} references missing parent_column {}",
+                    entry.column_id, parent
+                )));
+            }
+            if entry.is_partition && entry.parent_column.is_some() {
+                return Err(DuckLakeError::InvalidConfig(format!(
+                    "nested name-mapping column {} cannot be synthesized from a Hive path",
+                    entry.column_id
+                )));
+            }
+            let mut ancestors = HashSet::new();
+            let mut ancestor = Some(entry.column_id);
+            while let Some(column_id) = ancestor {
+                if !ancestors.insert(column_id) {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "cycle in DuckLake name mapping at column_id {column_id}"
+                    )));
+                }
+                ancestor = mapping.entries[by_id[&column_id]].parent_column;
+            }
+        }
+        Ok(Self {
+            entries: &mapping.entries,
+            children,
+        })
+    }
+
+    fn entry_for_target(
+        &self,
+        parent: Option<i64>,
+        target_field_id: i64,
+    ) -> Option<&DuckLakeNameMappingEntry> {
+        self.children.get(&parent)?.iter().find_map(|index| {
+            let entry = &self.entries[*index];
+            (entry.target_field_id == target_field_id).then_some(entry)
+        })
+    }
+}
+
+fn physical_mapped_field(
+    table: &TableFieldTree<'_>,
+    mapping: &NameMappingTree<'_>,
+    table_index: usize,
+    mapping_entry: &DuckLakeNameMappingEntry,
+) -> Result<Field> {
+    let logical = table.arrow_field(table_index, &mut HashSet::new())?;
+    let table_field = &table.fields[table_index];
+    let data_type = match logical.data_type() {
+        DataType::Struct(_) => {
+            let children = table
+                .children(table_field.column_id)
+                .map(|child_index| {
+                    let child = &table.fields[child_index];
+                    match mapping.entry_for_target(Some(mapping_entry.column_id), child.column_id) {
+                        Some(entry) => physical_mapped_field(table, mapping, child_index, entry),
+                        None => {
+                            let field = table.arrow_field(child_index, &mut HashSet::new())?;
+                            Ok(Field::new(
+                                format!("__ducklake_absent_field_{}", child.column_id),
+                                field.data_type().clone(),
+                                true,
+                            ))
+                        },
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?;
+            DataType::Struct(children.into())
+        },
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
+            let child_index = table
+                .children(table_field.column_id)
+                .next()
+                .ok_or_else(|| {
+                    DuckLakeError::InvalidConfig(format!(
+                        "DuckLake list column {} has no element",
+                        table_field.column_id
+                    ))
+                })?;
+            let child = &table.fields[child_index];
+            let mut element =
+                match mapping.entry_for_target(Some(mapping_entry.column_id), child.column_id) {
+                    Some(child_mapping) => {
+                        physical_mapped_field(table, mapping, child_index, child_mapping)?
+                    },
+                    None => table
+                        .arrow_field(child_index, &mut HashSet::new())?
+                        .with_name(format!("__ducklake_absent_field_{}", child.column_id))
+                        .with_nullable(true),
+                };
+            if matches!(element.name().as_str(), "array" | "element") {
+                element = element.with_name("list");
+            }
+            DataType::List(Arc::new(element))
+        },
+        DataType::Map(_, sorted) => {
+            let children = table
+                .children(table_field.column_id)
+                .enumerate()
+                .map(|(index, child_index)| {
+                    let child = &table.fields[child_index];
+                    let field = match mapping
+                        .entry_for_target(Some(mapping_entry.column_id), child.column_id)
+                    {
+                        Some(child_mapping) => {
+                            physical_mapped_field(table, mapping, child_index, child_mapping)?
+                        },
+                        None => table
+                            .arrow_field(child_index, &mut HashSet::new())?
+                            .with_name(format!("__ducklake_absent_field_{}", child.column_id))
+                            .with_nullable(true),
+                    };
+                    Ok(if index == 0 {
+                        field.with_nullable(false)
+                    } else {
+                        field
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            DataType::Map(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(children.into()),
+                    false,
+                )),
+                *sorted,
+            )
+        },
+        data_type => data_type.clone(),
+    };
+    Ok(Field::new(
+        &mapping_entry.source_name,
+        data_type,
+        logical.is_nullable() || mapping_entry.parent_column.is_some(),
+    ))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct HivePartitionField {
+    pub logical_name: String,
+    pub source_name: String,
+    pub data_type: DataType,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct NameMappingSchema {
+    pub schema: Schema,
+    pub names: HashMap<String, String>,
+    pub partitions: Vec<HivePartitionField>,
+}
+
+/// Build the per-file physical schema for a `map_by_name` mapping.
+///
+/// The returned partition fields identify Hive-derived values keyed by the
+/// current logical column name. The caller extracts and parses the path values
+/// because the resolved object-store path is available at scan planning time.
+pub fn build_read_schema_with_name_mapping(
+    fields: &[DuckLakeTableField],
+    mapping: &DuckLakeNameMapping,
+) -> Result<NameMappingSchema> {
+    let table = TableFieldTree::new(fields)?;
+    let mapping_tree = NameMappingTree::new(mapping)?;
+    let mut name_mapping = HashMap::new();
+    let mut partitions = Vec::new();
+    let read_fields = table
+        .roots()
+        .map(|table_index| {
+            let field = &table.fields[table_index];
+            let logical = table.arrow_field(table_index, &mut HashSet::new())?;
+            let Some(entry) = mapping_tree.entry_for_target(None, field.column_id) else {
+                let read_name = format!("__ducklake_absent_field_{}", field.column_id);
+                name_mapping.insert(read_name.clone(), field.column_name.clone());
+                return Ok(Field::new(read_name, logical.data_type().clone(), true));
+            };
+            if entry.is_partition {
+                let read_name = format!("__ducklake_partition_field_{}", field.column_id);
+                partitions.push(HivePartitionField {
+                    logical_name: field.column_name.clone(),
+                    source_name: entry.source_name.clone(),
+                    data_type: logical.data_type().clone(),
+                });
+                return Ok(Field::new(read_name, logical.data_type().clone(), true));
+            }
+            let physical = physical_mapped_field(&table, &mapping_tree, table_index, entry)?;
+            if physical.name() != &field.column_name {
+                name_mapping.insert(physical.name().clone(), field.column_name.clone());
+            }
+            Ok(physical)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(NameMappingSchema {
+        schema: Schema::new(read_fields),
+        names: name_mapping,
+        partitions,
+    })
+}
+
+/// Field-id mapping variant that takes the already-built logical schema. This
+/// supports recursive types without re-parsing their catalog type rows.
+pub fn build_read_schema_with_field_id_mapping_from_schema(
+    current_columns: &[DuckLakeTableColumn],
+    current_schema: &Schema,
+    parquet_field_ids: &HashMap<i32, String>,
+    file_schema: Option<&Schema>,
+) -> Result<(Schema, HashMap<String, String>)> {
+    if current_columns.len() != current_schema.fields().len() {
+        return Err(DuckLakeError::Internal(
+            "DuckLake columns and logical schema have different lengths".to_string(),
+        ));
+    }
+    let columns = current_columns
+        .iter()
+        .zip(current_schema.fields())
+        .map(|(column, logical)| {
+            let mut column = column.clone();
+            column.data_type = Some(logical.data_type().clone());
+            column
+        })
+        .collect::<Vec<_>>();
+    build_read_schema_with_field_id_mapping(&columns, parquet_field_ids, file_schema)
+}
+
 /// Extract field_id to column_name mapping from Parquet metadata.
 /// DuckLake column_id == Parquet field_id, enabling column matching after renames.
 pub fn extract_parquet_field_ids(metadata: &ParquetMetaData) -> HashMap<i32, String> {
@@ -1159,6 +1559,260 @@ pub fn build_read_schema_with_field_id_mapping(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    fn mapped_fields() -> Vec<DuckLakeTableField> {
+        vec![
+            DuckLakeTableField {
+                column_id: 1,
+                column_name: "id".to_string(),
+                column_type: "int32".to_string(),
+                is_nullable: false,
+                parent_column: None,
+            },
+            DuckLakeTableField {
+                column_id: 2,
+                column_name: "nested".to_string(),
+                column_type: "struct".to_string(),
+                is_nullable: true,
+                parent_column: None,
+            },
+            DuckLakeTableField {
+                column_id: 3,
+                column_name: "a".to_string(),
+                column_type: "int32".to_string(),
+                is_nullable: true,
+                parent_column: Some(2),
+            },
+            DuckLakeTableField {
+                column_id: 4,
+                column_name: "b".to_string(),
+                column_type: "varchar".to_string(),
+                is_nullable: true,
+                parent_column: Some(2),
+            },
+            DuckLakeTableField {
+                column_id: 5,
+                column_name: "part".to_string(),
+                column_type: "int32".to_string(),
+                is_nullable: true,
+                parent_column: None,
+            },
+        ]
+    }
+
+    fn name_mapping(mapping_type: &str) -> DuckLakeNameMapping {
+        DuckLakeNameMapping {
+            mapping_id: 7,
+            table_id: 11,
+            mapping_type: mapping_type.to_string(),
+            entries: vec![
+                DuckLakeNameMappingEntry {
+                    column_id: 10,
+                    source_name: "source_id".to_string(),
+                    target_field_id: 1,
+                    parent_column: None,
+                    is_partition: false,
+                },
+                DuckLakeNameMappingEntry {
+                    column_id: 11,
+                    source_name: "source_nested".to_string(),
+                    target_field_id: 2,
+                    parent_column: None,
+                    is_partition: false,
+                },
+                DuckLakeNameMappingEntry {
+                    column_id: 12,
+                    source_name: "source_b".to_string(),
+                    target_field_id: 4,
+                    parent_column: Some(11),
+                    is_partition: false,
+                },
+                DuckLakeNameMappingEntry {
+                    column_id: 13,
+                    source_name: "source_a".to_string(),
+                    target_field_id: 3,
+                    parent_column: Some(11),
+                    is_partition: false,
+                },
+                DuckLakeNameMappingEntry {
+                    column_id: 14,
+                    source_name: "part".to_string(),
+                    target_field_id: 5,
+                    parent_column: None,
+                    is_partition: true,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn builds_recursive_name_mapping_schema() {
+        let fields = mapped_fields();
+        let logical = build_arrow_schema_from_fields(&fields).unwrap();
+        assert_eq!(logical.fields().len(), 3);
+        assert_eq!(logical.field(0).name(), "id");
+        let DataType::Struct(children) = logical.field(1).data_type() else {
+            panic!("nested must be a struct");
+        };
+        assert_eq!(children[0].name(), "a");
+        assert_eq!(children[1].name(), "b");
+
+        let mapped =
+            build_read_schema_with_name_mapping(&fields, &name_mapping("map_by_name")).unwrap();
+        assert_eq!(mapped.schema.fields().len(), 3);
+        assert_eq!(mapped.schema.field(0).name(), "source_id");
+        assert_eq!(
+            mapped.names.get("source_id").map(String::as_str),
+            Some("id")
+        );
+        let DataType::Struct(children) = mapped.schema.field(1).data_type() else {
+            panic!("mapped nested must be a struct");
+        };
+        assert_eq!(children[0].name(), "source_a");
+        assert_eq!(children[1].name(), "source_b");
+        assert_eq!(
+            mapped.partitions,
+            vec![HivePartitionField {
+                logical_name: "part".to_string(),
+                source_name: "part".to_string(),
+                data_type: DataType::Int32,
+            }]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_name_mapping_type() {
+        let error =
+            build_read_schema_with_name_mapping(&mapped_fields(), &name_mapping("map_by_position"))
+                .unwrap_err();
+        assert!(error.to_string().contains("map_by_position"));
+    }
+
+    #[test]
+    fn rejects_missing_name_mapping_parent() {
+        let mut mapping = name_mapping("map_by_name");
+        mapping.entries[2].parent_column = Some(999);
+        let error = build_read_schema_with_name_mapping(&mapped_fields(), &mapping).unwrap_err();
+        assert!(error.to_string().contains("missing parent_column 999"));
+    }
+
+    #[rstest]
+    fn name_mapping_uses_first_duplicate_entry() {
+        let mut mapping = name_mapping("map_by_name");
+        mapping.entries.push(DuckLakeNameMappingEntry {
+            column_id: 10,
+            source_name: "ignored_column_id_duplicate".to_string(),
+            target_field_id: 5,
+            parent_column: Some(999),
+            is_partition: false,
+        });
+        mapping.entries.push(DuckLakeNameMappingEntry {
+            column_id: 15,
+            source_name: "ignored_target_duplicate".to_string(),
+            target_field_id: 1,
+            parent_column: None,
+            is_partition: false,
+        });
+
+        let mapped = build_read_schema_with_name_mapping(&mapped_fields(), &mapping).unwrap();
+
+        assert_eq!(mapped.schema.field(0).name(), "source_id");
+        assert_eq!(mapped.partitions.len(), 1);
+    }
+
+    #[rstest]
+    fn mapped_nested_fields_use_read_compatible_nullability() {
+        let mut fields = mapped_fields();
+        fields[2].is_nullable = false;
+
+        let mapped =
+            build_read_schema_with_name_mapping(&fields, &name_mapping("map_by_name")).unwrap();
+        let DataType::Struct(children) = mapped.schema.field(1).data_type() else {
+            panic!("mapped nested must be a struct");
+        };
+
+        assert!(children[0].is_nullable());
+    }
+
+    #[rstest]
+    fn mapped_list_and_map_allow_omitted_children() {
+        let fields = vec![
+            DuckLakeTableField {
+                column_id: 1,
+                column_name: "items".to_string(),
+                column_type: "list".to_string(),
+                is_nullable: true,
+                parent_column: None,
+            },
+            DuckLakeTableField {
+                column_id: 2,
+                column_name: "element".to_string(),
+                column_type: "int32".to_string(),
+                is_nullable: true,
+                parent_column: Some(1),
+            },
+            DuckLakeTableField {
+                column_id: 3,
+                column_name: "properties".to_string(),
+                column_type: "map".to_string(),
+                is_nullable: true,
+                parent_column: None,
+            },
+            DuckLakeTableField {
+                column_id: 4,
+                column_name: "key".to_string(),
+                column_type: "varchar".to_string(),
+                is_nullable: true,
+                parent_column: Some(3),
+            },
+            DuckLakeTableField {
+                column_id: 5,
+                column_name: "value".to_string(),
+                column_type: "int32".to_string(),
+                is_nullable: true,
+                parent_column: Some(3),
+            },
+        ];
+        let mapping = DuckLakeNameMapping {
+            mapping_id: 1,
+            table_id: 1,
+            mapping_type: "map_by_name".to_string(),
+            entries: vec![
+                DuckLakeNameMappingEntry {
+                    column_id: 10,
+                    source_name: "source_items".to_string(),
+                    target_field_id: 1,
+                    parent_column: None,
+                    is_partition: false,
+                },
+                DuckLakeNameMappingEntry {
+                    column_id: 11,
+                    source_name: "source_properties".to_string(),
+                    target_field_id: 3,
+                    parent_column: None,
+                    is_partition: false,
+                },
+            ],
+        };
+
+        let mapped = build_read_schema_with_name_mapping(&fields, &mapping).unwrap();
+        let DataType::List(element) = mapped.schema.field(0).data_type() else {
+            panic!("items must be a list");
+        };
+        assert_eq!(element.name(), "__ducklake_absent_field_2");
+        assert!(element.is_nullable());
+        let DataType::Map(entries, _) = mapped.schema.field(1).data_type() else {
+            panic!("properties must be a map");
+        };
+        let DataType::Struct(children) = entries.data_type() else {
+            panic!("map entries must be a struct");
+        };
+        assert_eq!(children[0].name(), "__ducklake_absent_field_4");
+        assert!(!children[0].is_nullable());
+        assert_eq!(children[1].name(), "__ducklake_absent_field_5");
+        assert!(children[1].is_nullable());
+    }
 
     #[test]
     fn test_build_read_schema_with_renamed_columns() {

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -294,6 +294,183 @@ async fn run_merge(temp: &TempDir, opts: MergeOptions) -> CompactionResult {
     .await
 }
 
+#[cfg(feature = "metadata-duckdb")]
+fn create_official_mapped_compaction_fixture(temp: &TempDir) -> anyhow::Result<()> {
+    let data_path = temp.path().join("data");
+    let first_partition = data_path.join("part=7");
+    let second_partition = data_path.join("part=8");
+    std::fs::create_dir_all(&first_partition)?;
+    std::fs::create_dir_all(&second_partition)?;
+
+    let conn = duckdb::Connection::open_in_memory()?;
+    crate::common::ensure_ducklake_installed();
+    conn.execute("INSTALL sqlite", [])?;
+    conn.execute("LOAD sqlite", [])?;
+    conn.execute("LOAD ducklake", [])?;
+    conn.execute(
+        &format!(
+            "ATTACH 'ducklake:sqlite:{}' AS lake \
+             (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 0)",
+            temp.path().join("test.db").display(),
+            data_path.display()
+        ),
+        [],
+    )?;
+    conn.execute("CREATE TABLE lake.t(id INTEGER, part INTEGER)", [])?;
+    conn.execute(
+        &format!(
+            "COPY (SELECT 1 AS id) TO '{}' (FORMAT PARQUET)",
+            first_partition.join("first.parquet").display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "COPY (SELECT 2 AS id) TO '{}' (FORMAT PARQUET)",
+            second_partition.join("second.parquet").display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CALL ducklake_add_data_files(\
+                 'lake', 't', '{}/**/*.parquet', hive_partitioning => true\
+             )",
+            data_path.display()
+        ),
+        [],
+    )?;
+    conn.execute("DETACH lake", [])?;
+    Ok(())
+}
+
+#[cfg(feature = "metadata-duckdb")]
+async fn read_mapped_rows(temp: &TempDir) -> anyhow::Result<Vec<(i32, i32)>> {
+    let provider = SqliteMetadataProvider::new(&ro_url(temp)).await?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT id, part FROM ducklake.main.t ORDER BY id")
+        .await?
+        .collect()
+        .await?;
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let parts = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        rows.extend((0..batch.num_rows()).map(|row| (ids.value(row), parts.value(row))));
+    }
+    Ok(rows)
+}
+
+#[cfg(feature = "metadata-duckdb")]
+async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
+    let pool = pool(temp).await;
+    SqliteMetadataWriter::new_with_init(&db_url(temp)).await?;
+    let schema_version_columns = sqlx::query("PRAGMA table_info(ducklake_schema_versions)")
+        .fetch_all(&pool)
+        .await?;
+    if !schema_version_columns
+        .iter()
+        .any(|row| row.get::<String, _>(1) == "table_id")
+    {
+        // The pinned DuckDB 1.4.1 test extension predates the per-table column
+        // that released DuckDB 1.5.5 writes; keep the fixture shape equivalent
+        sqlx::query("ALTER TABLE ducklake_schema_versions ADD COLUMN table_id INTEGER")
+            .execute(&pool)
+            .await?;
+        sqlx::query(
+            "UPDATE ducklake_schema_versions
+             SET table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 't')",
+        )
+        .execute(&pool)
+        .await?;
+    }
+    let data_file_columns = sqlx::query("PRAGMA table_info(ducklake_data_file)")
+        .fetch_all(&pool)
+        .await?;
+    let data_file_id_type = data_file_columns
+        .iter()
+        .find(|row| row.get::<String, _>(1) == "data_file_id")
+        .map(|row| row.get::<String, _>(2))
+        .unwrap();
+    if data_file_id_type != "INTEGER" {
+        // SQLite auto-allocates only an exact INTEGER PRIMARY KEY; normalize the
+        // official BIGINT declaration to the crate writer's documented precondition
+        sqlx::query("ALTER TABLE ducklake_data_file RENAME TO ducklake_data_file__official")
+            .execute(&pool)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE ducklake_data_file (
+                data_file_id INTEGER PRIMARY KEY,
+                table_id INTEGER NOT NULL,
+                path VARCHAR NOT NULL,
+                path_is_relative BOOLEAN NOT NULL DEFAULT 1,
+                file_size_bytes INTEGER NOT NULL,
+                footer_size INTEGER,
+                encryption_key VARCHAR,
+                record_count INTEGER,
+                row_id_start INTEGER,
+                mapping_id INTEGER,
+                begin_snapshot INTEGER NOT NULL,
+                end_snapshot INTEGER,
+                partial_max INTEGER,
+                partition_id INTEGER
+            )",
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO ducklake_data_file (
+                data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                footer_size, encryption_key, record_count, row_id_start, mapping_id,
+                begin_snapshot, end_snapshot, partial_max, partition_id
+             )
+             SELECT data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                    footer_size, encryption_key, record_count, row_id_start, mapping_id,
+                    begin_snapshot, end_snapshot, partial_max, partition_id
+             FROM ducklake_data_file__official",
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query("DROP TABLE ducklake_data_file__official")
+            .execute(&pool)
+            .await?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "metadata-duckdb")]
+#[tokio::test(flavor = "multi_thread")]
+async fn mapped_hive_values_survive_merge_adjacent_files() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    create_official_mapped_compaction_fixture(&temp)?;
+    migrate_pinned_duckdb_fixture(&temp).await?;
+    assert_eq!(read_mapped_rows(&temp).await?, vec![(1, 7), (2, 8)]);
+
+    let result = run_merge(&temp, MergeOptions::default()).await;
+
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 2,
+            files_created: 1,
+            rows_written: 2,
+        }
+    );
+    assert_eq!(read_mapped_rows(&temp).await?, vec![(1, 7), (2, 8)]);
+    Ok(())
+}
+
 /// Run a merge with explicit table write options, as a catalog configured for a
 /// codec would produce.
 async fn run_merge_with_write_options(

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -47,6 +47,7 @@ mod multicatalog_postgres_tests;
 mod multicatalog_provider_tests;
 mod mysql_metadata_provider_test;
 mod mysql_metadata_writer_test;
+mod name_mapping_tests;
 mod nested_field_id_schema_tests;
 mod numeric_metadata_validation_tests;
 mod object_store_integration_test;

--- a/tests/it/multicatalog_provider_tests.rs
+++ b/tests/it/multicatalog_provider_tests.rs
@@ -27,6 +27,58 @@ async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)
     Ok((pool, container))
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn name_mapping_is_read_from_shared_metadata() -> anyhow::Result<()> {
+    let (pool, _container) = spin_up_postgres().await?;
+    sqlx::query(
+        "CREATE TABLE ducklake_column_mapping (
+            mapping_id BIGINT PRIMARY KEY,
+            table_id BIGINT NOT NULL,
+            type TEXT NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE ducklake_name_mapping (
+            mapping_id BIGINT NOT NULL,
+            column_id BIGINT NOT NULL,
+            source_name TEXT NOT NULL,
+            target_field_id BIGINT NOT NULL,
+            parent_column BIGINT,
+            is_partition BOOLEAN NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_column_mapping(mapping_id, table_id, type)
+         VALUES (7, 11, 'map_by_name')",
+    )
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_name_mapping(
+            mapping_id, column_id, source_name, target_field_id, parent_column, is_partition
+         ) VALUES
+            (7, 1, 'nested', 3, NULL, false),
+            (7, 2, 'child', 4, 1, false),
+            (7, 3, 'part', 5, NULL, true)",
+    )
+    .execute(&pool)
+    .await?;
+    let provider = MulticatalogProvider::with_pool_and_id(pool, 1).await?;
+
+    let mapping = provider.get_name_mapping(7)?;
+    assert_eq!(mapping.mapping_id, 7);
+    assert_eq!(mapping.table_id, 11);
+    assert_eq!(mapping.mapping_type, "map_by_name");
+    assert_eq!(mapping.entries.len(), 3);
+    assert!(mapping.entries[1].is_partition);
+    assert_eq!(mapping.entries[2].parent_column, Some(1));
+    Ok(())
+}
+
 fn users_cols() -> Vec<ColumnDef> {
     vec![
         ColumnDef::new("id", "int64", false).unwrap(),

--- a/tests/it/mysql_metadata_provider_test.rs
+++ b/tests/it/mysql_metadata_provider_test.rs
@@ -43,6 +43,28 @@ async fn init_schema(pool: &MySqlPool) -> anyhow::Result<()> {
     .await?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_column_mapping (
+            mapping_id BIGINT PRIMARY KEY,
+            table_id BIGINT NOT NULL,
+            type VARCHAR(255) NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_name_mapping (
+            mapping_id BIGINT NOT NULL,
+            column_id BIGINT NOT NULL,
+            source_name TEXT NOT NULL,
+            target_field_id BIGINT NOT NULL,
+            parent_column BIGINT,
+            is_partition BOOLEAN NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_schema (
             schema_id BIGINT PRIMARY KEY,
             schema_name VARCHAR(255) NOT NULL,
@@ -810,6 +832,36 @@ async fn test_get_table_structure() {
 
     assert_eq!(columns[2].column_name, "email");
     assert_eq!(columns[2].column_type, "varchar");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_name_mapping() -> anyhow::Result<()> {
+    let (provider, _container) = create_mysql_provider().await?;
+    sqlx::query(
+        "INSERT INTO ducklake_column_mapping(mapping_id, table_id, type)
+         VALUES (7, 1, 'map_by_name')",
+    )
+    .execute(&provider.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_name_mapping(
+            mapping_id, column_id, source_name, target_field_id, parent_column, is_partition
+         ) VALUES
+            (7, 1, 'nested', 3, NULL, false),
+            (7, 2, 'child', 4, 1, false),
+            (7, 3, 'part', 5, NULL, true)",
+    )
+    .execute(&provider.pool)
+    .await?;
+
+    let mapping = provider.get_name_mapping(7)?;
+    assert_eq!(mapping.mapping_id, 7);
+    assert_eq!(mapping.table_id, 1);
+    assert_eq!(mapping.mapping_type, "map_by_name");
+    assert_eq!(mapping.entries.len(), 3);
+    assert!(mapping.entries[1].is_partition);
+    assert_eq!(mapping.entries[2].parent_column, Some(1));
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/name_mapping_tests.rs
+++ b/tests/it/name_mapping_tests.rs
@@ -1,0 +1,328 @@
+#![cfg(feature = "metadata-duckdb")]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Decimal128Array, Int32Array, StringArray};
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, Column, Literal};
+use datafusion::prelude::SessionContext;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTable, DuckdbMetadataProvider, MetadataProvider,
+    register_ducklake_functions,
+};
+use rstest::rstest;
+use tempfile::TempDir;
+
+#[derive(Debug, PartialEq, Eq)]
+struct MappedRow {
+    id: i32,
+    name: String,
+    nested_a: i32,
+    nested_b: String,
+    part: i32,
+}
+
+fn create_name_mapping_catalog(
+    catalog_path: &Path,
+    data_path: &Path,
+) -> anyhow::Result<Vec<MappedRow>> {
+    let first_hive_path = data_path.join("part=9");
+    let second_hive_path = data_path.join("part=10");
+    std::fs::create_dir_all(&first_hive_path)?;
+    std::fs::create_dir_all(&second_hive_path)?;
+    let first_parquet_path = first_hive_path.join("mapped.parquet");
+    let second_parquet_path = second_hive_path.join("mapped.parquet");
+
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake", [])?;
+    conn.execute("LOAD ducklake", [])?;
+    conn.execute("INSTALL parquet", [])?;
+    conn.execute(
+        &format!(
+            "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 0)",
+            catalog_path.display(),
+            data_path.display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE lake.mapped(
+            source_id INTEGER,
+            source_name VARCHAR,
+            nested STRUCT(a INTEGER, b VARCHAR),
+            part INTEGER
+        )",
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "COPY (
+                SELECT {{'b': 'nested', 'a': 7}} AS nested,
+                       42 AS source_id,
+                       'value' AS source_name
+             ) TO '{}' (FORMAT PARQUET)",
+            first_parquet_path.display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "COPY (
+                SELECT {{'b': 'second', 'a': 8}} AS nested,
+                       43 AS source_id,
+                       'next' AS source_name
+             ) TO '{}' (FORMAT PARQUET)",
+            second_parquet_path.display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CALL ducklake_add_data_files(
+                'lake', 'mapped', '{}/**/*.parquet', hive_partitioning => true
+            )",
+            data_path.display()
+        ),
+        [],
+    )?;
+    conn.execute("ALTER TABLE lake.mapped RENAME COLUMN source_id TO id", [])?;
+    conn.execute(
+        "ALTER TABLE lake.mapped RENAME COLUMN source_name TO name",
+        [],
+    )?;
+
+    let mut statement = conn.prepare(
+        "SELECT id, name, nested.a, nested.b, part
+         FROM lake.mapped
+         WHERE nested.a >= 7 AND part IN (9, 10)
+         ORDER BY id",
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(MappedRow {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                nested_a: row.get(2)?,
+                nested_b: row.get(3)?,
+                part: row.get(4)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+#[tokio::test]
+async fn add_data_files_name_mapping_matches_duckdb() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    let catalog_path = temp.path().join("mapping.ducklake");
+    let data_path = temp.path().join("data");
+    let expected = create_name_mapping_catalog(&catalog_path, &data_path)?;
+    assert_eq!(
+        expected,
+        vec![
+            MappedRow {
+                id: 42,
+                name: "value".to_string(),
+                nested_a: 7,
+                nested_b: "nested".to_string(),
+                part: 9,
+            },
+            MappedRow {
+                id: 43,
+                name: "next".to_string(),
+                nested_a: 8,
+                nested_b: "second".to_string(),
+                part: 10,
+            },
+        ]
+    );
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+    let function_provider: Arc<dyn MetadataProvider> =
+        Arc::new(DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?);
+    register_ducklake_functions(&context, function_provider);
+
+    let batches = context
+        .sql(
+            "SELECT id, name, nested.a, nested.b, part
+             FROM ducklake.main.mapped
+             WHERE nested.a >= 7 AND part IN (9, 10)
+             ORDER BY id",
+        )
+        .await?
+        .collect()
+        .await?;
+    let mut actual = Vec::new();
+    for batch in batches {
+        let id = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let name = arrow::compute::cast(batch.column(1), &arrow::datatypes::DataType::Utf8)?;
+        let name = name.as_any().downcast_ref::<StringArray>().unwrap();
+        let nested_a = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let nested_b = arrow::compute::cast(batch.column(3), &arrow::datatypes::DataType::Utf8)?;
+        let nested_b = nested_b.as_any().downcast_ref::<StringArray>().unwrap();
+        let part = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            actual.push(MappedRow {
+                id: id.value(row),
+                name: name.value(row).to_string(),
+                nested_a: nested_a.value(row),
+                nested_b: nested_b.value(row).to_string(),
+                part: part.value(row),
+            });
+        }
+    }
+    assert_eq!(actual, expected);
+
+    let table_provider = context
+        .catalog("ducklake")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table("mapped")
+        .await?
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .unwrap();
+    let mapped_file = table
+        .files()?
+        .into_iter()
+        .find(|file| file.file.path.contains("part=10"))
+        .unwrap();
+    let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+        Arc::new(Column::new("part", 3)),
+        Operator::Eq,
+        Arc::new(Literal::new(datafusion::common::ScalarValue::Int32(Some(
+            10,
+        )))),
+    ));
+    let positions = table
+        .resolve_positions(&context.state(), &mapped_file.file, predicate)
+        .await?;
+    assert_eq!(positions, [0].into_iter().collect());
+
+    let batches = context
+        .sql(
+            "SELECT id, part
+             FROM ducklake_table_insertions('main.mapped', 0, 1000)
+             ORDER BY id",
+        )
+        .await?
+        .collect()
+        .await?;
+    let mut changes = Vec::new();
+    for batch in batches {
+        let id = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let part = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            changes.push((id.value(row), part.value(row)));
+        }
+    }
+    assert_eq!(changes, vec![(42, 9), (43, 10)]);
+
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn add_data_files_accepts_duckdb_numeric_hive_literals() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    let catalog_path = temp.path().join("numeric-mapping.ducklake");
+    let data_path = temp.path().join("data");
+    let partition_path = data_path.join("p=0x10").join("amount=1e2");
+    std::fs::create_dir_all(&partition_path)?;
+    let parquet_path = partition_path.join("mapped.parquet");
+
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake", [])?;
+    conn.execute("LOAD ducklake", [])?;
+    conn.execute(
+        &format!(
+            "ATTACH 'ducklake:{}' AS lake \
+             (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 0)",
+            catalog_path.display(),
+            data_path.display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE lake.numeric_mapped(
+            id INTEGER,
+            p INTEGER,
+            amount DECIMAL(10,2)
+        )",
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "COPY (SELECT 1 AS id) TO '{}' (FORMAT PARQUET)",
+            parquet_path.display()
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CALL ducklake_add_data_files(
+                'lake', 'numeric_mapped', '{}/**/*.parquet', hive_partitioning => true
+            )",
+            data_path.display()
+        ),
+        [],
+    )?;
+    let expected: (i32, String) = conn.query_row(
+        "SELECT p, CAST(amount AS VARCHAR) FROM lake.numeric_mapped",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(expected, (16, "100.00".to_string()));
+    conn.execute("DETACH lake", [])?;
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+    let batches = context
+        .sql("SELECT p, amount FROM ducklake.main.numeric_mapped")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(batches.len(), 1);
+    let p = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let amount = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<Decimal128Array>()
+        .unwrap();
+    assert_eq!(p.values(), &[16]);
+    assert_eq!(amount.values(), &[10_000]);
+    Ok(())
+}

--- a/tests/it/postgres_metadata_provider_test.rs
+++ b/tests/it/postgres_metadata_provider_test.rs
@@ -43,6 +43,28 @@ async fn init_schema(pool: &PgPool) -> anyhow::Result<()> {
     .await?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_column_mapping (
+            mapping_id BIGINT PRIMARY KEY,
+            table_id BIGINT NOT NULL,
+            type TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_name_mapping (
+            mapping_id BIGINT NOT NULL,
+            column_id BIGINT NOT NULL,
+            source_name TEXT NOT NULL,
+            target_field_id BIGINT NOT NULL,
+            parent_column BIGINT,
+            is_partition BOOLEAN NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_schema (
             schema_id BIGINT PRIMARY KEY,
             schema_name VARCHAR NOT NULL,
@@ -838,6 +860,36 @@ async fn test_get_table_structure() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_get_name_mapping() -> anyhow::Result<()> {
+    let (provider, _container) = create_postgres_provider().await?;
+    sqlx::query(
+        "INSERT INTO ducklake_column_mapping(mapping_id, table_id, type)
+         VALUES (7, 1, 'map_by_name')",
+    )
+    .execute(&provider.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_name_mapping(
+            mapping_id, column_id, source_name, target_field_id, parent_column, is_partition
+         ) VALUES
+            (7, 1, 'nested', 3, NULL, false),
+            (7, 2, 'child', 4, 1, false),
+            (7, 3, 'part', 5, NULL, true)",
+    )
+    .execute(&provider.pool)
+    .await?;
+
+    let mapping = provider.get_name_mapping(7)?;
+    assert_eq!(mapping.mapping_id, 7);
+    assert_eq!(mapping.table_id, 1);
+    assert_eq!(mapping.mapping_type, "map_by_name");
+    assert_eq!(mapping.entries.len(), 3);
+    assert!(mapping.entries[1].is_partition);
+    assert_eq!(mapping.entries[2].parent_column, Some(1));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "provider-test fixture drift vs current schema; fixed with the provider rework"]
 async fn test_get_table_files_for_select() {
     let (provider, _container) = create_postgres_provider().await.unwrap();
@@ -1142,7 +1194,8 @@ async fn migrate_fixture_to_current_schema(pool: &PgPool) -> anyhow::Result<()> 
              ADD COLUMN IF NOT EXISTS begin_snapshot BIGINT NOT NULL DEFAULT 1,
              ADD COLUMN IF NOT EXISTS end_snapshot BIGINT,
              ADD COLUMN IF NOT EXISTS partial_max BIGINT,
-             ADD COLUMN IF NOT EXISTS partition_id BIGINT",
+             ADD COLUMN IF NOT EXISTS partition_id BIGINT,
+             ADD COLUMN IF NOT EXISTS mapping_id BIGINT",
     )
     .execute(pool)
     .await?;

--- a/tests/it/sqlite_metadata_provider_test.rs
+++ b/tests/it/sqlite_metadata_provider_test.rs
@@ -41,6 +41,28 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     .await?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_column_mapping (
+            mapping_id INTEGER PRIMARY KEY,
+            table_id INTEGER NOT NULL,
+            type TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_name_mapping (
+            mapping_id INTEGER NOT NULL,
+            column_id INTEGER NOT NULL,
+            source_name TEXT NOT NULL,
+            target_field_id INTEGER NOT NULL,
+            parent_column INTEGER,
+            is_partition INTEGER NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_schema (
             schema_id INTEGER PRIMARY KEY,
             schema_name TEXT NOT NULL,
@@ -799,6 +821,54 @@ async fn test_get_table_structure() {
     assert_eq!(columns[2].column_name, "email");
     assert_eq!(columns[2].column_type, "varchar");
     assert!(columns[2].is_nullable);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_name_mapping() -> anyhow::Result<()> {
+    let provider = create_sqlite_provider().await?;
+    populate_test_data(&provider).await?;
+    sqlx::query(
+        "INSERT INTO ducklake_column_mapping(mapping_id, table_id, type)
+         VALUES (7, 1, 'map_by_name')",
+    )
+    .execute(&provider.pool)
+    .await?;
+    sqlx::query("UPDATE ducklake_data_file SET mapping_id = 7 WHERE table_id = 1")
+        .execute(&provider.pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_name_mapping(
+            mapping_id, column_id, source_name, target_field_id, parent_column, is_partition
+         ) VALUES
+            (7, 1, 'nested', 3, NULL, 0),
+            (7, 2, 'child', 4, 1, 0),
+            (7, 3, 'part', 5, NULL, 1)",
+    )
+    .execute(&provider.pool)
+    .await?;
+
+    let mapping = provider.get_name_mapping(7)?;
+    assert_eq!(mapping.mapping_id, 7);
+    assert_eq!(mapping.table_id, 1);
+    assert_eq!(mapping.mapping_type, "map_by_name");
+    assert_eq!(mapping.entries.len(), 3);
+    assert_eq!(mapping.entries[1].parent_column, None);
+    assert!(mapping.entries[1].is_partition);
+    assert_eq!(mapping.entries[2].parent_column, Some(1));
+    let files = provider.get_table_files_for_select(1, 2)?;
+    assert!(!files.is_empty());
+    assert!(files.iter().all(|file| file.file.mapping_id == Some(7)));
+
+    sqlx::query(
+        "INSERT INTO ducklake_column_mapping(mapping_id, table_id, type)
+         VALUES (8, 1, 'map_by_name')",
+    )
+    .execute(&provider.pool)
+    .await?;
+    let error = provider.get_name_mapping(8).unwrap_err();
+    assert!(error.to_string().contains("does not exist"));
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
### Summary

Read `ducklake_column_mapping` and `ducklake_name_mapping` through every metadata provider and carry
each data file's `mapping_id`, physical schema, renames, and Hive constants through every file
consumer. Ordinary scans, predicate-based DELETE/UPDATE position resolution, compaction rewrites,
and change feeds now agree after top-level or nested renames. Recursive Map/List adaptation remains
Arrow-valid, and Hive NULL directory values match the shipping DuckDB extension.

Hive discovery now ports DuckDB 1.5.5's raw path-segment parser instead of passing object keys
through a URL parser. Hexadecimal integer and exponent-form decimal partition values accepted by
`ducklake_add_data_files` are normalized before Arrow conversion. A destructive SQLite regression
compacts two mapped Hive files and proves the replacement still returns their exact partition values.

### Name mapping flow

```mermaid
flowchart LR
    DataFile["ducklake_data_file<br/>mapping_id"] --> Cache["Mapping cache<br/>keyed by mapping_id"]
    ColumnMapping["ducklake_column_mapping<br/>map_by_name"] --> Cache
    NameMapping["ducklake_name_mapping<br/>source and target fields"] --> Tree["Validated mapping tree"]
    Columns["ducklake_column<br/>recursive field tree"] --> Tree
    Cache --> Tree
    Tree --> Physical["Per-file physical schema"]
    Hive["Hive path<br/>partition=value"] --> Constants["Typed partition constants"]
    Physical --> Config["Per-file read configuration"]
    Constants --> Config
    Config --> Scan["SELECT"]
    Config --> Mutation["DELETE / UPDATE / compaction"]
    Config --> CDC["Change feeds"]
    Scan --> Logical["Catalog schema and field IDs"]
    Mutation --> Logical
    CDC --> Logical
```

The mapping-derived configuration feeds every consumer of a data file.

### Contract

- Select each visible data file's nullable `mapping_id` on every provider and preserve `None` for
  delete files and ordinary field‑ID files.
- Load complete recursive `ducklake_column` rows, including `parent_column`, before building the
  logical Arrow schema.
- Accept only the specified `map_by_name` mapping type and return explicit errors for unknown
  types or missing mapping IDs.
- Match the reference implementation's first-wins handling for duplicate mapping rows and treat
  omitted recursive children as absent fields; reject missing parents, cycles, and invalid table
  shapes before planning a scan.
- Treat a data file's `mapping_id` as authoritative, including when its Parquet schema also
  contains field IDs.
- Resolve top‑level and nested physical names through `source_name`, then expose the current
  catalog names and target field IDs to DataFusion.
- Fill catalog fields absent from an older mapping with their typed initial default or typed null.
- Scan raw Hive object keys with DuckDB's slash/backslash separators and candidate-invalidation
  rules; compare raw keys and percent-decode only values.
- Decode case-insensitive `NULL`, empty non-string values, and `__HIVE_DEFAULT_PARTITION__` as typed
  NULL; normalize hexadecimal integers and exponent-form decimals before Arrow conversion.
- Keep mapping objects cached by immutable `mapping_id` across scans and catalog clones.
- Disable unsafe predicate pushdown when a predicate references a renamed, absent, or Hive-derived
  column in the actual mapped schema.
- Preserve `mapping_id` in non-exhaustive, default-constructible `DataFileChange` values so all
  metadata backends adapt CDC data files; fail when a mapping header has no name rows rather than
  returning an all-NULL table.
- Keep Map keys non-nullable and make nested read fields nullable where schema evolution can omit them.
- Reject nested `is_partition` fields explicitly until recursive constant synthesis is supported;
  DuckDB's writer does not emit this third-party-catalog shape, while top-level mapped partition
  fields work across every file consumer.

### DuckLake semantics

`ducklake_column_mapping` identifies the mapping assigned to a file. The stable specification
defines `map_by_name` as the mapping method for Parquet fields that do not contain field IDs.
`ducklake_name_mapping` then associates each physical `source_name` with a stable
`target_field_id`; `parent_column` represents nested field paths, and `is_partition` marks values
provided by Hive partition paths instead of the file schema.

The `mapping_id` stored on `ducklake_data_file` selects the mapping for that individual file. This
is a per‑file compatibility contract: later catalog renames must not change how an older file's
physical names resolve. The implementation therefore plans each mapped file against its own
immutable mapping rather than falling back to current name coincidence.

### Commit and branch

- Branch: `ducklake-name-mapping-pr`.
- Commit: `6fea1771f837e23b4f5e577e486d53fc32f4b4aa feat: resolve DuckLake name mappings`.
- Base: upstream `main` at `662bda9098447dc2673177842c4173622ccc3910`.
- Preceding PR: none. PR #262 is already merged into the upstream base.
- Shape: one commit over current upstream `main`.
- Remote: `ata/ducklake-name-mapping-pr`.
- Pull request: [#263](https://github.com/datafusion-contrib/datafusion-ducklake/pull/263).

### Verification

- 2026-09-02 second-review gate: 419 library tests, 431 integration tests with 200 expected
  service-gated ignores, and 8 doctests passed. The focused mapping suite passed 4 unit tests and
  6 integration tests; 16 raw-path/numeric cases and the destructive mapped-Hive compaction
  regression passed. Formatting, all-test/all-feature compilation, warnings-denied
  all-target/all-feature Clippy, strict OpenSpec, PR-summary Markdown, and Mermaid checks passed.
- 2026-09-02 review-hardening gate: formatting, all-test/all-feature compilation,
  warnings-denied all-target/all-feature Clippy, 429 tests with 200 expected service-gated
  ignores, and 8 doctests passed. The focused mapping suite passed 4 unit tests and 5 integration
  tests; the internal-position-name collision regression also passed. Strict OpenSpec validation,
  PR-summary Markdown lint, and Mermaid lint passed.
- 2026-08-31 one-commit rebase gate: all-target/all-feature compilation and the focused `cargo test --all-features name_mapping` suite passed.
- 2026-08-29 cumulative rebase gate at `976ded1873c7d6877c7138ff63aa8c3143035aa2`:
  formatting, all-target/all-feature workspace check, strict Clippy, 391 library tests,
  405 integration tests with 3 expected ignores, and 8 doctests passed.
- 2026-08-25 rebase gate: formatting, all-target/all-feature compile, strict Clippy, and
  `cargo test --all-features name_mapping` passed.
- `cargo fmt --all -- --check`: passed.
- `CARGO_BUILD_JOBS=8 cargo check --tests --all-features`: passed.
- `CARGO_BUILD_JOBS=8 cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=8 cargo doc --all-features --no-deps`: passed.
- `CARGO_BUILD_JOBS=8 cargo test --all-features name_mapping -- --nocapture`: passed, with 4 unit
  tests and 5 integration tests, including the DuckDB oracle and all metadata backends.
- `CARGO_BUILD_JOBS=8 cargo test --all-features renamed_columns_tests`: passed, 13 tests.
- Exact list round‑trip tests for list, list‑of‑struct, and struct/list/map values: passed.
- `CARGO_BUILD_JOBS=8 cargo test --all-features column_rename`: passed, 6 tests.
- Live PostgreSQL, MySQL, and multicatalog PostgreSQL name‑mapping reads: passed.
- `cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres
  metadata-sqlite write-sqlite"`: passed, 368 unit tests, 393 integration tests, and 8 doc tests;
  15 integration tests were ignored. The current-schema PostgreSQL fixture includes the nullable
  `mapping_id` selected by Group 4.
- `git diff --check`: passed.

### Specification proof

| DuckLake rule                                                                                                                                                                              | Implementation invariant                                                                                                                                                          | Discriminating proof                                                                                                                                                                                                       |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`ducklake_column_mapping`](https://ducklake.select/docs/stable/specification/tables/ducklake_column_mapping.html) defines `map_by_name` for Parquet files without field IDs.              | Every provider reads the mapping header and entries; unsupported mapping types and unknown IDs fail explicitly rather than reverting to current column names.                     | `rejects_unknown_name_mapping_type`, provider‑specific `test_get_name_mapping` cases, and the official `ducklake_add_data_files` oracle exercise the accepted and rejected paths.                                          |
| [`ducklake_name_mapping`](https://ducklake.select/docs/stable/specification/tables/ducklake_name_mapping) maps `source_name` to `target_field_id`, with `parent_column` for nested fields. | `NameMappingTree` and `TableFieldTree` reconstruct both hierarchies, validate their shape, and recursively adapt struct, list, and map fields to the current catalog schema.      | `builds_recursive_name_mapping_schema` asserts the exact nested Arrow schema; `rejects_missing_name_mapping_parent` proves malformed chains do not silently flatten; the oracle reorders nested struct fields.             |
| Each [`ducklake_data_file.mapping_id`](https://ducklake.select/docs/stable/specification/tables/ducklake_data_file) selects the mapping for that file.                                     | Scan planning carries `mapping_id` from metadata to the file group and caches the immutable mapping by ID; mapped files never use the name‑coincidence fallback.                  | The official fixture registers two field‑ID‑less Parquet files, renames their catalog columns later, and returns exact rows through DuckDB and DataFusion. Backend tests also assert that file metadata retains `Some(7)`. |
| [`ducklake_name_mapping.is_partition`](https://ducklake.select/docs/stable/specification/tables/ducklake_name_mapping) marks a Hive‑partitioned source field.                              | The scan extracts path components, percent‑decodes them, casts them to the catalog type, supports the Hive null marker, and groups files by their constant values.                | `add_data_files_name_mapping_matches_duckdb` reads exact partition values `9` and `10` from distinct paths and applies a filtered nested‑field and partition projection with identical DuckDB results.                     |
| [`ducklake_add_data_files`](https://ducklake.select/docs/stable/duckdb/metadata/adding_files) registers existing Parquet files while keeping DuckLake transactional semantics.             | Registration metadata drives the physical‑to‑logical rewrite without copying or rewriting source files; fields absent from a mapping retain the existing default/null adaptation. | The integration fixture is created entirely through the official extension's `ducklake_add_data_files` procedure, then read through a separately attached DataFusion catalog.                                              |

| [`ducklake_name_mapping.is_partition`](https://ducklake.select/docs/stable/specification/tables/ducklake_name_mapping) supplies a column from its Hive path. | One mapped configuration supplies typed constants to scans, position resolution, rewrites, compaction, and CDC. | `add_data_files_name_mapping_matches_duckdb` proves filtered position resolution and insertion feeds preserve exact partition values; `hive_partition_values_match_duckdb` pins NULL cases. |
| [`ducklake_name_mapping`](https://ducklake.select/docs/stable/specification/tables/ducklake_name_mapping) stores recursive source and target fields. | First duplicate entries win, omitted children become absent fields, Map keys stay non-nullable, and other nested read fields permit schema-evolution NULLs. | `name_mapping_uses_first_duplicate_entry`, `mapped_list_and_map_allow_omitted_children`, and `mapped_nested_fields_use_read_compatible_nullability` discriminate these cases. |

| DuckDB 1.5.5 [`HivePartitioning::Parse`](https://github.com/duckdb/duckdb/blob/v1.5.5/src/common/hive_partitioning.cpp) scans raw file names and decodes only partition values. | Hive discovery ports the same separator, candidate, equals-sign, raw-key, and value-decoding decisions without URL normalization. | `hive_partition_path_parsing_matches_duckdb` and `hive_partition_path_rejects_non_candidates` cover backslashes, fragments, later segments after query markers, encoded keys and values, and multiple equals signs. |
| [`ducklake_add_data_files`](https://ducklake.select/docs/stable/duckdb/metadata/adding_files) accepts source-system Hive paths whose numeric text DuckDB can cast. | Hexadecimal integer and exponent-form decimal values are normalized exactly before the existing typed Arrow conversion. | `add_data_files_accepts_duckdb_numeric_hive_literals` has DuckDB register `p=0x10/amount=1e2`, then proves DuckDB and DataFusion return exact 16 and 100.00; unit cases also cover `1.25e-1`. |
| [`ducklake_name_mapping.is_partition`](https://ducklake.select/docs/stable/specification/tables/ducklake_name_mapping) remains part of a rewrite's logical rows. | Compaction materializes each source file's mapped constant before writing the replacement and retiring its sources. | `mapped_hive_values_survive_merge_adjacent_files` registers two field-ID-less Hive files, compacts them from two sources to one output, and re-reads exact values 7 and 8. |

### Reference implementation

The official DuckLake source reads the mapping header and flattened entries, accepts only
`map_by_name`, and rebuilds the recursive tree from `parent_column` links
([metadata load](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L4220-L4249),
[tree conversion](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_catalog.cpp#L701-L735)).
For each file, it selects the mapping by `mapping_id`, resolves catalog field IDs to physical
`source_name` values recursively, and replaces Hive‑partitioned fields with typed constants from
the file path
([per‑file mapping](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_multi_file_reader.cpp#L455-L519),
[mapping selection](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_multi_file_reader.cpp#L547-L558)).
DuckDB 1.5.5 discovers Hive fields by scanning the raw filename and casts decoded values through
its numeric conversion rules
([path parsing and conversion](https://github.com/duckdb/duckdb/blob/v1.5.5/src/common/hive_partitioning.cpp)).
The branch follows the supported recursive-name and top-level partition semantics across every
metadata backend and every data-file consumer. Nested `is_partition` remains an explicit error.
Like the reference implementation, duplicate rows use their first entry and omitted recursive
children remain absent; unsupported mapping types, missing rows, missing parents, and cycles fail.

### Upstream readiness

The patch extends existing metadata-provider, Arrow-schema adaptation, mutation-read, and CDC
paths. It adds no Nautilus-specific API, runtime dependency, data format, or write API. Provider
differences remain confined to placeholder syntax and dialect-safe ordering. The branch is one
commit above upstream `main` and has no prerequisite branch.
