### PR TITLE
Expose DuckLake views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add read-only DuckLake views across metadata backends and writer-compatible view metadata (#264).
+
 ### Fixed
 
 - `files_matching` prunes a data file that carries a delete file. Its recorded

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -130,6 +130,7 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | Parquet footer size hints (1 read/file instead of 2)    |   ✅   |
 | Row lineage (`rowid` virtual column, opt-in)            |   ✅   |
 | SQL-queryable `information_schema`                      |   ✅   |
+| Read-only DuckLake views on every metadata backend      |   🟧   |
 | Table functions (`ducklake_snapshots()`, `ducklake_table_info()`, `ducklake_list_files()`, `ducklake_table_changes()`, `ducklake_table_deletions()`, `ducklake_table_insertions()`) | ✅ |
 | Maintenance: expire snapshots, cleanup superseded files, orphan-file reclamation | ✅ |
 | Parquet Modular Encryption (PME) reads (feature `encryption`) | ✅ |
@@ -141,6 +142,28 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 
 Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` module and
 `MetadataWriter`), not SQL DDL.
+
+### Views
+
+Every metadata backend reads snapshot-visible rows from `ducklake_view`. Catalogs without that
+table expose an empty view set, and each writer creates the official table layout, including
+`view_uuid`. Creating, replacing, altering, or dropping views is not supported.
+
+DataFusion plans each stored definition using its recorded dialect. The reader restores DuckLake's
+`{DUCKLAKE_CATALOG}` placeholder outside quoted strings and identifiers. For DuckDB
+`schema.table` bodies, it resolves only a unique schema visible at the view's `begin_snapshot`
+whose `schema_id` remains visible at the requested snapshot, then quotes the canonical schema name.
+This supports same-schema, cross-schema, and mixed-case references without letting an external
+qualifier retarget a schema created later. Other multipart qualifiers fail with the named view and
+dialect error. This disambiguation assumes metadata created through DuckDB's view binder; manually
+inserted definitions that violate its ambiguity checks are outside the compatibility guarantee.
+
+A definition that DataFusion cannot plan remains visible in view listings. Such a view has no rows
+in DataFusion's `information_schema.columns` until its definition becomes plannable.
+
+View planning uses a private, snapshot-pinned `SessionContext`, rejects DDL, DML, and statement
+commands, and propagates the catalog's row-lineage option. Caller-registered UDFs and caller session
+settings, including `execution.time_zone`, are not inherited.
 
 ---
 

--- a/src/information_schema.rs
+++ b/src/information_schema.rs
@@ -303,6 +303,94 @@ impl TableProvider for TablesTable {
     }
 }
 
+/// Live table provider for views.
+#[derive(Debug)]
+pub struct ViewsTable {
+    provider: Arc<dyn MetadataProvider>,
+    schema: SchemaRef,
+}
+
+impl ViewsTable {
+    pub fn new(provider: Arc<dyn MetadataProvider>) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("snapshot_id", DataType::Int64, false),
+            Field::new("schema_name", DataType::Utf8, false),
+            Field::new("view_id", DataType::Int64, false),
+            Field::new("view_name", DataType::Utf8, false),
+            Field::new("dialect", DataType::Utf8, false),
+            Field::new("sql", DataType::Utf8, false),
+            Field::new("column_aliases", DataType::Utf8, true),
+        ]));
+        Self {
+            provider,
+            schema,
+        }
+    }
+
+    fn query_views(&self) -> DataFusionResult<RecordBatch> {
+        let snapshot_id = self
+            .provider
+            .get_current_snapshot()
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        let views = self
+            .provider
+            .list_all_views(snapshot_id)
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(Int64Array::from(vec![snapshot_id; views.len()])),
+                Arc::new(StringArray::from_iter_values(
+                    views.iter().map(|view| view.schema_name.as_str()),
+                )),
+                Arc::new(Int64Array::from_iter_values(
+                    views.iter().map(|view| view.view.view_id),
+                )),
+                Arc::new(StringArray::from_iter_values(
+                    views.iter().map(|view| view.view.view_name.as_str()),
+                )),
+                Arc::new(StringArray::from_iter_values(
+                    views.iter().map(|view| view.view.dialect.as_str()),
+                )),
+                Arc::new(StringArray::from_iter_values(
+                    views.iter().map(|view| view.view.sql.as_str()),
+                )),
+                Arc::new(StringArray::from(
+                    views
+                        .iter()
+                        .map(|view| view.view.column_aliases.as_deref())
+                        .collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for ViewsTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[datafusion::prelude::Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let batch = self.query_views()?;
+        let mem_table = MemTable::try_new(Arc::clone(&self.schema), vec![vec![batch]])?;
+        mem_table.scan(state, projection, filters, limit).await
+    }
+}
+
 /// Live table provider for columns - queries metadata on every scan
 #[derive(Debug)]
 pub struct ColumnsTable {
@@ -704,6 +792,7 @@ impl SchemaProvider for InformationSchemaProvider {
             "snapshots".to_string(),
             "schemata".to_string(),
             "tables".to_string(),
+            "views".to_string(),
             "table_info".to_string(),
             "columns".to_string(),
             "files".to_string(),
@@ -716,6 +805,7 @@ impl SchemaProvider for InformationSchemaProvider {
             "snapshots" => Some(Arc::new(SnapshotsTable::new(self.provider.clone()))),
             "schemata" => Some(Arc::new(SchemataTable::new(self.provider.clone()))),
             "tables" => Some(Arc::new(TablesTable::new(self.provider.clone()))),
+            "views" => Some(Arc::new(ViewsTable::new(self.provider.clone()))),
             "table_info" => Some(Arc::new(TableInfoTable::new(self.provider.clone()))),
             "columns" => Some(Arc::new(ColumnsTable::new(self.provider.clone()))),
             "files" => Some(Arc::new(FilesTable::new(self.provider.clone()))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod table_changes;
 pub mod table_deletions;
 pub mod table_functions;
 pub mod types;
+pub(crate) mod view;
 
 // Metadata providers (feature-gated)
 #[cfg(feature = "metadata-duckdb")]

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -23,6 +23,19 @@ pub const SQL_LIST_TABLES: &str =
        AND ? >= begin_snapshot
        AND (? < end_snapshot OR end_snapshot IS NULL)";
 
+pub const SQL_LIST_VIEWS: &str =
+    "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases FROM ducklake_view
+     WHERE schema_id = ?
+       AND ? >= begin_snapshot
+       AND (? < end_snapshot OR end_snapshot IS NULL)";
+
+pub const SQL_GET_VIEW_BY_NAME: &str =
+    "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases FROM ducklake_view
+     WHERE schema_id = ?
+       AND view_name = ?
+       AND ? >= begin_snapshot
+       AND (? < end_snapshot OR end_snapshot IS NULL)";
+
 pub const SQL_GET_TABLE_COLUMNS: &str =
     "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
      FROM ducklake_column
@@ -292,6 +305,17 @@ pub const SQL_LIST_ALL_TABLES: &str = "
       AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
     ORDER BY s.schema_name, t.table_name";
 
+pub const SQL_LIST_ALL_VIEWS: &str = "
+    SELECT s.schema_name, v.view_id, v.schema_id, v.begin_snapshot, v.view_name, v.dialect, v.sql,
+           v.column_aliases
+    FROM ducklake_schema s
+    JOIN ducklake_view v ON s.schema_id = v.schema_id
+    WHERE ? >= s.begin_snapshot
+      AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
+      AND ? >= v.begin_snapshot
+      AND (? < v.end_snapshot OR v.end_snapshot IS NULL)
+    ORDER BY s.schema_name, v.view_name";
+
 pub const SQL_LIST_ALL_COLUMNS: &str = "
     SELECT
         s.schema_name,
@@ -479,6 +503,34 @@ pub struct TableWithSchema {
     pub schema_name: String,
     /// Table metadata
     pub table: TableMetadata,
+}
+
+/// Metadata for a view in the DuckLake catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewMetadata {
+    /// Unique identifier for this view in the catalog.
+    pub view_id: i64,
+    /// Schema containing the view.
+    pub schema_id: i64,
+    /// Snapshot that created this view generation.
+    pub begin_snapshot: i64,
+    /// Name of the view as it appears in SQL queries.
+    pub view_name: String,
+    /// SQL dialect used by the stored definition.
+    pub dialect: String,
+    /// Query defining the view.
+    pub sql: String,
+    /// DuckLake's quoted, comma-separated output aliases.
+    pub column_aliases: Option<String>,
+}
+
+/// View metadata with its schema name for information-schema queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewWithSchema {
+    /// Name of the schema this view belongs to.
+    pub schema_name: String,
+    /// View metadata.
+    pub view: ViewMetadata,
 }
 
 /// Column metadata with its schema and table names (for bulk queries)
@@ -1129,6 +1181,11 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
     /// List tables for a specific snapshot
     fn list_tables(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<TableMetadata>>;
 
+    /// List views visible in a schema at a specific snapshot.
+    fn list_views(&self, _schema_id: i64, _snapshot_id: i64) -> Result<Vec<ViewMetadata>> {
+        Ok(Vec::new())
+    }
+
     /// Get table structure (columns) visible at `snapshot_id`. Columns are
     /// snapshot-scoped (`snapshot_id >= begin_snapshot AND (snapshot_id <
     /// end_snapshot OR end_snapshot IS NULL)`), matching upstream DuckLake and
@@ -1303,6 +1360,16 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         snapshot_id: i64,
     ) -> Result<Option<TableMetadata>>;
 
+    /// Get a visible view by name.
+    fn get_view_by_name(
+        &self,
+        _schema_id: i64,
+        _name: &str,
+        _snapshot_id: i64,
+    ) -> Result<Option<ViewMetadata>> {
+        Ok(None)
+    }
+
     /// Check if table exists for a specific snapshot
     fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> Result<bool>;
 
@@ -1310,6 +1377,22 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
 
     /// List all tables across all schemas for a snapshot
     fn list_all_tables(&self, snapshot_id: i64) -> Result<Vec<TableWithSchema>>;
+
+    /// List all views across all visible schemas for a snapshot.
+    fn list_all_views(&self, snapshot_id: i64) -> Result<Vec<ViewWithSchema>> {
+        let mut views = Vec::new();
+        for schema in self.list_schemas(snapshot_id)? {
+            views.extend(
+                self.list_views(schema.schema_id, snapshot_id)?
+                    .into_iter()
+                    .map(|view| ViewWithSchema {
+                        schema_name: schema.schema_name.clone(),
+                        view,
+                    }),
+            );
+        }
+        Ok(views)
+    }
 
     /// List all columns across all tables for a snapshot
     fn list_all_columns(&self, snapshot_id: i64) -> Result<Vec<ColumnWithTable>>;

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -8,10 +8,12 @@ use crate::metadata_provider::{
     SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
     SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT, SQL_GET_PARTITION_SPEC,
     SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS,
-    SQL_GET_TABLE_COLUMNS, SQL_GET_TABLE_STATS, SQL_LIST_ALL_COLUMNS, SQL_LIST_ALL_FILES,
-    SQL_LIST_ALL_TABLES, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_TABLE_EXISTS,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, build_inlined_batch,
-    is_inlined_data_table, reconstruct_columns, reconstruct_columns_with_table,
+    SQL_GET_TABLE_COLUMNS, SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_COLUMNS,
+    SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES, SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS,
+    SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS, SQL_TABLE_EXISTS, SchemaMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
+    build_inlined_batch, is_inlined_data_table, reconstruct_columns,
+    reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -152,6 +154,18 @@ fn decode_duckdb_text(value: &[u8], column: &str) -> crate::Result<String> {
     })
 }
 
+fn decode_view(row: &duckdb::Row<'_>) -> duckdb::Result<ViewMetadata> {
+    Ok(ViewMetadata {
+        view_id: row.get(0)?,
+        schema_id: row.get(1)?,
+        begin_snapshot: row.get(2)?,
+        view_name: row.get(3)?,
+        dialect: row.get(4)?,
+        sql: row.get(5)?,
+        column_aliases: row.get(6)?,
+    })
+}
+
 /// Optional catalog-schema capabilities probed before CDC / inlined-data queries.
 ///
 /// Older catalogs (spec 0.2) may lack the `partial_max` columns and the
@@ -166,11 +180,16 @@ struct SchemaCapabilities {
     delete_file_partial_max: bool,
     /// The `ducklake_inlined_data_tables` registry exists.
     inlined_data_tables: bool,
+    /// The `ducklake_view` table exists.
+    views: bool,
 }
 
 impl SchemaCapabilities {
     fn all(&self) -> bool {
-        self.data_file_partial_max && self.delete_file_partial_max && self.inlined_data_tables
+        self.data_file_partial_max
+            && self.delete_file_partial_max
+            && self.inlined_data_tables
+            && self.views
     }
 }
 
@@ -230,7 +249,8 @@ impl DuckdbMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let (data_file_partial_max, delete_file_partial_max, inlined_data_tables): (
+        let (data_file_partial_max, delete_file_partial_max, inlined_data_tables, views): (
+            bool,
             bool,
             bool,
             bool,
@@ -241,14 +261,17 @@ impl DuckdbMetadataProvider {
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_delete_file')
                 WHERE name = 'partial_max') > 0,
                (SELECT COUNT(*) FROM information_schema.tables
-                WHERE table_name = 'ducklake_inlined_data_tables') > 0",
+                WHERE table_name = 'ducklake_inlined_data_tables') > 0,
+               (SELECT COUNT(*) FROM information_schema.tables
+                WHERE table_name = 'ducklake_view') > 0",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
         let caps = SchemaCapabilities {
             data_file_partial_max,
             delete_file_partial_max,
             inlined_data_tables,
+            views,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -353,6 +376,18 @@ impl MetadataProvider for DuckdbMetadataProvider {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(tables)
+    }
+
+    fn list_views(&self, schema_id: i64, snapshot_id: i64) -> crate::Result<Vec<ViewMetadata>> {
+        let conn = self.connection();
+        if !self.schema_capabilities(&conn)?.views {
+            return Ok(Vec::new());
+        }
+        let mut stmt = conn.prepare(SQL_LIST_VIEWS)?;
+        let views = stmt
+            .query_map([schema_id, snapshot_id, snapshot_id], decode_view)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(views)
     }
 
     fn get_table_structure(
@@ -968,6 +1003,25 @@ impl MetadataProvider for DuckdbMetadataProvider {
         }
     }
 
+    fn get_view_by_name(
+        &self,
+        schema_id: i64,
+        name: &str,
+        snapshot_id: i64,
+    ) -> crate::Result<Option<ViewMetadata>> {
+        let conn = self.connection();
+        if !self.schema_capabilities(&conn)?.views {
+            return Ok(None);
+        }
+        let mut stmt = conn.prepare(SQL_GET_VIEW_BY_NAME)?;
+        let mut rows = stmt.query(params![schema_id, name, snapshot_id, snapshot_id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(decode_view(row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> crate::Result<bool> {
         let conn = self.connection();
         let exists: bool = conn.query_row(
@@ -1002,6 +1056,33 @@ impl MetadataProvider for DuckdbMetadataProvider {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(tables)
+    }
+
+    fn list_all_views(&self, snapshot_id: i64) -> crate::Result<Vec<ViewWithSchema>> {
+        let conn = self.connection();
+        if !self.schema_capabilities(&conn)?.views {
+            return Ok(Vec::new());
+        }
+        let mut stmt = conn.prepare(SQL_LIST_ALL_VIEWS)?;
+        stmt.query_map(
+            params![snapshot_id, snapshot_id, snapshot_id, snapshot_id],
+            |row| {
+                Ok(ViewWithSchema {
+                    schema_name: row.get(0)?,
+                    view: ViewMetadata {
+                        view_id: row.get(1)?,
+                        schema_id: row.get(2)?,
+                        begin_snapshot: row.get(3)?,
+                        view_name: row.get(4)?,
+                        dialect: row.get(5)?,
+                        sql: row.get(6)?,
+                        column_aliases: row.get(7)?,
+                    },
+                })
+            },
+        )?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
     }
 
     fn list_all_columns(&self, snapshot_id: i64) -> crate::Result<Vec<ColumnWithTable>> {

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -6,9 +6,9 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     InlinedDataBackend, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC,
-    SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    inlined_text_projection, is_inlined_data_table, parse_inlined_rows, reconstruct_columns,
-    reconstruct_columns_with_table,
+    SQL_GET_SORT_SPEC, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
+    ViewMetadata, ViewWithSchema, block_on, inlined_text_projection, is_inlined_data_table,
+    parse_inlined_rows, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -30,6 +30,18 @@ fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
 
 fn quote_ident(name: &str) -> String {
     format!("`{}`", name.replace('`', "``"))
+}
+
+fn decode_view(row: &MySqlRow) -> Result<ViewMetadata> {
+    Ok(ViewMetadata {
+        view_id: row.try_get(0)?,
+        schema_id: row.try_get(1)?,
+        begin_snapshot: row.try_get(2)?,
+        view_name: row.try_get(3)?,
+        dialect: row.try_get(4)?,
+        sql: row.try_get(5)?,
+        column_aliases: row.try_get(6)?,
+    })
 }
 
 fn decode_table_file(row: &MySqlRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
@@ -84,11 +96,16 @@ struct SchemaCapabilities {
     delete_file_partial_max: bool,
     /// The `ducklake_inlined_data_tables` registry exists.
     inlined_data_tables: bool,
+    /// The `ducklake_view` table exists.
+    views: bool,
 }
 
 impl SchemaCapabilities {
     fn all(&self) -> bool {
-        self.data_file_partial_max && self.delete_file_partial_max && self.inlined_data_tables
+        self.data_file_partial_max
+            && self.delete_file_partial_max
+            && self.inlined_data_tables
+            && self.views
     }
 }
 
@@ -145,7 +162,7 @@ impl MySqlMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (i64, i64, i64) = sqlx::query_as(
+        let row: (i64, i64, i64, i64) = sqlx::query_as(
             "SELECT
                (SELECT COUNT(*) FROM information_schema.columns
                 WHERE table_schema = DATABASE()
@@ -157,7 +174,10 @@ impl MySqlMetadataProvider {
                   AND column_name = 'partial_max'),
                (SELECT COUNT(*) FROM information_schema.tables
                 WHERE table_schema = DATABASE()
-                  AND table_name = 'ducklake_inlined_data_tables')",
+                  AND table_name = 'ducklake_inlined_data_tables'),
+               (SELECT COUNT(*) FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'ducklake_view')",
         )
         .fetch_one(&self.pool)
         .await?;
@@ -165,6 +185,7 @@ impl MySqlMetadataProvider {
             data_file_partial_max: row.0 > 0,
             delete_file_partial_max: row.1 > 0,
             inlined_data_tables: row.2 > 0,
+            views: row.3 > 0,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -276,6 +297,28 @@ impl MetadataProvider for MySqlMetadataProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_views(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, `sql`, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter().map(|row| decode_view(&row)).collect()
         })
     }
 
@@ -935,6 +978,35 @@ impl MetadataProvider for MySqlMetadataProvider {
         })
     }
 
+    fn get_view_by_name(
+        &self,
+        schema_id: i64,
+        name: &str,
+        snapshot_id: i64,
+    ) -> Result<Option<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(None);
+            }
+            let row = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, `sql`, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = ?
+                   AND view_name = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            row.map(|row| decode_view(&row)).transpose()
+        })
+    }
+
     fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> Result<bool> {
         block_on(async {
             // MySQL doesn't support SELECT EXISTS(...) the same way PostgreSQL does
@@ -989,6 +1061,47 @@ impl MetadataProvider for MySqlMetadataProvider {
                     Ok(TableWithSchema {
                         schema_name,
                         table,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_all_views(&self, snapshot_id: i64) -> Result<Vec<ViewWithSchema>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT s.schema_name, v.view_id, v.schema_id, v.begin_snapshot, v.view_name,
+                        v.dialect, v.`sql`, v.column_aliases
+                 FROM ducklake_schema s
+                 JOIN ducklake_view v ON s.schema_id = v.schema_id
+                 WHERE ? >= s.begin_snapshot
+                   AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
+                   AND ? >= v.begin_snapshot
+                   AND (? < v.end_snapshot OR v.end_snapshot IS NULL)
+                 ORDER BY s.schema_name, v.view_name",
+            )
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(ViewWithSchema {
+                        schema_name: row.try_get(0)?,
+                        view: ViewMetadata {
+                            view_id: row.try_get(1)?,
+                            schema_id: row.try_get(2)?,
+                            begin_snapshot: row.try_get(3)?,
+                            view_name: row.try_get(4)?,
+                            dialect: row.try_get(5)?,
+                            sql: row.try_get(6)?,
+                            column_aliases: row.try_get(7)?,
+                        },
                     })
                 })
                 .collect()

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -6,8 +6,8 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     InlinedDataBackend, MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata,
-    TableWithSchema, block_on, inlined_text_projection, is_inlined_data_table, parse_inlined_rows,
-    reconstruct_columns, reconstruct_columns_with_table,
+    TableWithSchema, ViewMetadata, ViewWithSchema, block_on, inlined_text_projection,
+    is_inlined_data_table, parse_inlined_rows, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -27,6 +27,18 @@ fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
 
 fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn decode_view(row: &PgRow) -> Result<ViewMetadata> {
+    Ok(ViewMetadata {
+        view_id: row.try_get(0)?,
+        schema_id: row.try_get(1)?,
+        begin_snapshot: row.try_get(2)?,
+        view_name: row.try_get(3)?,
+        dialect: row.try_get(4)?,
+        sql: row.try_get(5)?,
+        column_aliases: row.try_get(6)?,
+    })
 }
 
 fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
@@ -126,6 +138,8 @@ struct SchemaCapabilities {
     data_file_partition_id: bool,
     /// The `ducklake_inlined_data_tables` registry exists.
     inlined_data_tables: bool,
+    /// The `ducklake_view` table exists.
+    views: bool,
 }
 
 impl SchemaCapabilities {
@@ -135,6 +149,7 @@ impl SchemaCapabilities {
             && self.schema_versions
             && self.data_file_partition_id
             && self.inlined_data_tables
+            && self.views
     }
 }
 
@@ -191,7 +206,7 @@ impl PostgresMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
@@ -200,7 +215,8 @@ impl PostgresMetadataProvider {
                to_regclass('ducklake_schema_versions') IS NOT NULL,
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id'),
-               to_regclass('ducklake_inlined_data_tables') IS NOT NULL",
+               to_regclass('ducklake_inlined_data_tables') IS NOT NULL,
+               to_regclass('ducklake_view') IS NOT NULL",
         )
         .fetch_one(&self.pool)
         .await?;
@@ -210,6 +226,7 @@ impl PostgresMetadataProvider {
             schema_versions: row.2,
             data_file_partition_id: row.3,
             inlined_data_tables: row.4,
+            views: row.5,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -320,6 +337,28 @@ impl MetadataProvider for PostgresMetadataProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_views(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter().map(|row| decode_view(&row)).collect()
         })
     }
 
@@ -1098,6 +1137,35 @@ impl MetadataProvider for PostgresMetadataProvider {
         })
     }
 
+    fn get_view_by_name(
+        &self,
+        schema_id: i64,
+        name: &str,
+        snapshot_id: i64,
+    ) -> Result<Option<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(None);
+            }
+            let row = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = $1
+                   AND view_name = $2
+                   AND $3 >= begin_snapshot
+                   AND ($4 < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            row.map(|row| decode_view(&row)).transpose()
+        })
+    }
+
     fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> Result<bool> {
         block_on(async {
             let row = sqlx::query(
@@ -1151,6 +1219,44 @@ impl MetadataProvider for PostgresMetadataProvider {
                     Ok(TableWithSchema {
                         schema_name,
                         table,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_all_views(&self, snapshot_id: i64) -> Result<Vec<ViewWithSchema>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT s.schema_name, v.view_id, v.schema_id, v.begin_snapshot, v.view_name,
+                        v.dialect, v.sql, v.column_aliases
+                 FROM ducklake_schema s
+                 JOIN ducklake_view v ON s.schema_id = v.schema_id
+                 WHERE $1 >= s.begin_snapshot
+                   AND ($1 < s.end_snapshot OR s.end_snapshot IS NULL)
+                   AND $1 >= v.begin_snapshot
+                   AND ($1 < v.end_snapshot OR v.end_snapshot IS NULL)
+                 ORDER BY s.schema_name, v.view_name",
+            )
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(ViewWithSchema {
+                        schema_name: row.try_get(0)?,
+                        view: ViewMetadata {
+                            view_id: row.try_get(1)?,
+                            schema_id: row.try_get(2)?,
+                            begin_snapshot: row.try_get(3)?,
+                            view_name: row.try_get(4)?,
+                            dialect: row.try_get(5)?,
+                            sql: row.try_get(6)?,
+                            column_aliases: row.try_get(7)?,
+                        },
                     })
                 })
                 .collect()

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -6,8 +6,8 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_columns, reconstruct_columns_with_table,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
+    block_on, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -28,6 +28,18 @@ use std::sync::{Arc, OnceLock};
 /// so catalog-supplied inlined-table / column names can't break the query.
 fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn decode_view(row: &SqliteRow) -> Result<ViewMetadata> {
+    Ok(ViewMetadata {
+        view_id: row.try_get(0)?,
+        schema_id: row.try_get(1)?,
+        begin_snapshot: row.try_get(2)?,
+        view_name: row.try_get(3)?,
+        dialect: row.try_get(4)?,
+        sql: row.try_get(5)?,
+        column_aliases: row.try_get(6)?,
+    })
 }
 
 fn decode_table_file(row: &SqliteRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
@@ -187,6 +199,8 @@ struct SchemaCapabilities {
     schema_versions: bool,
     /// The `ducklake_inlined_data_tables` registry exists.
     inlined_data_tables: bool,
+    /// The `ducklake_view` table exists.
+    views: bool,
 }
 
 impl SchemaCapabilities {
@@ -196,6 +210,7 @@ impl SchemaCapabilities {
             && self.data_file_partition_id
             && self.schema_versions
             && self.inlined_data_tables
+            && self.views
     }
 }
 
@@ -254,7 +269,7 @@ impl SqliteMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file')
                 WHERE name = 'partial_max') > 0,
@@ -265,7 +280,9 @@ impl SqliteMetadataProvider {
                (SELECT COUNT(*) FROM sqlite_master
                 WHERE type = 'table' AND name = 'ducklake_schema_versions') > 0,
                (SELECT COUNT(*) FROM sqlite_master
-                WHERE type = 'table' AND name = 'ducklake_inlined_data_tables') > 0",
+                WHERE type = 'table' AND name = 'ducklake_inlined_data_tables') > 0,
+               (SELECT COUNT(*) FROM sqlite_master
+                WHERE type = 'table' AND name = 'ducklake_view') > 0",
         )
         .fetch_one(&self.pool)
         .await?;
@@ -275,6 +292,7 @@ impl SqliteMetadataProvider {
             data_file_partition_id: row.2,
             schema_versions: row.3,
             inlined_data_tables: row.4,
+            views: row.5,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -385,6 +403,28 @@ impl MetadataProvider for SqliteMetadataProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_views(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter().map(|row| decode_view(&row)).collect()
         })
     }
 
@@ -1151,6 +1191,35 @@ impl MetadataProvider for SqliteMetadataProvider {
         })
     }
 
+    fn get_view_by_name(
+        &self,
+        schema_id: i64,
+        name: &str,
+        snapshot_id: i64,
+    ) -> Result<Option<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(None);
+            }
+            let row = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = ?
+                   AND view_name = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            row.map(|row| decode_view(&row)).transpose()
+        })
+    }
+
     fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> Result<bool> {
         block_on(async {
             let row = sqlx::query(
@@ -1203,6 +1272,47 @@ impl MetadataProvider for SqliteMetadataProvider {
                     Ok(TableWithSchema {
                         schema_name,
                         table,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_all_views(&self, snapshot_id: i64) -> Result<Vec<ViewWithSchema>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT s.schema_name, v.view_id, v.schema_id, v.begin_snapshot, v.view_name,
+                        v.dialect, v.sql, v.column_aliases
+                 FROM ducklake_schema s
+                 JOIN ducklake_view v ON s.schema_id = v.schema_id
+                 WHERE ? >= s.begin_snapshot
+                   AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
+                   AND ? >= v.begin_snapshot
+                   AND (? < v.end_snapshot OR v.end_snapshot IS NULL)
+                 ORDER BY s.schema_name, v.view_name",
+            )
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(ViewWithSchema {
+                        schema_name: row.try_get(0)?,
+                        view: ViewMetadata {
+                            view_id: row.try_get(1)?,
+                            schema_id: row.try_get(2)?,
+                            begin_snapshot: row.try_get(3)?,
+                            view_name: row.try_get(4)?,
+                            dialect: row.try_get(5)?,
+                            sql: row.try_get(6)?,
+                            column_aliases: row.try_get(7)?,
+                        },
                     })
                 })
                 .collect()

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -117,6 +117,18 @@ CREATE TABLE IF NOT EXISTS ducklake_table (
 -- write a second row sharing the same column_id. Mirrors the SQLite writer's
 -- `ducklake_column`. The four `*default*` columns + `parent_column` are left
 -- NULL (no nested-type / column-default writes here).
+CREATE TABLE IF NOT EXISTS ducklake_view (
+    view_id BIGINT,
+    view_uuid UUID,
+    begin_snapshot BIGINT,
+    end_snapshot BIGINT,
+    schema_id BIGINT,
+    view_name VARCHAR,
+    dialect VARCHAR,
+    sql VARCHAR,
+    column_aliases VARCHAR
+);
+
 CREATE TABLE IF NOT EXISTS ducklake_column (
     column_id BIGINT,
     begin_snapshot BIGINT,

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -104,6 +104,17 @@ const SQL_CREATE_TABLES: &[&str] = &[
     // never promotes types — the shape stays identical to SQLite/upstream so
     // catalogs interoperate. The four `*default*` columns and `parent_column` are
     // left NULL (no nested-type / column-default writes).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_view (
+        view_id BIGINT,
+        view_uuid VARCHAR(36),
+        begin_snapshot BIGINT,
+        end_snapshot BIGINT,
+        schema_id BIGINT,
+        view_name VARCHAR(1024),
+        dialect VARCHAR(1024),
+        `sql` TEXT,
+        column_aliases TEXT
+    ) ENGINE = InnoDB"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_column (
         column_id BIGINT,
         begin_snapshot BIGINT,

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -65,6 +65,17 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
     // row sharing the same `column_id`. Identity is the composite
     // (table_id, column_id, begin_snapshot); a partial unique index (below) enforces
     // at most one *live* version per field-id.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_view (
+        view_id BIGINT,
+        view_uuid UUID,
+        begin_snapshot BIGINT,
+        end_snapshot BIGINT,
+        schema_id BIGINT,
+        view_name VARCHAR,
+        dialect VARCHAR,
+        sql VARCHAR,
+        column_aliases VARCHAR
+    )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_column (
         column_id BIGINT GENERATED ALWAYS AS IDENTITY,
         table_id BIGINT NOT NULL,

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -85,6 +85,17 @@ const SQL_CREATE_TABLES: &[&str] = &[
     // Bare table (no PRIMARY KEY), mirroring upstream: a versioned column needs
     // several rows sharing one `column_id`. The `*default*` columns and
     // `parent_column` are left NULL.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_view (
+        view_id BIGINT,
+        view_uuid UUID,
+        begin_snapshot BIGINT,
+        end_snapshot BIGINT,
+        schema_id BIGINT,
+        view_name VARCHAR,
+        dialect VARCHAR,
+        sql VARCHAR,
+        column_aliases VARCHAR
+    )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_column (
         column_id BIGINT,
         begin_snapshot BIGINT,

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -96,6 +96,18 @@ CREATE TABLE IF NOT EXISTS ducklake_table (
 -- constraints). The four `*default*` columns + `parent_column` are projected by
 -- DuckDB when it reads catalogs we produce; we leave them NULL (no nested-type
 -- or column-default writes yet). See docs/column-id-versioning-design.md §4.1.
+CREATE TABLE IF NOT EXISTS ducklake_view (
+    view_id BIGINT,
+    view_uuid UUID,
+    begin_snapshot BIGINT,
+    end_snapshot BIGINT,
+    schema_id BIGINT,
+    view_name VARCHAR,
+    dialect VARCHAR,
+    sql VARCHAR,
+    column_aliases VARCHAR
+);
+
 CREATE TABLE IF NOT EXISTS ducklake_column (
     column_id BIGINT,
     begin_snapshot BIGINT,

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -16,8 +16,8 @@ use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
-    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_columns, reconstruct_columns_with_table,
+    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
+    ViewMetadata, ViewWithSchema, block_on, reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -31,6 +31,18 @@ use std::sync::{Arc, OnceLock};
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("undefined table")
+}
+
+fn decode_view(row: &PgRow) -> Result<ViewMetadata> {
+    Ok(ViewMetadata {
+        view_id: row.try_get(0)?,
+        schema_id: row.try_get(1)?,
+        begin_snapshot: row.try_get(2)?,
+        view_name: row.try_get(3)?,
+        dialect: row.try_get(4)?,
+        sql: row.try_get(5)?,
+        column_aliases: row.try_get(6)?,
+    })
 }
 
 fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
@@ -93,6 +105,8 @@ struct SchemaCapabilities {
     schema_versions: bool,
     /// `ducklake_data_file.partition_id` exists.
     data_file_partition_id: bool,
+    /// The `ducklake_view` table exists.
+    views: bool,
 }
 
 impl SchemaCapabilities {
@@ -101,6 +115,7 @@ impl SchemaCapabilities {
             && self.delete_file_partial_max
             && self.schema_versions
             && self.data_file_partition_id
+            && self.views
     }
 }
 
@@ -180,7 +195,7 @@ impl MulticatalogProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
@@ -188,7 +203,8 @@ impl MulticatalogProvider {
                        WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
                to_regclass('ducklake_schema_versions') IS NOT NULL,
                EXISTS (SELECT 1 FROM information_schema.columns
-                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id')",
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id'),
+               to_regclass('ducklake_view') IS NOT NULL",
         )
         .fetch_one(&self.pool)
         .await?;
@@ -197,6 +213,7 @@ impl MulticatalogProvider {
             delete_file_partial_max: row.1,
             schema_versions: row.2,
             data_file_partition_id: row.3,
+            views: row.4,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -330,6 +347,28 @@ impl MetadataProvider for MulticatalogProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_views(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter().map(|row| decode_view(&row)).collect()
         })
     }
 
@@ -1040,6 +1079,35 @@ impl MetadataProvider for MulticatalogProvider {
         })
     }
 
+    fn get_view_by_name(
+        &self,
+        schema_id: i64,
+        name: &str,
+        snapshot_id: i64,
+    ) -> Result<Option<ViewMetadata>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(None);
+            }
+            let row = sqlx::query(
+                "SELECT view_id, schema_id, begin_snapshot, view_name, dialect, sql, column_aliases
+                 FROM ducklake_view
+                 WHERE schema_id = $1
+                   AND view_name = $2
+                   AND $3 >= begin_snapshot
+                   AND ($4 < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            row.map(|row| decode_view(&row)).transpose()
+        })
+    }
+
     fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> Result<bool> {
         block_on(async {
             let row = sqlx::query(
@@ -1095,6 +1163,47 @@ impl MetadataProvider for MulticatalogProvider {
                     Ok(TableWithSchema {
                         schema_name,
                         table,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_all_views(&self, snapshot_id: i64) -> Result<Vec<ViewWithSchema>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.views {
+                return Ok(Vec::new());
+            }
+            let rows = sqlx::query(
+                "SELECT s.schema_name, v.view_id, v.schema_id, v.begin_snapshot, v.view_name,
+                        v.dialect, v.sql, v.column_aliases
+                 FROM ducklake_schema s
+                 JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                 JOIN ducklake_view v ON s.schema_id = v.schema_id
+                 WHERE m.catalog_id = $1
+                   AND $2 >= s.begin_snapshot
+                   AND ($2 < s.end_snapshot OR s.end_snapshot IS NULL)
+                   AND $2 >= v.begin_snapshot
+                   AND ($2 < v.end_snapshot OR v.end_snapshot IS NULL)
+                 ORDER BY s.schema_name, v.view_name",
+            )
+            .bind(self.catalog_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+            rows.into_iter()
+                .map(|row| {
+                    Ok(ViewWithSchema {
+                        schema_name: row.try_get(0)?,
+                        view: ViewMetadata {
+                            view_id: row.try_get(1)?,
+                            schema_id: row.try_get(2)?,
+                            begin_snapshot: row.try_get(3)?,
+                            view_name: row.try_get(4)?,
+                            dialect: row.try_get(5)?,
+                            sql: row.try_get(6)?,
+                            column_aliases: row.try_get(7)?,
+                        },
                     })
                 })
                 .collect()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,10 +6,12 @@ use async_trait::async_trait;
 use datafusion::catalog::{SchemaProvider, TableProvider};
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::error::Result as DataFusionResult;
+use datafusion::logical_expr::TableType;
 
 use crate::metadata_provider::MetadataProvider;
 use crate::path_resolver::resolve_path;
 use crate::table::DuckLakeTable;
+use crate::view::{UnplannableViewTable, plan_view, resolve_view_definition};
 
 #[cfg(feature = "write")]
 use crate::metadata_writer::{ColumnDef, MetadataWriter, WriteMode, validate_name};
@@ -126,8 +128,8 @@ impl DuckLakeSchema {
 #[async_trait]
 impl SchemaProvider for DuckLakeSchema {
     fn table_names(&self) -> Vec<String> {
-        // Use cached snapshot_id
-        self.provider
+        let mut names = self
+            .provider
             .list_tables(self.schema_id, self.snapshot_id)
             .inspect_err(|e| {
                 tracing::error!(
@@ -141,7 +143,26 @@ impl SchemaProvider for DuckLakeSchema {
             .unwrap_or_default()
             .into_iter()
             .map(|t| t.table_name)
-            .collect()
+            .collect::<Vec<_>>();
+        names.extend(
+            self.provider
+                .list_views(self.schema_id, self.snapshot_id)
+                .inspect_err(|e| {
+                    tracing::error!(
+                        error = %e,
+                        schema_id = %self.schema_id,
+                        snapshot_id = %self.snapshot_id,
+                        schema_name = %self.schema_name,
+                        "Failed to list views from catalog"
+                    )
+                })
+                .unwrap_or_default()
+                .into_iter()
+                .map(|view| view.view_name),
+        );
+        names.sort();
+        names.dedup();
+        names
     }
 
     async fn table(&self, name: &str) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
@@ -179,16 +200,67 @@ impl SchemaProvider for DuckLakeSchema {
 
                 Ok(Some(Arc::new(table) as Arc<dyn TableProvider>))
             },
-            Ok(None) => Ok(None),
+            Ok(None) => match self
+                .provider
+                .get_view_by_name(self.schema_id, name, self.snapshot_id)
+            {
+                Ok(Some(view)) => {
+                    let (definition, planned) = match resolve_view_definition(
+                        &view,
+                        self.provider.as_ref(),
+                        self.snapshot_id,
+                        &self.schema_name,
+                    ) {
+                        Ok(definition) => {
+                            let planned = plan_view(
+                                &view,
+                                &definition,
+                                Arc::clone(&self.provider),
+                                self.snapshot_id,
+                                &self.schema_name,
+                                self.row_lineage,
+                            )
+                            .await;
+                            (definition, planned)
+                        },
+                        Err(e) => (view.sql.clone(), Err(e)),
+                    };
+                    let table = match planned {
+                        Ok(table) => table,
+                        Err(e) => Arc::new(UnplannableViewTable::new(definition, &e)),
+                    };
+                    Ok(Some(table))
+                },
+                Ok(None) => Ok(None),
+                Err(e) => Err(datafusion::error::DataFusionError::External(Box::new(e))),
+            },
             Err(e) => Err(datafusion::error::DataFusionError::External(Box::new(e))),
         }
     }
 
+    async fn table_type(&self, name: &str) -> DataFusionResult<Option<TableType>> {
+        if self
+            .provider
+            .table_exists(self.schema_id, name, self.snapshot_id)
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+        {
+            return Ok(Some(TableType::Base));
+        }
+        self.provider
+            .get_view_by_name(self.schema_id, name, self.snapshot_id)
+            .map(|view| view.map(|_| TableType::View))
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))
+    }
+
     fn table_exist(&self, name: &str) -> bool {
-        // Use cached snapshot_id
         self.provider
             .table_exists(self.schema_id, name, self.snapshot_id)
             .unwrap_or(false)
+            || self
+                .provider
+                .get_view_by_name(self.schema_id, name, self.snapshot_id)
+                .map(|view| view.is_some())
+                .unwrap_or(false)
     }
 
     /// Register a new table in this schema.
@@ -203,6 +275,17 @@ impl SchemaProvider for DuckLakeSchema {
     ) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
         // Validate table name to prevent path traversal attacks
         validate_table_name(&name)?;
+
+        if self
+            .provider
+            .get_view_by_name(self.schema_id, &name, self.snapshot_id)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?
+            .is_some()
+        {
+            return Err(DataFusionError::Plan(format!(
+                "Cannot create table '{name}': a view with that name already exists"
+            )));
+        }
 
         let writer = self.writer.as_ref().ok_or_else(|| {
             DataFusionError::Plan(

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,0 +1,566 @@
+use std::cell::RefCell;
+use std::ops::ControlFlow;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use arrow::datatypes::{Schema, SchemaRef};
+use datafusion::catalog::Session;
+use datafusion::common::Column;
+use datafusion::common::config::Dialect;
+use datafusion::datasource::{TableProvider, ViewTable};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder, TableType};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
+use datafusion::sql::sqlparser::ast::{Ident, ObjectNamePart, visit_relations_mut};
+use datafusion::sql::sqlparser::dialect::dialect_from_str;
+use datafusion::sql::sqlparser::parser::Parser;
+use datafusion::sql::sqlparser::tokenizer::{Token, Tokenizer};
+
+use crate::catalog::DuckLakeCatalog;
+use crate::metadata_provider::{MetadataProvider, SchemaMetadata, ViewMetadata};
+
+const VIEW_CATALOG: &str = "__ducklake_view";
+
+#[derive(Debug)]
+pub(crate) struct UnplannableViewTable {
+    definition: String,
+    error: String,
+    schema: SchemaRef,
+}
+
+impl UnplannableViewTable {
+    pub(crate) fn new(definition: String, error: &DataFusionError) -> Self {
+        Self {
+            definition,
+            error: error.to_string(),
+            schema: Arc::new(Schema::empty()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for UnplannableViewTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    fn get_table_definition(&self) -> Option<&str> {
+        Some(&self.definition)
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::Plan(self.error.clone()))
+    }
+}
+
+tokio::task_local! {
+    static VIEW_PLAN_STACK: RefCell<Vec<i64>>;
+}
+
+pub(crate) async fn plan_view(
+    view: &ViewMetadata,
+    sql: &str,
+    provider: Arc<dyn MetadataProvider>,
+    snapshot_id: i64,
+    schema_name: &str,
+    row_lineage: bool,
+) -> Result<Arc<dyn TableProvider>> {
+    let cycle = VIEW_PLAN_STACK
+        .try_with(|stack| stack.borrow().contains(&view.view_id))
+        .unwrap_or(false);
+    if cycle {
+        return Err(view_error(view, "view dependency cycle"));
+    }
+
+    if VIEW_PLAN_STACK
+        .try_with(|stack| stack.borrow_mut().push(view.view_id))
+        .is_ok()
+    {
+        let result =
+            plan_view_inner(view, sql, provider, snapshot_id, schema_name, row_lineage).await;
+        VIEW_PLAN_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+        result
+    } else {
+        VIEW_PLAN_STACK
+            .scope(
+                RefCell::new(vec![view.view_id]),
+                plan_view_inner(view, sql, provider, snapshot_id, schema_name, row_lineage),
+            )
+            .await
+    }
+}
+
+async fn plan_view_inner(
+    view: &ViewMetadata,
+    sql: &str,
+    provider: Arc<dyn MetadataProvider>,
+    snapshot_id: i64,
+    schema_name: &str,
+    row_lineage: bool,
+) -> Result<Arc<dyn TableProvider>> {
+    let dialect = Dialect::from_str(&view.dialect).map_err(|e| view_error(view, e))?;
+    let mut config = SessionConfig::new()
+        .with_create_default_catalog_and_schema(false)
+        .with_default_catalog_and_schema(VIEW_CATALOG, schema_name);
+    config.options_mut().sql_parser.dialect = dialect;
+
+    let context = SessionContext::new_with_config(config);
+    let catalog = DuckLakeCatalog::with_snapshot(provider, snapshot_id)
+        .map_err(|e| view_error(view, e))?
+        .with_row_lineage(row_lineage);
+    context.register_catalog(VIEW_CATALOG, Arc::new(catalog));
+
+    let options = SQLOptions::new()
+        .with_allow_ddl(false)
+        .with_allow_dml(false)
+        .with_allow_statements(false);
+    let plan = context
+        .sql_with_options(sql, options)
+        .await
+        .map_err(|e| view_error(view, e))?
+        .into_unoptimized_plan();
+    let plan = apply_aliases(plan, view).map_err(|e| view_error(view, e))?;
+
+    Ok(Arc::new(ViewTable::new(plan, Some(sql.to_string()))))
+}
+
+fn apply_aliases(plan: LogicalPlan, view: &ViewMetadata) -> Result<LogicalPlan> {
+    let aliases = parse_aliases(view.column_aliases.as_deref().unwrap_or_default())?;
+    if aliases.is_empty() {
+        return Ok(plan);
+    }
+    if aliases.len() > plan.schema().fields().len() {
+        return Err(DataFusionError::Plan(format!(
+            "view defines {} aliases for {} columns",
+            aliases.len(),
+            plan.schema().fields().len()
+        )));
+    }
+
+    let expressions = plan
+        .schema()
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            let column = Expr::Column(Column::from(plan.schema().qualified_field(index)));
+            aliases
+                .get(index)
+                .map_or(column.clone(), |alias| column.alias(alias))
+        })
+        .collect::<Vec<_>>();
+    LogicalPlanBuilder::from(plan).project(expressions)?.build()
+}
+
+fn parse_aliases(input: &str) -> Result<Vec<String>> {
+    if input.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut aliases = Vec::new();
+    let mut chars = input.chars().peekable();
+    loop {
+        if chars.next() != Some('"') {
+            return Err(DataFusionError::Plan(
+                "column_aliases must contain quoted identifiers".to_string(),
+            ));
+        }
+
+        let mut alias = String::new();
+        loop {
+            match chars.next() {
+                Some('"') if chars.peek() == Some(&'"') => {
+                    chars.next();
+                    alias.push('"');
+                },
+                Some('"') => break,
+                Some(character) => alias.push(character),
+                None => {
+                    return Err(DataFusionError::Plan(
+                        "column_aliases contains an unterminated identifier".to_string(),
+                    ));
+                },
+            }
+        }
+        aliases.push(alias);
+
+        match chars.next() {
+            Some(',') => {},
+            None => break,
+            Some(_) => {
+                return Err(DataFusionError::Plan(
+                    "column_aliases must separate identifiers with commas".to_string(),
+                ));
+            },
+        }
+    }
+    Ok(aliases)
+}
+
+pub(crate) fn resolve_view_definition(
+    view: &ViewMetadata,
+    provider: &dyn MetadataProvider,
+    snapshot_id: i64,
+    schema_name: &str,
+) -> Result<String> {
+    let dialect = Dialect::from_str(&view.dialect).map_err(|e| view_error(view, e))?;
+    let (creation_schemas, visible_schemas) = if dialect == Dialect::DuckDB {
+        let creation_schemas = provider
+            .list_schemas(view.begin_snapshot)
+            .map_err(|e| view_error(view, e))?;
+        let visible_schemas = if snapshot_id == view.begin_snapshot {
+            creation_schemas.clone()
+        } else {
+            provider
+                .list_schemas(snapshot_id)
+                .map_err(|e| view_error(view, e))?
+        };
+        (creation_schemas, visible_schemas)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    resolve_view_sql(
+        &view.sql,
+        schema_name,
+        dialect,
+        &creation_schemas,
+        &visible_schemas,
+    )
+    .map_err(|e| view_error(view, e))
+}
+
+fn resolve_view_sql(
+    sql: &str,
+    schema_name: &str,
+    dialect: Dialect,
+    creation_schemas: &[SchemaMetadata],
+    visible_schemas: &[SchemaMetadata],
+) -> crate::Result<String> {
+    let is_duckdb = dialect == Dialect::DuckDB;
+    let dialect = dialect_from_str(dialect.as_ref()).ok_or_else(|| {
+        crate::DuckLakeError::Unsupported(format!("SQL dialect '{}'", dialect.as_ref()))
+    })?;
+    let tokens = match Tokenizer::new(dialect.as_ref(), sql)
+        .with_unescape(false)
+        .tokenize()
+    {
+        Ok(tokens) => tokens,
+        Err(_) => return Ok(sql.to_string()),
+    };
+
+    let quoted_schema = Ident::with_quote('"', schema_name).to_string();
+    let mut resolved = String::with_capacity(sql.len() + quoted_schema.len());
+    let mut index = 0;
+    while index < tokens.len() {
+        if is_catalog_placeholder(&tokens, index) {
+            resolved.push_str(VIEW_CATALOG);
+            resolved.push('.');
+            let first_part = next_non_whitespace(&tokens, index + 4);
+            let second_part = first_part.and_then(|part| next_non_whitespace(&tokens, part + 1));
+            if first_part.is_some_and(|part| matches!(tokens[part], Token::Word(_)))
+                && second_part.is_none_or(|part| tokens[part] != Token::Period)
+            {
+                resolved.push_str(&quoted_schema);
+                resolved.push('.');
+            }
+            index += 4;
+            continue;
+        }
+
+        if reserved_catalog_qualifier(&tokens, index) {
+            return Err(crate::DuckLakeError::Unsupported(format!(
+                "reserved view catalog qualifier '{VIEW_CATALOG}'"
+            )));
+        }
+        resolved.push_str(&tokens[index].to_string());
+        index += 1;
+    }
+
+    let mut statements = match Parser::parse_sql(dialect.as_ref(), &resolved) {
+        Ok(statements) => statements,
+        Err(_) => return Ok(resolved),
+    };
+    let mut changed = false;
+    if let ControlFlow::Break(relation) = visit_relations_mut(&mut statements, |relation| {
+        let parts = relation
+            .0
+            .iter()
+            .map(|part| part.as_ident().cloned())
+            .collect::<Option<Vec<_>>>();
+        let Some(parts) = parts else {
+            return ControlFlow::Break(relation.to_string());
+        };
+        match parts.as_slice() {
+            [_] => ControlFlow::Continue(()),
+            [schema, _] if is_duckdb => {
+                let canonical = match canonical_schema(schema, creation_schemas, visible_schemas) {
+                    Ok(canonical) => canonical,
+                    Err(()) => return ControlFlow::Break(relation.to_string()),
+                };
+                relation
+                    .0
+                    .insert(0, ObjectNamePart::Identifier(Ident::new(VIEW_CATALOG)));
+                relation.0[1] = ObjectNamePart::Identifier(Ident::with_quote('"', canonical));
+                changed = true;
+                ControlFlow::Continue(())
+            },
+            [catalog, schema, _]
+                if catalog.quote_style.is_none() && catalog.value == VIEW_CATALOG =>
+            {
+                if is_duckdb {
+                    let canonical =
+                        match canonical_schema(schema, creation_schemas, visible_schemas) {
+                            Ok(canonical) => canonical,
+                            Err(()) => return ControlFlow::Break(relation.to_string()),
+                        };
+                    let canonical = ObjectNamePart::Identifier(Ident::with_quote('"', canonical));
+                    if relation.0[1] != canonical {
+                        relation.0[1] = canonical;
+                        changed = true;
+                    }
+                }
+                ControlFlow::Continue(())
+            },
+            _ => ControlFlow::Break(relation.to_string()),
+        }
+    }) {
+        return Err(crate::DuckLakeError::Unsupported(format!(
+            "ambiguous catalog-qualified relation '{relation}'"
+        )));
+    }
+    if changed {
+        Ok(statements
+            .into_iter()
+            .map(|statement| statement.to_string())
+            .collect::<Vec<_>>()
+            .join("; "))
+    } else {
+        Ok(resolved)
+    }
+}
+
+fn canonical_schema<'a>(
+    identifier: &Ident,
+    creation_schemas: &[SchemaMetadata],
+    visible_schemas: &'a [SchemaMetadata],
+) -> std::result::Result<&'a str, ()> {
+    let mut creation_matches = creation_schemas
+        .iter()
+        .filter(|schema| schema.schema_name.eq_ignore_ascii_case(&identifier.value));
+    let created = creation_matches.next().ok_or(())?;
+    if creation_matches.next().is_some() {
+        return Err(());
+    }
+    let mut visible_matches = visible_schemas
+        .iter()
+        .filter(|schema| schema.schema_id == created.schema_id);
+    let visible = visible_matches.next().ok_or(())?;
+    if visible_matches.next().is_some() {
+        return Err(());
+    }
+    visible
+        .schema_name
+        .eq_ignore_ascii_case(&identifier.value)
+        .then_some(visible.schema_name.as_str())
+        .ok_or(())
+}
+
+fn is_catalog_placeholder(tokens: &[Token], index: usize) -> bool {
+    if index
+        .checked_sub(1)
+        .is_some_and(|previous| matches!(tokens[previous], Token::Word(_)))
+    {
+        return false;
+    }
+    matches!(
+        tokens.get(index..index + 4),
+        Some([Token::LBrace, Token::Word(word), Token::RBrace, Token::Period])
+            if word.quote_style.is_none() && word.value == "DUCKLAKE_CATALOG"
+    )
+}
+
+fn next_non_whitespace(tokens: &[Token], start: usize) -> Option<usize> {
+    (start..tokens.len()).find(|index| !matches!(tokens[*index], Token::Whitespace(_)))
+}
+
+fn reserved_catalog_qualifier(tokens: &[Token], index: usize) -> bool {
+    let Token::Word(word) = &tokens[index] else {
+        return false;
+    };
+    word.value == VIEW_CATALOG
+        && next_non_whitespace(tokens, index + 1).is_some_and(|next| tokens[next] == Token::Period)
+}
+
+fn view_error(view: &ViewMetadata, error: impl std::fmt::Display) -> DataFusionError {
+    DataFusionError::Plan(format!(
+        "DuckLake view '{}' with dialect '{}' could not be planned: {error}",
+        view.view_name, view.dialect
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::logical_expr::lit;
+
+    fn schema(schema_id: i64, schema_name: &str) -> SchemaMetadata {
+        SchemaMetadata {
+            schema_id,
+            schema_name: schema_name.to_string(),
+            path: String::new(),
+            path_is_relative: true,
+        }
+    }
+
+    fn schemas() -> Vec<SchemaMetadata> {
+        vec![
+            schema(1, "main"),
+            schema(2, "s1"),
+            schema(3, "MySchema"),
+            schema(4, "odd schema\"name"),
+        ]
+    }
+
+    fn resolve(sql: &str, schema_name: &str) -> crate::Result<String> {
+        let schemas = schemas();
+        resolve_view_sql(sql, schema_name, Dialect::DuckDB, &schemas, &schemas)
+    }
+
+    #[test]
+    fn parses_quoted_aliases() {
+        assert_eq!(
+            parse_aliases(r#""left","embedded""quote","right""#).unwrap(),
+            vec!["left", "embedded\"quote", "right"]
+        );
+    }
+
+    #[test]
+    fn resolves_only_unquoted_catalog_placeholders() {
+        assert_eq!(
+            resolve(
+                "SELECT * FROM {DUCKLAKE_CATALOG}.t WHERE note = '{DUCKLAKE_CATALOG}.t'",
+                "main",
+            )
+            .unwrap(),
+            "SELECT * FROM __ducklake_view.\"main\".t WHERE note = '{DUCKLAKE_CATALOG}.t'"
+        );
+        assert_eq!(
+            resolve(
+                "SELECT my{DUCKLAKE_CATALOG}.id FROM {DUCKLAKE_CATALOG}.main.t AS mydb",
+                "main",
+            )
+            .unwrap(),
+            "SELECT my{DUCKLAKE_CATALOG}.id FROM __ducklake_view.main.t AS mydb"
+        );
+        assert_eq!(
+            resolve("SELECT * FROM other_db.main.events", "main")
+                .unwrap_err()
+                .to_string(),
+            "Unsupported feature: ambiguous catalog-qualified relation 'other_db.main.events'"
+        );
+    }
+
+    #[test]
+    fn preserves_placeholders_in_quoted_text_and_comments() {
+        let sql = "SELECT '{DUCKLAKE_CATALOG}.literal', $$ {DUCKLAKE_CATALOG}.dollar $$\n\
+                   FROM {DUCKLAKE_CATALOG}.items -- don't rewrite {DUCKLAKE_CATALOG}.comment\n";
+        let resolved = resolve(sql, "odd schema\"name").unwrap();
+        assert!(resolved.contains("'{DUCKLAKE_CATALOG}.literal'"));
+        assert!(resolved.contains("$$ {DUCKLAKE_CATALOG}.dollar $$"));
+        assert!(resolved.contains("-- don't rewrite {DUCKLAKE_CATALOG}.comment"));
+        assert!(resolved.contains("FROM __ducklake_view.\"odd schema\"\"name\".items"));
+    }
+
+    #[test]
+    fn rejects_reserved_and_legacy_qualifiers() {
+        for sql in [
+            "SELECT * FROM lake.users",
+            "SELECT * FROM {DUCKLAKE_CATALOG}.users JOIN __ducklake_view.audit_log USING (id)",
+            "SELECT * FROM {DUCKLAKE_CATALOG}.users JOIN \"__ducklake_view\".audit_log USING (id)",
+        ] {
+            assert!(resolve(sql, "main").is_err());
+        }
+    }
+
+    #[test]
+    fn resolves_creation_time_schema_qualifiers_and_canonical_case() {
+        assert_eq!(
+            resolve("SELECT * FROM main.t JOIN s1.u USING (id)", "main").unwrap(),
+            "SELECT * FROM __ducklake_view.\"main\".t JOIN __ducklake_view.\"s1\".u USING(id)"
+        );
+        assert_eq!(
+            resolve("SELECT * FROM {DUCKLAKE_CATALOG}.MySchema.m", "main",).unwrap(),
+            "SELECT * FROM __ducklake_view.\"MySchema\".m"
+        );
+    }
+
+    #[test]
+    fn rejects_later_schema_collisions_and_recreated_schemas() {
+        let creation = schemas();
+        let mut visible = schemas();
+        visible.push(schema(5, "ext"));
+        assert!(
+            resolve_view_sql(
+                "SELECT * FROM ext.t",
+                "main",
+                Dialect::DuckDB,
+                &creation,
+                &visible,
+            )
+            .is_err()
+        );
+
+        let visible = vec![schema(1, "main"), schema(9, "s1")];
+        assert!(
+            resolve_view_sql(
+                "SELECT * FROM s1.u",
+                "main",
+                Dialect::DuckDB,
+                &creation,
+                &visible,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn applies_partial_alias_list() {
+        let plan = LogicalPlanBuilder::empty(false)
+            .project(vec![lit(1).alias("first"), lit(2).alias("second")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let view = ViewMetadata {
+            view_id: 1,
+            schema_id: 1,
+            begin_snapshot: 1,
+            view_name: "partial".to_string(),
+            dialect: "duckdb".to_string(),
+            sql: "SELECT 1, 2".to_string(),
+            column_aliases: Some("\"renamed\"".to_string()),
+        };
+
+        let plan = apply_aliases(plan, &view).unwrap();
+        assert_eq!(
+            plan.schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            vec!["renamed", "second"]
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -72,4 +72,5 @@ mod table_deletions_repartition_tests;
 mod table_tests;
 mod time_travel_tests;
 mod type_promotion_tests;
+mod view_tests;
 mod write_tests;

--- a/tests/it/multicatalog_hardening_tests.rs
+++ b/tests/it/multicatalog_hardening_tests.rs
@@ -1018,3 +1018,76 @@ async fn unknown_catalog_id_errors_clearly_on_lock() {
         err
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn multicatalog_provider_lists_and_resolves_views() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("views")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let setup = writer
+        .begin_write_transaction("public", "items", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    let committed = writer
+        .publish_snapshot(
+            setup.table_id,
+            "public",
+            "items",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &users_cols(),
+            &setup.column_ids,
+        )
+        .unwrap();
+
+    let schema_id: i64 = sqlx::query_scalar(
+        "SELECT s.schema_id FROM ducklake_schema s
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+         WHERE m.catalog_id = $1 AND s.schema_name = 'public' AND s.end_snapshot IS NULL",
+    )
+    .bind(catalog_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_view
+         (view_id, view_uuid, begin_snapshot, end_snapshot, schema_id, view_name, dialect, sql, column_aliases)
+         VALUES ($1, '00000000-0000-0000-0000-000000000001'::uuid, $2, NULL, $3, $4, $5, $6, $7)",
+    )
+    .bind(1_i64)
+    .bind(committed.snapshot_id)
+    .bind(schema_id)
+    .bind("active_items")
+    .bind("duckdb")
+    .bind("SELECT * FROM {DUCKLAKE_CATALOG}.public.items")
+    .bind("")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let provider = MulticatalogProvider::with_pool_and_id(pool, catalog_id)
+        .await
+        .unwrap();
+    let views = provider
+        .list_views(schema_id, committed.snapshot_id)
+        .unwrap();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].view_name, "active_items");
+    assert_eq!(views[0].begin_snapshot, committed.snapshot_id);
+    assert_eq!(
+        provider
+            .get_view_by_name(schema_id, "active_items", committed.snapshot_id)
+            .unwrap(),
+        Some(views[0].clone())
+    );
+    let all_views = provider.list_all_views(committed.snapshot_id).unwrap();
+    assert_eq!(all_views.len(), 1);
+    assert_eq!(all_views[0].schema_name, "public");
+    assert_eq!(all_views[0].view, views[0]);
+}

--- a/tests/it/mysql_metadata_provider_test.rs
+++ b/tests/it/mysql_metadata_provider_test.rs
@@ -71,6 +71,22 @@ async fn init_schema(pool: &MySqlPool) -> anyhow::Result<()> {
     .await?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_view (
+            view_id BIGINT,
+            view_uuid VARCHAR(36),
+            schema_id BIGINT NOT NULL,
+            view_name VARCHAR(255) NOT NULL,
+            dialect VARCHAR(255) NOT NULL,
+            `sql` TEXT NOT NULL,
+            column_aliases TEXT,
+            begin_snapshot BIGINT NOT NULL,
+            end_snapshot BIGINT
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_column (
             column_id BIGINT PRIMARY KEY,
             table_id BIGINT NOT NULL,
@@ -655,6 +671,52 @@ async fn test_list_tables() {
     let table_names: Vec<_> = tables.iter().map(|t| t.table_name.as_str()).collect();
     assert!(table_names.contains(&"users"));
     assert!(table_names.contains(&"products"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn test_list_views() -> anyhow::Result<()> {
+    let (provider, _container) = create_mysql_provider().await?;
+    populate_test_data(&provider).await?;
+    sqlx::query(
+        "INSERT INTO ducklake_view
+         (view_id, schema_id, view_name, dialect, `sql`, column_aliases, begin_snapshot, end_snapshot)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(7i64)
+    .bind(1i64)
+    .bind("active_view")
+    .bind("duckdb")
+    .bind("SELECT id FROM users")
+    .bind("\"identifier\"")
+    .bind(2i64)
+    .bind(None::<i64>)
+    .bind(8i64)
+    .bind(1i64)
+    .bind("expired_view")
+    .bind("duckdb")
+    .bind("SELECT name FROM users")
+    .bind("")
+    .bind(1i64)
+    .bind(2i64)
+    .execute(&provider.pool)
+    .await?;
+
+    assert_eq!(provider.list_views(1, 1)?[0].view_name, "expired_view");
+    let views = provider.list_views(1, 2)?;
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].view_name, "active_view");
+    assert_eq!(views[0].begin_snapshot, 2);
+    assert_eq!(views[0].column_aliases.as_deref(), Some("\"identifier\""));
+    assert_eq!(
+        provider.get_view_by_name(1, "active_view", 2)?,
+        Some(views[0].clone())
+    );
+    let all_views = provider.list_all_views(2)?;
+    assert_eq!(all_views.len(), 1);
+    assert_eq!(all_views[0].schema_name, "test_schema");
+    assert_eq!(all_views[0].view, views[0]);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/postgres_metadata_provider_test.rs
+++ b/tests/it/postgres_metadata_provider_test.rs
@@ -71,6 +71,22 @@ async fn init_schema(pool: &PgPool) -> anyhow::Result<()> {
     .await?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_view (
+            view_id BIGINT,
+            view_uuid UUID,
+            schema_id BIGINT NOT NULL,
+            view_name VARCHAR NOT NULL,
+            dialect VARCHAR NOT NULL,
+            sql VARCHAR NOT NULL,
+            column_aliases VARCHAR,
+            begin_snapshot BIGINT NOT NULL,
+            end_snapshot BIGINT
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_column (
             column_id BIGINT PRIMARY KEY,
             table_id BIGINT NOT NULL,
@@ -679,6 +695,53 @@ async fn test_list_tables() {
     let table_names: Vec<_> = tables.iter().map(|t| t.table_name.as_str()).collect();
     assert!(table_names.contains(&"users"));
     assert!(table_names.contains(&"products"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn test_list_views() -> anyhow::Result<()> {
+    let (provider, _container) = create_postgres_provider().await?;
+    populate_test_data(&provider).await?;
+    sqlx::query(
+        "INSERT INTO ducklake_view
+         (view_id, schema_id, view_name, dialect, sql, column_aliases, begin_snapshot, end_snapshot)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8),
+                ($9, $10, $11, $12, $13, $14, $15, $16)",
+    )
+    .bind(7i64)
+    .bind(1i64)
+    .bind("active_view")
+    .bind("duckdb")
+    .bind("SELECT id FROM users")
+    .bind("\"identifier\"")
+    .bind(2i64)
+    .bind(None::<i64>)
+    .bind(8i64)
+    .bind(1i64)
+    .bind("expired_view")
+    .bind("duckdb")
+    .bind("SELECT name FROM users")
+    .bind("")
+    .bind(1i64)
+    .bind(2i64)
+    .execute(&provider.pool)
+    .await?;
+
+    assert_eq!(provider.list_views(1, 1)?[0].view_name, "expired_view");
+    let views = provider.list_views(1, 2)?;
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].view_name, "active_view");
+    assert_eq!(views[0].begin_snapshot, 2);
+    assert_eq!(views[0].column_aliases.as_deref(), Some("\"identifier\""));
+    assert_eq!(
+        provider.get_view_by_name(1, "active_view", 2)?,
+        Some(views[0].clone())
+    );
+    let all_views = provider.list_all_views(2)?;
+    assert_eq!(all_views.len(), 1);
+    assert_eq!(all_views[0].schema_name, "test_schema");
+    assert_eq!(all_views[0].view, views[0]);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/sql_write_tests.rs
+++ b/tests/it/sql_write_tests.rs
@@ -12,6 +12,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
+use sqlx::SqlitePool;
 use tempfile::TempDir;
 
 use datafusion_ducklake::{
@@ -48,6 +49,29 @@ async fn create_writable_catalog() -> (SessionContext, TempDir) {
     let ctx = SessionContext::new();
     ctx.register_catalog("ducklake", Arc::new(catalog));
 
+    (ctx, temp_dir)
+}
+
+async fn create_writable_catalog_with_main_schema() -> (SessionContext, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let connection = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let writer = SqliteMetadataWriter::new_with_init(&connection)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let snapshot_id = writer.create_snapshot().unwrap();
+    writer
+        .get_or_create_schema("main", None, snapshot_id)
+        .unwrap();
+
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
     (ctx, temp_dir)
 }
 
@@ -93,8 +117,7 @@ async fn test_create_table_as_select() {
     // Check if CTAS is supported - it may not be fully implemented yet
     match result {
         Ok(df) => {
-            // Execute the statement
-            let _batches = df.collect().await.unwrap();
+            df.collect().await.unwrap();
 
             // Verify table was created by reading it back with fresh context
             let read_ctx = create_read_context(&temp_dir).await;
@@ -109,10 +132,127 @@ async fn test_create_table_as_select() {
             assert_eq!(total_rows, 3);
         },
         Err(e) => {
-            // CTAS may not be fully supported yet - this is expected
-            println!("CREATE TABLE AS SELECT not yet fully supported: {}", e);
+            println!("CREATE TABLE AS SELECT not yet fully supported: {e}");
         },
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_legacy_catalog_without_view_metadata_keeps_ctas_working() {
+    let (ctx, temp_dir) = create_writable_catalog_with_main_schema().await;
+    let connection = format!(
+        "sqlite:{}?mode=rwc",
+        temp_dir.path().join("test.db").display()
+    );
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+
+    let columns = sqlx::query_scalar::<_, String>(
+        "SELECT name FROM pragma_table_info('ducklake_view') ORDER BY cid",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        columns,
+        vec![
+            "view_id",
+            "view_uuid",
+            "begin_snapshot",
+            "end_snapshot",
+            "schema_id",
+            "view_name",
+            "dialect",
+            "sql",
+            "column_aliases",
+        ]
+    );
+
+    sqlx::query("DROP TABLE ducklake_view")
+        .execute(&pool)
+        .await
+        .unwrap();
+    pool.close().await;
+
+    let error = ctx
+        .sql("SELECT * FROM ducklake.main.missing")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("table 'ducklake.main.missing' not found"),
+        "{error}"
+    );
+
+    ctx.sql("CREATE TABLE ducklake.main.created AS SELECT 1 AS id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let views = ctx
+        .sql("SELECT * FROM ducklake.information_schema.views")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(views.iter().map(|batch| batch.num_rows()).sum::<usize>(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_view_is_queryable_and_blocks_table_shadowing() {
+    let (ctx, temp_dir) = create_writable_catalog_with_main_schema().await;
+    let connection = format!(
+        "sqlite:{}?mode=rwc",
+        temp_dir.path().join("test.db").display()
+    );
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    let schema_id = sqlx::query_scalar::<_, i64>(
+        "SELECT schema_id FROM ducklake_schema WHERE schema_name = 'main' AND end_snapshot IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO ducklake_view
+         (view_id, view_uuid, begin_snapshot, end_snapshot, schema_id, view_name, dialect, sql, column_aliases)
+         VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)",
+    )
+    .bind(1_i64)
+    .bind("00000000-0000-0000-0000-000000000001")
+    .bind(1_i64)
+    .bind(schema_id)
+    .bind("constant_view")
+    .bind("duckdb")
+    .bind("SELECT 42 AS answer")
+    .bind("")
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let batches = ctx
+        .sql("SELECT answer FROM ducklake.main.constant_view")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let answer = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(answer.values(), &[42]);
+
+    let error = ctx
+        .sql("CREATE TABLE ducklake.main.constant_view AS SELECT 1 AS id")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("already exists"), "{error}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/sqlite_metadata_provider_test.rs
+++ b/tests/it/sqlite_metadata_provider_test.rs
@@ -68,6 +68,22 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_view (
+            view_id INTEGER,
+            view_uuid TEXT,
+            schema_id INTEGER NOT NULL,
+            view_name TEXT NOT NULL,
+            dialect TEXT NOT NULL,
+            sql TEXT NOT NULL,
+            column_aliases TEXT,
+            begin_snapshot INTEGER NOT NULL,
+            end_snapshot INTEGER
+        )",
+    )
+    .execute(pool)
+    .await?;
+
     // Schema must match SQL_CREATE_SCHEMA in metadata_writer_sqlite.rs.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_column (
@@ -645,6 +661,51 @@ async fn test_list_tables() {
     let table_names: Vec<_> = tables.iter().map(|t| t.table_name.as_str()).collect();
     assert!(table_names.contains(&"users"));
     assert!(table_names.contains(&"products"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_views() -> anyhow::Result<()> {
+    let provider = create_sqlite_provider().await?;
+    populate_test_data(&provider).await?;
+    sqlx::query(
+        "INSERT INTO ducklake_view
+         (view_id, schema_id, view_name, dialect, sql, column_aliases, begin_snapshot, end_snapshot)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(7i64)
+    .bind(1i64)
+    .bind("active_view")
+    .bind("duckdb")
+    .bind("SELECT id FROM users")
+    .bind("\"identifier\"")
+    .bind(2i64)
+    .bind(None::<i64>)
+    .bind(8i64)
+    .bind(1i64)
+    .bind("expired_view")
+    .bind("duckdb")
+    .bind("SELECT name FROM users")
+    .bind("")
+    .bind(1i64)
+    .bind(2i64)
+    .execute(&provider.pool)
+    .await?;
+
+    assert_eq!(provider.list_views(1, 1)?[0].view_name, "expired_view");
+    let views = provider.list_views(1, 2)?;
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].view_name, "active_view");
+    assert_eq!(views[0].begin_snapshot, 2);
+    assert_eq!(views[0].column_aliases.as_deref(), Some("\"identifier\""));
+    assert_eq!(
+        provider.get_view_by_name(1, "active_view", 2)?,
+        Some(views[0].clone())
+    );
+    let all_views = provider.list_all_views(2)?;
+    assert_eq!(all_views.len(), 1);
+    assert_eq!(all_views[0].schema_name, "test_schema");
+    assert_eq!(all_views[0].view, views[0]);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/view_tests.rs
+++ b/tests/it/view_tests.rs
@@ -1,0 +1,360 @@
+#![cfg(feature = "metadata-duckdb")]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::util::display::{ArrayFormatter, FormatOptions};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+use tempfile::TempDir;
+
+fn create_view_catalog(catalog_path: &Path, data_path: &Path) -> anyhow::Result<()> {
+    let connection = duckdb::Connection::open_in_memory()?;
+    crate::common::ensure_ducklake_installed();
+    connection.execute("LOAD ducklake", [])?;
+    connection.execute(
+        &format!(
+            "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 0)",
+            catalog_path.display(),
+            data_path.display()
+        ),
+        [],
+    )?;
+    connection.execute("CREATE TABLE lake.users(id INTEGER, name VARCHAR)", [])?;
+    connection.execute("CREATE TABLE lake.scores(id INTEGER, score INTEGER)", [])?;
+    connection.execute("CREATE TABLE lake.aliases(id INTEGER, myid INTEGER)", [])?;
+    connection.execute("CREATE SCHEMA lake.s1", [])?;
+    connection.execute("CREATE TABLE lake.s1.cross_values(value INTEGER)", [])?;
+    connection.execute("CREATE SCHEMA lake.MySchema", [])?;
+    connection.execute("CREATE TABLE lake.MySchema.mixed_values(value INTEGER)", [])?;
+    connection.execute("ATTACH ':memory:' AS ext", [])?;
+    connection.execute("CREATE TABLE ext.main.collision(value INTEGER)", [])?;
+    connection.execute(
+        "INSERT INTO lake.users VALUES (1, 'one'), (2, 'two'), (3, 'three')",
+        [],
+    )?;
+    connection.execute("INSERT INTO lake.scores VALUES (2, 20), (3, 30)", [])?;
+    connection.execute("INSERT INTO lake.aliases VALUES (1, 99)", [])?;
+    connection.execute("INSERT INTO lake.s1.cross_values VALUES (41)", [])?;
+    connection.execute("INSERT INTO lake.MySchema.mixed_values VALUES (42)", [])?;
+    connection.execute(
+        "CREATE VIEW lake.filtered(identifier, label) AS
+         SELECT id, upper(name) FROM lake.users WHERE id > 1",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.joined AS
+         SELECT users.id, users.name, scores.score
+         FROM lake.users JOIN lake.scores USING (id)",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.duckdb_only AS SELECT COLUMNS('id') FROM lake.users",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.semantics AS
+         SELECT id, CASE WHEN score IS NULL THEN -1 ELSE score + 1 END AS adjusted
+         FROM lake.scores",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.placeholder_collision AS
+         SELECT mylake.id FROM lake.aliases AS mylake",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.rowid_values AS SELECT rowid FROM lake.users",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.rowids AS SELECT rowid FROM lake.rowid_values",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW lake.legacy_qualified AS SELECT id FROM lake.users",
+        [],
+    )?;
+    connection.execute("USE lake", [])?;
+    connection.execute(
+        "CREATE VIEW main.schema_qualified AS SELECT * FROM s1.cross_values",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW main.mixed_schema AS SELECT * FROM MySchema.mixed_values",
+        [],
+    )?;
+    connection.execute(
+        "CREATE VIEW main.external_qualified AS SELECT * FROM ext.collision",
+        [],
+    )?;
+    connection.execute("CREATE SCHEMA lake.ext", [])?;
+    connection.execute("CREATE TABLE lake.ext.collision(value INTEGER)", [])?;
+    connection.execute("INSERT INTO lake.ext.collision VALUES (99)", [])?;
+    Ok(())
+}
+
+fn stored_view_sql(catalog_path: &Path, view_name: &str) -> anyhow::Result<String> {
+    let connection = duckdb::Connection::open(catalog_path)?;
+    Ok(connection.query_row(
+        "SELECT sql FROM ducklake_view WHERE view_name = ?",
+        [view_name],
+        |row| row.get(0),
+    )?)
+}
+
+fn normalize_current_view_sql(catalog_path: &Path) -> anyhow::Result<()> {
+    let connection = duckdb::Connection::open(catalog_path)?;
+    connection.execute(
+        "UPDATE ducklake_view
+         SET sql = replace(sql, 'lake.', '{DUCKLAKE_CATALOG}.')
+         WHERE view_name <> 'legacy_qualified'",
+        [],
+    )?;
+    Ok(())
+}
+
+fn duckdb_rows(
+    catalog_path: &Path,
+    data_path: &Path,
+    sql: &str,
+) -> anyhow::Result<Vec<Vec<String>>> {
+    let connection = duckdb::Connection::open_in_memory()?;
+    connection.execute("LOAD ducklake", [])?;
+    connection.execute(
+        &format!(
+            "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}')",
+            catalog_path.display(),
+            data_path.display()
+        ),
+        [],
+    )?;
+    let mut statement = connection.prepare(sql)?;
+    let rows = statement
+        .query_map([], |row| {
+            (0..row.as_ref().column_count())
+                .map(|column| row.get::<_, String>(column))
+                .collect::<Result<Vec<_>, _>>()
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+async fn datafusion_rows(context: &SessionContext, sql: &str) -> anyhow::Result<Vec<Vec<String>>> {
+    let batches = context.sql(sql).await?.collect().await?;
+    let options = FormatOptions::default();
+    let mut rows = Vec::new();
+    for batch in batches {
+        let formatters = batch
+            .columns()
+            .iter()
+            .map(|array| ArrayFormatter::try_new(array.as_ref(), &options))
+            .collect::<Result<Vec<_>, _>>()?;
+        for row in 0..batch.num_rows() {
+            rows.push(
+                formatters
+                    .iter()
+                    .map(|formatter| formatter.value(row).to_string())
+                    .collect(),
+            );
+        }
+    }
+    Ok(rows)
+}
+
+#[tokio::test]
+async fn duckdb_views_are_listed_and_queryable() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    let catalog_path = temp.path().join("views.ducklake");
+    let data_path = temp.path().join("data");
+    create_view_catalog(&catalog_path, &data_path)?;
+    let oracle_queries = [
+        "SELECT CAST(identifier AS VARCHAR) AS identifier_text, label
+         FROM lake.filtered ORDER BY identifier",
+        "SELECT CAST(id AS VARCHAR) AS id_text, name, CAST(score AS VARCHAR) AS score_text
+         FROM lake.joined ORDER BY id",
+        "SELECT CAST(id AS VARCHAR) AS id_text, CAST(adjusted AS VARCHAR) AS adjusted_text
+         FROM lake.semantics ORDER BY id",
+        "SELECT CAST(value AS VARCHAR) AS value_text FROM lake.schema_qualified",
+        "SELECT CAST(value AS VARCHAR) AS value_text FROM lake.mixed_schema",
+    ];
+    let oracle_rows = oracle_queries
+        .iter()
+        .map(|query| duckdb_rows(&catalog_path, &data_path, query))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let rowid_oracle = duckdb_rows(
+        &catalog_path,
+        &data_path,
+        "SELECT CAST(rowid AS VARCHAR) AS rowid_text FROM lake.rowids ORDER BY rowid",
+    )?;
+    assert!(stored_view_sql(&catalog_path, "filtered")?.contains("lake.users"));
+    normalize_current_view_sql(&catalog_path)?;
+    assert!(stored_view_sql(&catalog_path, "filtered")?.contains("{DUCKLAKE_CATALOG}.users"));
+    assert!(stored_view_sql(&catalog_path, "legacy_qualified")?.contains("lake.users"));
+    assert!(stored_view_sql(&catalog_path, "schema_qualified")?.contains("s1.cross_values"));
+    assert!(stored_view_sql(&catalog_path, "mixed_schema")?.contains("MySchema.mixed_values"));
+    assert!(stored_view_sql(&catalog_path, "external_qualified")?.contains("ext.collision"));
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+
+    let schema = context.catalog("ducklake").unwrap().schema("main").unwrap();
+    assert_eq!(
+        schema.table_names(),
+        vec![
+            "aliases",
+            "duckdb_only",
+            "external_qualified",
+            "filtered",
+            "joined",
+            "legacy_qualified",
+            "mixed_schema",
+            "placeholder_collision",
+            "rowid_values",
+            "rowids",
+            "schema_qualified",
+            "scores",
+            "semantics",
+            "users",
+        ]
+    );
+    assert!(schema.table_exist("filtered"));
+
+    context
+        .sql("SELECT * FROM ducklake.main.filtered")
+        .await?
+        .collect()
+        .await?;
+
+    for (query, expected) in oracle_queries.into_iter().zip(oracle_rows) {
+        let datafusion_query = query.replace("lake.", "ducklake.main.");
+        assert_eq!(
+            datafusion_rows(&context, &datafusion_query).await?,
+            expected
+        );
+    }
+
+    let views = datafusion_rows(
+        &context,
+        "SELECT schema_name, view_name, dialect, column_aliases
+         FROM ducklake.information_schema.views
+         ORDER BY view_name",
+    )
+    .await?;
+    assert_eq!(
+        views,
+        vec![
+            vec!["main", "duckdb_only", "duckdb", ""],
+            vec!["main", "external_qualified", "duckdb", ""],
+            vec!["main", "filtered", "duckdb", "\"identifier\",\"label\""],
+            vec!["main", "joined", "duckdb", ""],
+            vec!["main", "legacy_qualified", "duckdb", ""],
+            vec!["main", "mixed_schema", "duckdb", ""],
+            vec!["main", "placeholder_collision", "duckdb", ""],
+            vec!["main", "rowid_values", "duckdb", ""],
+            vec!["main", "rowids", "duckdb", ""],
+            vec!["main", "schema_qualified", "duckdb", ""],
+            vec!["main", "semantics", "duckdb", ""],
+        ]
+    );
+
+    let error = context
+        .sql("SELECT * FROM ducklake.main.duckdb_only")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("DuckLake view 'duckdb_only'"), "{error}");
+    assert!(error.contains("dialect 'duckdb'"), "{error}");
+
+    let error = context
+        .sql("SELECT * FROM ducklake.main.placeholder_collision")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("DuckLake view 'placeholder_collision'"),
+        "{error}"
+    );
+
+    let error = context
+        .sql("SELECT * FROM ducklake.main.legacy_qualified")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("DuckLake view 'legacy_qualified'"),
+        "{error}"
+    );
+
+    let error = context
+        .sql("SELECT * FROM ducklake.main.external_qualified")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("DuckLake view 'external_qualified'"),
+        "{error}"
+    );
+
+    let enumeration_provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?;
+    let enumeration_catalog = DuckLakeCatalog::new(enumeration_provider)?;
+    let enumeration_context =
+        SessionContext::new_with_config(SessionConfig::new().with_information_schema(true));
+    enumeration_context.register_catalog("ducklake", Arc::new(enumeration_catalog));
+
+    let built_in_views = datafusion_rows(
+        &enumeration_context,
+        "SELECT table_name, definition
+         FROM information_schema.views
+         WHERE table_catalog = 'ducklake' AND table_schema = 'main'
+         ORDER BY table_name",
+    )
+    .await?;
+    assert_eq!(built_in_views.len(), 14);
+    let definition = |name: &str| {
+        built_in_views
+            .iter()
+            .find(|row| row[0] == name)
+            .map(|row| row[1].as_str())
+            .unwrap()
+    };
+    assert!(!definition("filtered").contains("{DUCKLAKE_CATALOG}"));
+    assert!(definition("placeholder_collision").contains("{DUCKLAKE_CATALOG}"));
+
+    datafusion_rows(
+        &enumeration_context,
+        "SELECT table_name, column_name
+         FROM information_schema.columns
+         WHERE table_catalog = 'ducklake' AND table_schema = 'main'
+         ORDER BY table_name, ordinal_position",
+    )
+    .await?;
+
+    let lineage_provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy())?;
+    let lineage_catalog = DuckLakeCatalog::new(lineage_provider)?.with_row_lineage(true);
+    let lineage_context = SessionContext::new();
+    lineage_context.register_catalog("ducklake", Arc::new(lineage_catalog));
+    assert_eq!(
+        datafusion_rows(
+            &lineage_context,
+            "SELECT CAST(rowid AS VARCHAR) AS rowid_text FROM ducklake.main.rowids ORDER BY rowid",
+        )
+        .await?,
+        rowid_oracle
+    );
+    Ok(())
+}

--- a/tests/it/write_tests.rs
+++ b/tests/it/write_tests.rs
@@ -125,11 +125,7 @@ fn assert_duckdb_extension_reads_depths(catalog_path: &std::path::Path) {
              mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, \
              target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN \
          ); \
-         CREATE TABLE raw.ducklake_view( \
-             view_id BIGINT, view_uuid VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, \
-             schema_id BIGINT, view_name VARCHAR, dialect VARCHAR, sql VARCHAR, column_aliases VARCHAR \
-         ); \
-         CREATE TABLE raw.ducklake_macro( \
+             CREATE TABLE raw.ducklake_macro( \
              schema_id BIGINT, macro_id BIGINT, macro_name VARCHAR, \
              begin_snapshot BIGINT, end_snapshot BIGINT \
          ); \


### PR DESCRIPTION
### Summary

Expose snapshot-visible `ducklake_view` entries through every metadata provider, schema discovery,
and `ducklake.information_schema.views`. Queryable definitions become standard DataFusion
`ViewTable` providers using the recorded dialect and DuckLake's quoted `column_aliases` format.

The review follow-up makes that support safe for both catalog generations. Providers probe
`ducklake_view` as an optional schema capability, so table-only catalogs retain normal lookup and
CTAS behavior; writers create the official nine-column table including `view_uuid`. Current
`{DUCKLAKE_CATALOG}.` definitions resolve through a private snapshot-pinned catalog. DuckDB
`schema.table` bodies resolve only through a schema generation visible both when the view was
created and at the requested snapshot; foreign or unstable qualifiers fail loudly.

### View planning flow

```mermaid
flowchart LR
    Metadata["ducklake_view metadata"] --> Capability{"View table exists?"}
    Capability -->|No| TablesOnly["Table-only catalog"]
    Capability -->|Yes| Resolve["Restore catalog and schema identity"]
    Snapshot["Pinned snapshot and row lineage"] --> Plan["Private DataFusion planner"]
    Resolve --> Plan
    Plan -->|Plannable| Aliases["Apply column aliases"]
    Aliases --> ViewTable["ViewTable"]
    Plan -->|Unsupported| Deferred["Enumerable deferred error"]
    Deferred --> ScanError["Named scan error"]
```

### Contract

- Read `view_id`, `schema_id`, `begin_snapshot`, `view_name`, `dialect`, `sql`, and
  `column_aliases` through DuckDB, SQLite, PostgreSQL, MySQL, and multicatalog PostgreSQL providers.
- Probe `ducklake_view` with the existing positive-only schema-capability cache. A missing table
  means an empty view set, not a failed table lookup.
- Create the official `ducklake_view` layout, including `view_uuid`, in every writer bootstrap.
- Apply inclusive-begin, exclusive-end snapshot predicates to listings and named lookups.
- Read all visible views with one joined query per backend instead of an N+1 schema loop.
- List views beside tables in `SchemaProvider::table_names`, `table_exist`, and `table_type`.
- Keep unplannable views enumerable by DataFusion's information schema. Scanning one returns an
  error naming the view and recorded dialect.
- Replace only unquoted `{DUCKLAKE_CATALOG}.` occurrences. Preserve quoted text, quoted identifiers,
  and mangled identifiers. Resolve DuckDB `schema.table` only through creation/query schema-ID
  continuity; reject other multipart qualifiers.
- Parse with the recorded dialect and reject DDL, DML, and command statements.
- Apply all or a leading subset of quoted aliases, including escaped double quotes.
- Propagate the requesting catalog's snapshot and row-lineage option through dependent views.
- Reject table creation when a visible view already owns the name.

### DuckLake semantics and limits

`ducklake_view` stores a versioned SQL definition. `begin_snapshot` and `end_snapshot` define its
visibility, `dialect` selects parser semantics, `sql` holds the query, and `column_aliases`
optionally renames output columns.

Current DuckLake stores the generic `{DUCKLAKE_CATALOG}.` placeholder. The crate's pinned DuckDB
1.4.1 extension predates that format and writes its attachment name directly, such as
`lake.users`. DuckDB also stores `schema.table` verbatim when the author omits the catalog name.
The reader accepts that form only when exactly one matching schema existed at the view's
`begin_snapshot` and the same `schema_id` remains visible at the requested snapshot. It quotes the
canonical name for DataFusion, including mixed-case schemas. Other literal qualifiers fail with the
view/dialect planning error.

View planning uses a private `SessionContext`. Caller UDFs and caller session settings, including
`execution.time_zone`, are not inherited. An unplannable view has no entries in DataFusion's
`information_schema.columns`, but it remains present in view listings and direct `SELECT *` scans
return the named planning error.

### Commit and branch

- Branch: `ducklake-views-pr`.
- Base: `51312c8b960722e1f769d80cd5b0a22991027c7d` (`origin/main`).
- Commit: `a05f9ffa38d60525626c9de7fd4cc78967bddc11 feat: expose DuckLake views`.
- Prerequisite PR: none.
- Remote: `ata/ducklake-views-pr`.
- Pull request: [#264](https://github.com/datafusion-contrib/datafusion-ducklake/pull/264).

### Verification

- `cargo fmt --all -- --check`: passed.
- `CARGO_BUILD_JOBS=8 cargo check --tests --all-features`: passed.
- CI feature matrix (`cargo check --no-default-features` across 12 feature sets): passed.
- `CARGO_BUILD_JOBS=8 cargo clippy --all-targets --all-features --no-deps -- -D warnings`: passed.
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=8 cargo doc --all-features --no-deps`: passed.
- `cargo test --all-features view -- --nocapture`: passed, 11 unit and 5 non-Docker integration
  tests; 3 service-backed tests were selected separately.
- Live PostgreSQL, MySQL, and multicatalog PostgreSQL view tests: passed.
- Full single-catalog CI lane: passed, 378 unit tests, 399 integration tests, and 8 doc tests;
  15 existing integration tests remained ignored.
- `openspec validate ducklake-spec-parity --strict`: passed.
- `git diff --check`: passed.

### Specification proof

| DuckLake rule | Implementation invariant | Discriminating proof |
| --- | --- | --- |
| [`ducklake_view`](https://ducklake.select/docs/stable/specification/tables/ducklake_view) has nine fields including `view_uuid`. | Every writer creates the official layout; every reader treats the table as optional. | SQLite asserts the exact bootstrap column order; a dropped-table legacy fixture preserves missing-table lookup, CTAS, and empty view enumeration. |
| [DuckLake view SQL](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_schema_entry.cpp#L152-L167) replaces an explicit catalog name with `{DUCKLAKE_CATALOG}.` and otherwise retains `schema.table`. | Placeholder and two-part DuckDB relations bind only through the same schema generation visible at view creation and query time; canonical names are quoted. | The DuckDB oracle covers `main.t`, cross-schema `s1.u`, and mixed-case `MySchema.m`; a foreign `ext.t` cannot retarget a colliding schema created later. |
| [A failed view bind](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_view_entry.cpp#L163-L170) must not poison catalog enumeration. | A deferred-error `TableProvider` exposes definition/type with an empty schema and raises the stored named error on scan. | DataFusion `information_schema.views` and `.columns` enumerate a catalog containing DuckDB-only and unsafe legacy definitions; direct scans fail with view and dialect. |
| [`column_aliases`](https://ducklake.select/docs/stable/specification/tables/ducklake_view) renames output columns. | Quoted aliases are decoded and projected over the planned definition. | DuckDB and DataFusion return identical rows for aliased projection, join, and expression views; unit tests cover escaped quotes and partial alias lists. |
| [`ducklake_view` rows](https://ducklake.select/docs/stable/specification/tables/ducklake_view) use inclusive `begin_snapshot` and exclusive `end_snapshot`. | Named, per-schema, and joined all-view queries use the same snapshot predicate. | SQLite, live PostgreSQL, live MySQL, and multicatalog tests assert exact visibility and lookup results. |

### Reference implementation

The official extension reads each snapshot-visible `ducklake_view` row and decodes its quoted
alias list
([metadata load](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L866-L910),
[alias decoding](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/common/ducklake_util.cpp#L53-L70)).
It attaches aliases to the catalog view and retains the stored SQL
([catalog construction](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_catalog.cpp#L579-L603)).
When queried, it replaces `{DUCKLAKE_CATALOG}.` outside quoted text and accepts one `SELECT`
statement
([view parsing](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_view_entry.cpp#L113-L147)).

The branch follows those rules in DataFusion, adds explicit dialect selection and cycle detection,
and keeps unsupported DuckDB SQL behind a named error rather than translating it.

### Upstream readiness

The patch reuses DataFusion's `ViewTable`, dialect configuration, logical planner, and catalog
interfaces. It adds no Nautilus-specific API, dependency, file format, or view mutation API.
External metadata providers remain source-compatible through empty default view methods. The branch
is one commit above upstream `main` and has no prerequisite branch.
