### PR TITLE
Honor scoped DuckLake settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pushed-down filters narrow the DuckLake file listing in the catalog query itself, using
   per-column statistics, so planning a selective scan or keyed mutation no longer lists
   every live file (#293).
+- Scoped DuckLake settings resolve per key with table-over-schema-over-global precedence on
+  every metadata backend; SQL writes and compaction honour the resolved values (#271).
 - `DuckLakeTableWriter::with_upload_concurrency` and `DuckLakeWriteOptions::upload_concurrency`
   set how many finished data files a rolling or partitioned write uploads at once, default 4.
   Written output is identical at any setting (#280).
@@ -35,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).
+- **BREAKING**: `DuckLakeWriteOptions` is non-exhaustive and gains `parquet_version`,
+  `auto_compact` and `rewrite_delete_threshold`; add `..Default::default()` to literals (#271).
+- Catalog-backed writes now default to Snappy compression, 122,880-row row groups and 512 MB
+  target files, changing Parquet layout and file size versus the previous defaults (#271).
 
 - **BREAKING**: `DuckLakeFileData` and `DataFileChange` are now non-exhaustive and
   implement `Default`; `DataFileChange` gains `mapping_id`. Downstream metadata
@@ -64,6 +70,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ducklake.upload_staged_file` spans now overlap in wall-clock time (#280).
 
 ### Fixed
+
+- Invalid write-only catalog settings no longer block table reads; they fail when a write or
+  maintenance operation is planned (#271).
+- Legacy two-column `ducklake_metadata` tables migrate both scope columns losslessly (#271).
+- Multicatalog catalog-scoped settings deterministically override shared globals (#271).
+- ZSTD compression level `0` maps to the Parquet library default; non-ZSTD codecs ignore the
+  setting (#271).
+- Fixed `UPDATE` and `DELETE` to retain scoped Parquet options (#271).
 
 - A float `min_value` was trusted as a lower bound even when the column's NaN state was unknown
   or positive; negative NaN sorts below every value, so a matching row could be pruned away

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -163,6 +163,14 @@ provider, run writer initialization with a schema-migration role before reading.
 Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` module and
 `MetadataWriter`), not SQL DDL.
 
+### Parquet writer defaults
+
+Scoped `parquet_version` settings apply to data files and positional-delete
+files written by `INSERT`, `UPDATE`, `DELETE`, and maintenance. When the setting
+is absent, this crate retains its existing Parquet V2 default; DuckDB `COPY`
+defaults to Parquet V1. Set `parquet_version = V1` explicitly when identical
+absent-setting behavior is required.
+
 ### Views
 
 Every metadata backend reads snapshot-visible rows from `ducklake_view`. Catalogs without that

--- a/examples/write_sorted.rs
+++ b/examples/write_sorted.rs
@@ -70,10 +70,8 @@ async fn main() {
     // small target so sort + rollover yields several tight-range files.
     let provider = SqliteMetadataProvider::new(&conn).await.unwrap();
     let iwriter = SqliteMetadataWriter::new_with_init(&conn).await.unwrap();
-    let options = DuckLakeWriteOptions {
-        target_file_size: Some(target_bytes),
-        ..Default::default()
-    };
+    let mut options = DuckLakeWriteOptions::default();
+    options.target_file_size = Some(target_bytes);
     let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(iwriter))
         .unwrap()
         .with_write_options(options);

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -705,6 +705,10 @@ impl DuckLakeTable {
         let schema_name = self.schema_name().ok_or_else(|| {
             DuckLakeError::Internal("writable table has no schema name".to_string())
         })?;
+        self.write_options().validate()?;
+        if !self.write_options().auto_compact.unwrap_or(true) {
+            return Ok(CompactionResult::empty());
+        }
 
         // Candidates: live, delete-free, below-target files with a known origin
         // snapshot + schema version, ordered so adjacency and same-version
@@ -983,14 +987,16 @@ impl DuckLakeTable {
             // grouping key), so the merged output inherits it: same Hive directory,
             // same `partition_id` + values in the catalog.
             let (partition_id, partition_values) = partition_key(bin[0]);
-            let subpath = partition_id.map(|pid| {
-                let names = self.partition_path_names(
-                    live_partition_spec.as_ref(),
-                    pid,
-                    &top_level_column_ids,
-                );
-                crate::partition::hive_subpath(&names, &partition_values)
-            });
+            let subpath = partition_id
+                .filter(|_| self.write_options().hive_file_pattern.unwrap_or(true))
+                .map(|pid| {
+                    let names = self.partition_path_names(
+                        live_partition_spec.as_ref(),
+                        pid,
+                        &top_level_column_ids,
+                    );
+                    crate::partition::hive_subpath(&names, &partition_values)
+                });
             let file = table_writer
                 .write_compacted_file_stream(
                     schema_name,
@@ -1050,8 +1056,18 @@ impl DuckLakeTable {
     pub async fn rewrite_data_files(
         &self,
         state: &dyn Session,
-        opts: RewriteOptions,
+        mut opts: RewriteOptions,
     ) -> Result<CompactionResult> {
+        self.write_options().validate()?;
+        if !self.write_options().auto_compact.unwrap_or(true) {
+            return Ok(CompactionResult::empty());
+        }
+        if opts.delete_threshold == RewriteOptions::default().delete_threshold {
+            opts.delete_threshold = self
+                .write_options()
+                .rewrite_delete_threshold
+                .unwrap_or(opts.delete_threshold);
+        }
         if !(0.0..=1.0).contains(&opts.delete_threshold) {
             return Err(DuckLakeError::InvalidConfig(format!(
                 "rewrite_data_files: delete_threshold must be in [0.0, 1.0], got {}",
@@ -1161,14 +1177,16 @@ impl DuckLakeTable {
             // holds a subset of that file's rows and therefore its exact
             // partition: inherit the identity and the Hive directory.
             let (partition_id, partition_values) = partition_key(tf);
-            let subpath = partition_id.map(|pid| {
-                let names = self.partition_path_names(
-                    live_partition_spec.as_ref(),
-                    pid,
-                    &top_level_column_ids,
-                );
-                crate::partition::hive_subpath(&names, &partition_values)
-            });
+            let subpath = partition_id
+                .filter(|_| self.write_options().hive_file_pattern.unwrap_or(true))
+                .map(|pid| {
+                    let names = self.partition_path_names(
+                        live_partition_spec.as_ref(),
+                        pid,
+                        &top_level_column_ids,
+                    );
+                    crate::partition::hive_subpath(&names, &partition_values)
+                });
             let file = table_writer
                 .write_compacted_file_stream(
                     schema_name,

--- a/src/delete_exec.rs
+++ b/src/delete_exec.rs
@@ -294,6 +294,7 @@ async fn run_delete(
         .runtime_env()
         .object_store(object_store_url.as_ref())?;
     let table_writer = DuckLakeTableWriter::new(Arc::clone(&writer), object_store)
+        .map(|writer| writer.with_options(table.write_options()))
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
     let mut entries: Vec<DeleteFileEntry> = Vec::new();

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -1330,12 +1330,77 @@ pub struct DeleteFileChange {
     pub snapshot_id: i64,
 }
 
+#[derive(Debug)]
+pub(crate) struct MetadataSetting {
+    pub key: String,
+    pub value: String,
+    pub scope: Option<String>,
+    pub scope_id: Option<i64>,
+}
+
+pub(crate) fn resolve_metadata_settings(
+    rows: Vec<MetadataSetting>,
+    schema_id: Option<i64>,
+    table_id: Option<i64>,
+) -> Result<HashMap<String, String>> {
+    let mut global = HashMap::new();
+    let mut schema = HashMap::new();
+    let mut table = HashMap::new();
+
+    for row in rows {
+        match row.scope.as_deref() {
+            None => {
+                global.insert(row.key, row.value);
+            },
+            Some("schema") if row.scope_id.is_none() => {
+                return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                    "ducklake_metadata schema setting '{}' has no scope_id",
+                    row.key
+                )));
+            },
+            Some("schema") if row.scope_id == schema_id => {
+                schema.insert(row.key, row.value);
+            },
+            Some("table") if row.scope_id.is_none() => {
+                return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                    "ducklake_metadata table setting '{}' has no scope_id",
+                    row.key
+                )));
+            },
+            Some("table") if row.scope_id == table_id => {
+                table.insert(row.key, row.value);
+            },
+            Some("schema") | Some("table") => {},
+            Some(scope) => {
+                return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                    "Unsupported ducklake_metadata scope '{scope}'; expected schema or table"
+                )));
+            },
+        }
+    }
+
+    global.extend(schema);
+    global.extend(table);
+    Ok(global)
+}
+
 pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
     /// Get the current snapshot ID (dynamic, not cached)
     fn get_current_snapshot(&self) -> Result<i64>;
 
     /// Get the data path from catalog metadata (not snapshot-dependent)
     fn get_data_path(&self) -> Result<String>;
+
+    /// Resolve catalog settings for an optional schema and table. Implementations
+    /// apply DuckLake's per-key precedence: Table, then Schema, then Global.
+    /// External providers default to no stored settings.
+    fn get_metadata_settings(
+        &self,
+        _schema_id: Option<i64>,
+        _table_id: Option<i64>,
+    ) -> Result<HashMap<String, String>> {
+        Ok(HashMap::new())
+    }
 
     /// List all snapshots in the catalog
     fn list_snapshots(&self) -> Result<Vec<SnapshotMetadata>>;
@@ -1741,6 +1806,52 @@ mod tests {
     }
 
     #[test]
+    fn resolve_metadata_settings_uses_per_key_scope_precedence() {
+        let rows = vec![
+            MetadataSetting {
+                key: "compression".into(),
+                value: "global".into(),
+                scope: None,
+                scope_id: None,
+            },
+            MetadataSetting {
+                key: "rows".into(),
+                value: "global-rows".into(),
+                scope: None,
+                scope_id: None,
+            },
+            MetadataSetting {
+                key: "compression".into(),
+                value: "schema".into(),
+                scope: Some("schema".into()),
+                scope_id: Some(7),
+            },
+            MetadataSetting {
+                key: "compression".into(),
+                value: "other-schema".into(),
+                scope: Some("schema".into()),
+                scope_id: Some(8),
+            },
+            MetadataSetting {
+                key: "compression".into(),
+                value: "table".into(),
+                scope: Some("table".into()),
+                scope_id: Some(11),
+            },
+        ];
+
+        let settings = resolve_metadata_settings(rows, Some(7), Some(11)).unwrap();
+
+        assert_eq!(
+            settings,
+            HashMap::from([
+                ("compression".to_string(), "table".to_string()),
+                ("rows".to_string(), "global-rows".to_string()),
+            ])
+        );
+    }
+
+    #[test]
     fn inlined_rows_reject_unsupported_nested_encoding() {
         let columns = vec![column("items", "list<int32>")];
         let schema = Arc::new(Schema::new(vec![Field::new_list(
@@ -1760,6 +1871,26 @@ mod tests {
         assert!(
             error.to_string().contains(INLINED_DATA_REMEDIATION),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn resolve_metadata_settings_rejects_scoped_row_without_id() {
+        let error = resolve_metadata_settings(
+            vec![MetadataSetting {
+                key: "compression".into(),
+                value: "zstd".into(),
+                scope: Some("table".into()),
+                scope_id: None,
+            }],
+            Some(7),
+            Some(11),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid configuration: ducklake_metadata table setting 'compression' has no scope_id"
         );
     }
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -4,17 +4,16 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
     DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
-    FileWithTable, INLINED_DATA_REMEDIATION, MetadataProvider, SQL_GET_DATA_FILES,
-    SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_DATA_PATH,
-    SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
-    SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT, SQL_GET_NAME_MAPPING,
-    SQL_GET_PARTITION_SPEC, SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME,
-    SQL_GET_TABLE_COLUMN_STATS, SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME, SQL_LIST_ALL_FILES,
-    SQL_LIST_ALL_TABLES, SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES,
-    SQL_LIST_VIEWS, SQL_TABLE_EXISTS, SchemaMetadata, SnapshotMetadata, TableMetadata,
-    TableWithSchema, ViewMetadata, ViewWithSchema, build_inlined_batch, inlined_delete_table_name,
-    inlined_missing_scalar, is_inlined_data_table, reconstruct_columns,
-    reconstruct_columns_with_table,
+    FileWithTable, INLINED_DATA_REMEDIATION, MetadataProvider, MetadataSetting, SQL_GET_DATA_FILES,
+    SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS,
+    SQL_GET_FILE_COLUMN_STATS, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_LATEST_SNAPSHOT,
+    SQL_GET_NAME_MAPPING, SQL_GET_PARTITION_SPEC, SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC,
+    SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS, SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME,
+    SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES, SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS,
+    SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS, SQL_TABLE_EXISTS, SchemaMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
+    build_inlined_batch, inlined_delete_table_name, inlined_missing_scalar, is_inlined_data_table,
+    reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -802,9 +801,54 @@ impl MetadataProvider for DuckdbMetadataProvider {
     }
 
     fn get_data_path(&self) -> crate::Result<String> {
+        self.get_metadata_settings(None, None)?
+            .remove("data_path")
+            .ok_or_else(|| {
+                DuckLakeError::InvalidConfig(
+                    "Missing required catalog metadata: 'data_path' not configured. \
+                     The catalog may be uninitialized or corrupted."
+                        .to_string(),
+                )
+            })
+    }
+
+    fn get_metadata_settings(
+        &self,
+        schema_id: Option<i64>,
+        table_id: Option<i64>,
+    ) -> crate::Result<HashMap<String, String>> {
         let conn = self.connection();
-        let data_path: String = conn.query_row(SQL_GET_DATA_PATH, [], |row| row.get(0))?;
-        Ok(data_path)
+        let has_scope_columns: bool = conn.query_row(
+            "SELECT COUNT(*) = 2 FROM pragma_table_info('ducklake_metadata') \
+             WHERE name IN ('scope', 'scope_id')",
+            [],
+            |row| row.get(0),
+        )?;
+        let rows = if has_scope_columns {
+            let mut stmt =
+                conn.prepare("SELECT key, value, scope, scope_id FROM ducklake_metadata")?;
+            stmt.query_map([], |row| {
+                Ok(MetadataSetting {
+                    key: row.get(0)?,
+                    value: row.get(1)?,
+                    scope: row.get(2)?,
+                    scope_id: row.get(3)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?
+        } else {
+            let mut stmt = conn.prepare("SELECT key, value FROM ducklake_metadata")?;
+            stmt.query_map([], |row| {
+                Ok(MetadataSetting {
+                    key: row.get(0)?,
+                    value: row.get(1)?,
+                    scope: None,
+                    scope_id: None,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        resolve_metadata_settings(rows, schema_id, table_id)
     }
 
     fn list_snapshots(&self) -> crate::Result<Vec<SnapshotMetadata>> {

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -6,11 +6,12 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
     DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
-    FileWithTable, InlinedDataBackend, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES,
-    SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SQL_GET_TABLE_COLUMNS, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
-    inlined_delete_table_name, inlined_text_projection, is_inlined_data_table,
-    parse_inlined_rows_with_present, reconstruct_columns, reconstruct_columns_with_table,
+    FileWithTable, InlinedDataBackend, MetadataProvider, MetadataSetting,
+    SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
+    SQL_GET_TABLE_COLUMNS, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
+    ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name, inlined_text_projection,
+    is_inlined_data_table, parse_inlined_rows_with_present, reconstruct_columns,
+    reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -562,22 +563,60 @@ impl MetadataProvider for MySqlMetadataProvider {
     }
 
     fn get_data_path(&self) -> Result<String> {
-        block_on(async {
-            let row = sqlx::query(
-                "SELECT value FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL",
-            )
-            .bind("data_path")
-            .fetch_optional(&self.pool)
-            .await?;
-
-            match row {
-                Some(r) => Ok(r.try_get(0)?),
-                None => Err(crate::error::DuckLakeError::InvalidConfig(
+        self.get_metadata_settings(None, None)?
+            .remove("data_path")
+            .ok_or_else(|| {
+                crate::error::DuckLakeError::InvalidConfig(
                     "Missing required catalog metadata: 'data_path' not configured. \
                      The catalog may be uninitialized or corrupted."
                         .to_string(),
-                )),
-            }
+                )
+            })
+    }
+
+    fn get_metadata_settings(
+        &self,
+        schema_id: Option<i64>,
+        table_id: Option<i64>,
+    ) -> Result<HashMap<String, String>> {
+        block_on(async {
+            let scope_column_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM information_schema.columns \
+                 WHERE table_schema = DATABASE() AND table_name = 'ducklake_metadata' \
+                 AND column_name IN ('scope', 'scope_id')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let rows = if scope_column_count == 2 {
+                sqlx::query("SELECT `key`, value, scope, scope_id FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: row.try_get(2)?,
+                            scope_id: row.try_get(3)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            } else {
+                sqlx::query("SELECT `key`, value FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: None,
+                            scope_id: None,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            };
+            resolve_metadata_settings(rows, schema_id, table_id)
         })
     }
 

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -6,10 +6,11 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
     DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
-    FileWithTable, InlinedDataBackend, MetadataProvider, SchemaMetadata, SnapshotMetadata,
-    TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
+    FileWithTable, InlinedDataBackend, MetadataProvider, MetadataSetting, SchemaMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
     inlined_delete_table_name, inlined_text_projection, is_inlined_data_table,
     parse_inlined_rows_with_present, reconstruct_columns, reconstruct_columns_with_table,
+    resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -854,21 +855,61 @@ impl MetadataProvider for PostgresMetadataProvider {
     }
 
     fn get_data_path(&self) -> Result<String> {
-        block_on(async {
-            let row =
-                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
-                    .bind("data_path")
-                    .fetch_optional(&self.pool)
-                    .await?;
-
-            match row {
-                Some(r) => Ok(r.try_get(0)?),
-                None => Err(crate::error::DuckLakeError::InvalidConfig(
+        self.get_metadata_settings(None, None)?
+            .remove("data_path")
+            .ok_or_else(|| {
+                crate::error::DuckLakeError::InvalidConfig(
                     "Missing required catalog metadata: 'data_path' not configured. \
                      The catalog may be uninitialized or corrupted."
                         .to_string(),
-                )),
-            }
+                )
+            })
+    }
+
+    fn get_metadata_settings(
+        &self,
+        schema_id: Option<i64>,
+        table_id: Option<i64>,
+    ) -> Result<HashMap<String, String>> {
+        block_on(async {
+            let has_scope_columns: bool = sqlx::query_scalar(
+                "SELECT COUNT(*) = 2 FROM information_schema.columns \
+                 WHERE table_schema = current_schema() \
+                 AND table_name = 'ducklake_metadata' \
+                 AND column_name IN ('scope', 'scope_id')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let rows = if has_scope_columns {
+                sqlx::query("SELECT key, value, scope, scope_id FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: row.try_get(2)?,
+                            scope_id: row.try_get(3)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            } else {
+                sqlx::query("SELECT key, value FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: None,
+                            scope_id: None,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            };
+            resolve_metadata_settings(rows, schema_id, table_id)
         })
     }
 

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -6,11 +6,11 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
     DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
-    FileWithTable, MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_NAME_MAPPING,
-    SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SQL_GET_TABLE_COLUMNS, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
-    inlined_delete_table_name, inlined_missing_scalar, reconstruct_columns,
-    reconstruct_columns_with_table,
+    FileWithTable, MetadataProvider, MetadataSetting, SQL_GET_FILE_PARTITION_VALUES,
+    SQL_GET_NAME_MAPPING, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SQL_GET_TABLE_COLUMNS,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
+    block_on, inlined_delete_table_name, inlined_missing_scalar, reconstruct_columns,
+    reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -618,21 +618,59 @@ impl MetadataProvider for SqliteMetadataProvider {
     }
 
     fn get_data_path(&self) -> Result<String> {
-        block_on(async {
-            let row =
-                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = ? AND scope IS NULL")
-                    .bind("data_path")
-                    .fetch_optional(&self.pool)
-                    .await?;
-
-            match row {
-                Some(r) => Ok(r.try_get(0)?),
-                None => Err(crate::error::DuckLakeError::InvalidConfig(
+        self.get_metadata_settings(None, None)?
+            .remove("data_path")
+            .ok_or_else(|| {
+                crate::error::DuckLakeError::InvalidConfig(
                     "Missing required catalog metadata: 'data_path' not configured. \
                      The catalog may be uninitialized or corrupted."
                         .to_string(),
-                )),
-            }
+                )
+            })
+    }
+
+    fn get_metadata_settings(
+        &self,
+        schema_id: Option<i64>,
+        table_id: Option<i64>,
+    ) -> Result<HashMap<String, String>> {
+        block_on(async {
+            let has_scope_columns: bool = sqlx::query_scalar(
+                "SELECT COUNT(*) = 2 FROM pragma_table_info('ducklake_metadata') \
+                 WHERE name IN ('scope', 'scope_id')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let rows = if has_scope_columns {
+                sqlx::query("SELECT key, value, scope, scope_id FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: row.try_get(2)?,
+                            scope_id: row.try_get(3)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            } else {
+                sqlx::query("SELECT key, value FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: None,
+                            scope_id: None,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            };
+            resolve_metadata_settings(rows, schema_id, table_id)
         })
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -1019,6 +1019,13 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// Create a new snapshot and return its ID.
     fn create_snapshot(&self) -> Result<i64>;
 
+    /// Replace a global-scoped catalog setting.
+    fn set_global_setting(&self, _key: &str, _value: &str) -> Result<()> {
+        Err(DuckLakeError::Unsupported(
+            "global-scoped settings are not supported by this metadata backend".to_string(),
+        ))
+    }
+
     /// Get or create a schema, returning `(schema_id, was_created)`.
     fn get_or_create_schema(
         &self,

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -69,7 +69,8 @@ CREATE SEQUENCE IF NOT EXISTS ducklake_sort_id_seq START 1;
 CREATE TABLE IF NOT EXISTS ducklake_metadata (
     key VARCHAR NOT NULL,
     value VARCHAR NOT NULL,
-    scope VARCHAR
+    scope VARCHAR,
+    scope_id BIGINT
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_snapshot (
@@ -859,6 +860,21 @@ impl MetadataWriter for DuckdbMetadataWriter {
         let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
         tx.commit()?;
         Ok(snapshot_id)
+    }
+
+    fn set_global_setting(&self, key: &str, value: &str) -> Result<()> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "DELETE FROM ducklake_metadata WHERE key = ? AND scope IS NULL",
+            params![key],
+        )?;
+        tx.execute(
+            "INSERT INTO ducklake_metadata (key, value, scope, scope_id) VALUES (?, ?, NULL, NULL)",
+            params![key, value],
+        )?;
+        tx.commit()?;
+        Ok(())
     }
 
     fn get_or_create_schema(
@@ -1664,6 +1680,10 @@ impl MetadataWriter for DuckdbMetadataWriter {
     fn initialize_schema(&self) -> Result<()> {
         let conn = self.connection();
         conn.execute_batch(SQL_CREATE_SCHEMA)?;
+        conn.execute_batch("ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope VARCHAR")?;
+        conn.execute_batch(
+            "ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope_id BIGINT",
+        )?;
         // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id
         // (CREATE TABLE IF NOT EXISTS never alters an existing table). DuckDB supports
         // ADD COLUMN IF NOT EXISTS, so this is idempotent and lossless (NULL means

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -62,7 +62,8 @@ const SQL_CREATE_TABLES: &[&str] = &[
     r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
         `key` VARCHAR(1024) NOT NULL,
         `value` TEXT NOT NULL,
-        scope VARCHAR(1024)
+        scope VARCHAR(1024),
+        scope_id BIGINT
     ) ENGINE = InnoDB"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot (
         snapshot_id BIGINT NOT NULL PRIMARY KEY,
@@ -1876,6 +1877,32 @@ impl MetadataWriter for MySqlMetadataWriter {
                 if !default_columns.iter().any(|column| column == name) {
                     sqlx::query(ddl).execute(&self.pool).await?;
                 }
+            }
+            let has_scope_id: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM information_schema.columns \
+                 WHERE table_schema = DATABASE() \
+                   AND table_name = 'ducklake_metadata' \
+                   AND column_name = 'scope_id'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let has_scope: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM information_schema.columns \
+                 WHERE table_schema = DATABASE() \
+                   AND table_name = 'ducklake_metadata' \
+                   AND column_name = 'scope'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            if has_scope == 0 {
+                sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN scope VARCHAR(255)")
+                    .execute(&self.pool)
+                    .await?;
+            }
+            if has_scope_id == 0 {
+                sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN scope_id BIGINT")
+                    .execute(&self.pool)
+                    .await?;
             }
             // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id.
             // MySQL has no `ADD COLUMN IF NOT EXISTS`, so probe information_schema first

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -34,7 +34,8 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
     r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
         key VARCHAR NOT NULL,
         value VARCHAR NOT NULL,
-        scope VARCHAR
+        scope VARCHAR,
+        scope_id BIGINT
     )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot (
         snapshot_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -1746,6 +1747,32 @@ impl MetadataWriter for PostgresMetadataWriter {
 
             tx.commit().await?;
             Ok(snapshot_id)
+        })
+    }
+
+    fn set_global_setting(&self, key: &str, value: &str) -> Result<()> {
+        block_on(async {
+            let mut transaction = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut transaction).await?;
+            sqlx::query(
+                "DELETE FROM ducklake_metadata
+                 WHERE key = $1 AND scope = 'catalog' AND scope_id = $2",
+            )
+            .bind(key)
+            .bind(self.catalog_id)
+            .execute(&mut *transaction)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope, scope_id)
+                 VALUES ($1, $2, 'catalog', $3)",
+            )
+            .bind(key)
+            .bind(value)
+            .bind(self.catalog_id)
+            .execute(&mut *transaction)
+            .await?;
+            transaction.commit().await?;
+            Ok(())
         })
     }
 
@@ -4392,6 +4419,12 @@ impl MetadataWriter for PostgresMetadataWriter {
             execute_ddl_statements(&self.pool, SQL_CREATE_STANDARD_TABLES).await?;
             execute_ddl_statements(&self.pool, SQL_CREATE_MULTICATALOG_TABLES).await?;
             migrate_column_default_metadata(&self.pool).await?;
+            sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope VARCHAR")
+                .execute(&self.pool)
+                .await?;
+            sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope_id BIGINT")
+                .execute(&self.pool)
+                .await?;
             // Upgrade a pre-existing store's ducklake_column to the composite PK
             // (legacy single-row column_id PK → versioned-capable). Idempotent.
             migrate_ducklake_column_to_composite_pk(&self.pool).await?;

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -42,7 +42,8 @@ const SQL_CREATE_TABLES: &[&str] = &[
     r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
         key VARCHAR NOT NULL,
         value VARCHAR NOT NULL,
-        scope VARCHAR
+        scope VARCHAR,
+        scope_id BIGINT
     )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot (
         snapshot_id BIGINT NOT NULL PRIMARY KEY,
@@ -1004,6 +1005,26 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
         })
     }
 
+    fn set_global_setting(&self, key: &str, value: &str) -> Result<()> {
+        block_on(async {
+            let mut transaction = self.pool.begin().await?;
+            sqlx::query("DELETE FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
+                .bind(key)
+                .execute(&mut *transaction)
+                .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope, scope_id)
+                 VALUES ($1, $2, NULL, NULL)",
+            )
+            .bind(key)
+            .bind(value)
+            .execute(&mut *transaction)
+            .await?;
+            transaction.commit().await?;
+            Ok(())
+        })
+    }
+
     fn get_or_create_schema(
         &self,
         name: &str,
@@ -1904,6 +1925,12 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             for ddl in SQL_CREATE_TABLES {
                 sqlx::query(*ddl).execute(&self.pool).await?;
             }
+            sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope VARCHAR")
+                .execute(&self.pool)
+                .await?;
+            sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope_id BIGINT")
+                .execute(&self.pool)
+                .await?;
             sqlx::query(
                 "ALTER TABLE ducklake_column
                  ADD COLUMN IF NOT EXISTS initial_default VARCHAR,

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -36,7 +36,8 @@ const SQL_CREATE_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS ducklake_metadata (
     key VARCHAR NOT NULL,
     value VARCHAR NOT NULL,
-    scope VARCHAR
+    scope VARCHAR,
+    scope_id INTEGER
 );
 
 -- `schema_version` is the per-catalog monotonic schema counter from the DuckLake
@@ -948,6 +949,29 @@ async fn migrate_add_schema_version(pool: &SqlitePool) -> Result<()> {
     Ok(())
 }
 
+async fn migrate_add_metadata_scope_columns(pool: &SqlitePool) -> Result<()> {
+    let columns = sqlx::query("SELECT name FROM pragma_table_info('ducklake_metadata')")
+        .fetch_all(pool)
+        .await?;
+    let has_scope = columns
+        .iter()
+        .any(|row| row.get::<String, _>("name") == "scope");
+    let has_scope_id = columns
+        .iter()
+        .any(|row| row.get::<String, _>("name") == "scope_id");
+    if !has_scope {
+        sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN scope VARCHAR")
+            .execute(pool)
+            .await?;
+    }
+    if !has_scope_id {
+        sqlx::query("ALTER TABLE ducklake_metadata ADD COLUMN scope_id INTEGER")
+            .execute(pool)
+            .await?;
+    }
+    Ok(())
+}
+
 /// Add `ducklake_data_file.partial_max` to a pre-existing catalog (DuckLake
 /// v1.0). `CREATE TABLE IF NOT EXISTS` only shapes brand-new catalogs, so an
 /// older one needs this `ALTER`.
@@ -1759,6 +1783,25 @@ impl MetadataWriter for SqliteMetadataWriter {
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
             tx.commit().await?;
             Ok(snapshot_id)
+        })
+    }
+
+    fn set_global_setting(&self, key: &str, value: &str) -> Result<()> {
+        block_on(async {
+            let mut transaction = self.pool.begin().await?;
+            sqlx::query("DELETE FROM ducklake_metadata WHERE key = ? AND scope IS NULL")
+                .bind(key)
+                .execute(&mut *transaction)
+                .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope, scope_id) VALUES (?, ?, NULL, NULL)",
+            )
+            .bind(key)
+            .bind(value)
+            .execute(&mut *transaction)
+            .await?;
+            transaction.commit().await?;
+            Ok(())
         })
     }
 
@@ -4128,6 +4171,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             // single-row-PK shape to upstream's bare shape (idempotent, crash-safe).
             // `CREATE TABLE IF NOT EXISTS` above only shapes new catalogs.
             migrate_ducklake_column_drop_pk(&self.pool).await?;
+            migrate_add_metadata_scope_columns(&self.pool).await?;
             // Upgrade a pre-existing catalog to track schema_version (add the
             // ducklake_snapshot.schema_version column; idempotent, lossless).
             migrate_add_schema_version(&self.pool).await?;

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -16,9 +16,9 @@ use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeNameMapping, DuckLakeNameMappingEntry,
     DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableField,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
-    reconstruct_columns, reconstruct_columns_with_table,
+    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, MetadataSetting,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
+    block_on, reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::metadata_provider_postgres::{
     PostgresStatsDialect, StatsFilterSql, fetch_data_file_page, stats_filter_sql,
@@ -532,6 +532,65 @@ impl MetadataProvider for MulticatalogProvider {
                         .to_string(),
                 )
             })
+        })
+    }
+
+    fn get_metadata_settings(
+        &self,
+        schema_id: Option<i64>,
+        table_id: Option<i64>,
+    ) -> Result<HashMap<String, String>> {
+        block_on(async {
+            let has_scope_columns: bool = sqlx::query_scalar(
+                "SELECT COUNT(*) = 2 FROM information_schema.columns \
+                 WHERE table_schema = current_schema() \
+                 AND table_name = 'ducklake_metadata' \
+                 AND column_name IN ('scope', 'scope_id')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let rows = if has_scope_columns {
+                sqlx::query(
+                    "SELECT key, value, scope, scope_id
+                     FROM ducklake_metadata
+                     WHERE scope IS DISTINCT FROM 'catalog' OR scope_id = $1
+                     ORDER BY CASE WHEN scope = 'catalog' THEN 1 ELSE 0 END, key",
+                )
+                .bind(self.catalog_id)
+                .fetch_all(&self.pool)
+                .await?
+                .into_iter()
+                .map(|row| {
+                    let scope: Option<String> = row.try_get(2)?;
+                    let is_catalog = scope.as_deref() == Some("catalog");
+                    Ok(MetadataSetting {
+                        key: row.try_get(0)?,
+                        value: row.try_get(1)?,
+                        scope: (!is_catalog).then_some(scope).flatten(),
+                        scope_id: if is_catalog {
+                            None
+                        } else {
+                            row.try_get(3)?
+                        },
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?
+            } else {
+                sqlx::query("SELECT key, value FROM ducklake_metadata")
+                    .fetch_all(&self.pool)
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        Ok(MetadataSetting {
+                            key: row.try_get(0)?,
+                            value: row.try_get(1)?,
+                            scope: None,
+                            scope_id: None,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            };
+            resolve_metadata_settings(rows, schema_id, table_id)
         })
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -191,9 +191,18 @@ impl SchemaProvider for DuckLakeSchema {
                 // Configure writer if this schema is writable
                 #[cfg(feature = "write")]
                 let table = if let Some(writer) = self.writer.as_ref() {
+                    let settings = self
+                        .provider
+                        .get_metadata_settings(Some(self.schema_id), Some(meta.table_id))
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                    let options =
+                        crate::table_writer::DuckLakeWriteOptions::from_metadata_settings_deferred(
+                            &settings,
+                        )
+                        .with_overrides(&self.write_options);
                     table
                         .with_writer(self.schema_name.clone(), Arc::clone(writer))
-                        .with_write_options(self.write_options.clone())
+                        .with_write_options(options)
                 } else {
                     table
                 };
@@ -333,6 +342,13 @@ impl SchemaProvider for DuckLakeSchema {
         // Build the table provider from the COMMITTED ids/snapshot (the begin-time
         // `setup.snapshot_id` is vestigial on the commit-time path; the real
         // snapshot is assigned at commit).
+        let settings = self
+            .provider
+            .get_metadata_settings(Some(self.schema_id), Some(committed.table_id))
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let options =
+            crate::table_writer::DuckLakeWriteOptions::from_metadata_settings_deferred(&settings)
+                .with_overrides(&self.write_options);
         let writable_table = DuckLakeTable::new(
             committed.table_id,
             name,
@@ -343,7 +359,7 @@ impl SchemaProvider for DuckLakeSchema {
         )
         .map_err(|e| DataFusionError::External(Box::new(e)))?
         .with_writer(self.schema_name.clone(), Arc::clone(writer))
-        .with_write_options(self.write_options.clone());
+        .with_write_options(options);
 
         Ok(Some(Arc::new(writable_table) as Arc<dyn TableProvider>))
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -3246,7 +3246,7 @@ impl DuckLakeTable {
             encryption_keys: Arc::clone(&self.encryption_keys),
             schema_name: None,
             writer: None,
-            write_options: crate::table_writer::DuckLakeWriteOptions::default(),
+            write_options: self.write_options.clone(),
         }
     }
 
@@ -3263,6 +3263,13 @@ impl DuckLakeTable {
     #[cfg(feature = "write")]
     pub(crate) fn writer(&self) -> Option<&Arc<dyn MetadataWriter>> {
         self.writer.as_ref()
+    }
+
+    /// Resolved catalog settings with explicit Rust overrides applied. Used by
+    /// maintenance writes so their Parquet layout matches ordinary inserts.
+    #[cfg(feature = "write")]
+    pub(crate) fn write_options(&self) -> &crate::table_writer::DuckLakeWriteOptions {
+        &self.write_options
     }
 
     /// The schema name, when this table was opened writable. Used by the
@@ -4048,6 +4055,9 @@ impl TableProvider for DuckLakeTable {
         let schema_name = self.schema_name.as_ref().ok_or_else(|| {
             DataFusionError::Internal("Schema name not set for writable table".to_string())
         })?;
+        self.write_options
+            .validate()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         let write_mode = match insert_op {
             InsertOp::Append => WriteMode::Append,
@@ -4097,11 +4107,15 @@ impl TableProvider for DuckLakeTable {
         // per-partition file remains a sorted subsequence. An unsupported expression
         // or missing sort column is rejected before execution rather than silently
         // producing files that violate the active sort contract.
-        let live_sort = self
-            .provider
-            .get_sort_spec(self.table_id, head_snapshot)
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let ordering = sort_ordering_for(&input.schema(), live_sort.as_ref())?;
+        let ordering = if self.write_options.sort_on_insert.unwrap_or(true) {
+            let live_sort = self
+                .provider
+                .get_sort_spec(self.table_id, head_snapshot)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            sort_ordering_for(&input.schema(), live_sort.as_ref())?
+        } else {
+            None
+        };
         // Wrap the input in a SortExec now AND declare the same requirement on
         // DuckLakeInsertExec, so DataFusion's EnforceSorting keeps the ordering
         // (a plain SortExec with no downstream ordering requirement would be
@@ -4151,6 +4165,9 @@ impl TableProvider for DuckLakeTable {
         let schema_name = self.schema_name.as_ref().ok_or_else(|| {
             DataFusionError::Internal("Schema name not set for writable table".to_string())
         })?;
+        self.write_options
+            .validate()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         // DuckDB / MySQL metadata writers do not implement the atomic
         // append-with-deletes commit UPDATE needs. Reject up front rather than
@@ -4253,6 +4270,10 @@ impl TableProvider for DuckLakeTable {
         let schema_name = self.schema_name.as_ref().ok_or_else(|| {
             DataFusionError::Internal("Schema name not set for writable table".to_string())
         })?;
+
+        self.write_options
+            .validate()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         // Build the physical predicate. Empty `filters` (no WHERE) => delete ALL,
         // signalled by `None` and handled as a metadata-only truncate. We resolve

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -14,8 +14,8 @@ use object_store::ObjectStore;
 use object_store::buffered::BufWriter as ObjectBufWriter;
 use object_store::path::Path as ObjectPath;
 use parquet::arrow::ArrowWriter;
-use parquet::basic::Compression;
-use parquet::file::properties::WriterProperties;
+use parquet::basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel};
+use parquet::file::properties::{WriterProperties, WriterVersion};
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -69,15 +69,19 @@ pub const MINIMUM_TARGET_FILE_SIZE: usize = 4096;
 /// later compaction to reorganize (DuckLake compaction merges, never splits).
 pub const DEFAULT_TARGET_FILE_SIZE: usize = 1 << 29;
 
-/// Write-layout options carried from the catalog down to the insert path, so a
-/// SQL `INSERT` builds its [`DuckLakeTableWriter`] with the same compression,
-/// row-group caps, and file-rollover target the embedding engine configured.
-/// A `None` field leaves the writer's default for that setting (uncompressed,
-/// parquet-default row groups, [`DEFAULT_TARGET_FILE_SIZE`] rollover).
+/// Write and maintenance options carried from the catalog down to each table.
+/// A SQL `INSERT`, update rewrite, or compaction output uses the same compression,
+/// row-group caps, file-rollover target, sorting, and partition-path policy.
+/// A `None` field leaves the receiving writer's configured value unchanged.
+/// Catalog-derived options populate DuckDB's defaults: Snappy, 122,880 rows per
+/// row group, and [`DEFAULT_TARGET_FILE_SIZE`] rollover.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct DuckLakeWriteOptions {
-    /// Parquet compression codec; `None` = uncompressed.
+    /// Parquet compression codec; `None` leaves the writer's codec unchanged.
     pub compression: Option<Compression>,
+    /// Parquet format version; `None` leaves the writer's version unchanged.
+    pub parquet_version: Option<WriterVersion>,
     /// Max rows per row group; `None` = parquet default.
     pub max_row_group_rows: Option<usize>,
     /// Max uncompressed bytes per row group; `None` = parquet default.
@@ -91,6 +95,267 @@ pub struct DuckLakeWriteOptions {
     /// How many finished data files to upload concurrently; `None` leaves the
     /// writer default ([`DEFAULT_UPLOAD_CONCURRENCY`]). Clamped to at least 1.
     pub upload_concurrency: Option<usize>,
+    /// Whether inserts honor the table's active sort order.
+    pub sort_on_insert: Option<bool>,
+    /// Whether partition values appear as Hive-style directories in file paths.
+    pub hive_file_pattern: Option<bool>,
+    /// Whether merge and rewrite maintenance include this table.
+    pub auto_compact: Option<bool>,
+    /// Minimum deleted-row fraction for automatic rewrite selection.
+    pub rewrite_delete_threshold: Option<f64>,
+    deferred_error: Option<String>,
+}
+
+impl DuckLakeWriteOptions {
+    pub(crate) fn from_metadata_settings(settings: &HashMap<String, String>) -> Result<Self> {
+        let compression_name = settings
+            .get("parquet_compression")
+            .map(String::as_str)
+            .unwrap_or("snappy");
+        let compression_level = compression_name
+            .eq_ignore_ascii_case("zstd")
+            .then(|| {
+                setting_i32(settings, "parquet_compression_level").map(|level| level.or(Some(3)))
+            })
+            .transpose()?
+            .flatten();
+
+        Ok(Self {
+            compression: Some(setting_compression(compression_name, compression_level)?),
+            parquet_version: setting_parquet_version(settings)?,
+            max_row_group_rows: setting_usize(settings, "parquet_row_group_size", Some(122_880))?,
+            max_row_group_bytes: setting_size(settings, "parquet_row_group_size_bytes", None)?,
+            target_file_size: setting_size(
+                settings,
+                "target_file_size",
+                Some(DEFAULT_TARGET_FILE_SIZE),
+            )?,
+            max_open_partitions: None,
+            upload_concurrency: None,
+            sort_on_insert: setting_bool(settings, "sort_on_insert", true)?,
+            hive_file_pattern: setting_bool(settings, "hive_file_pattern", true)?,
+            auto_compact: setting_bool(settings, "auto_compact", true)?,
+            rewrite_delete_threshold: setting_f64(
+                settings,
+                "rewrite_delete_threshold",
+                Some(0.95),
+            )?,
+            deferred_error: None,
+        })
+    }
+
+    pub(crate) fn from_metadata_settings_deferred(settings: &HashMap<String, String>) -> Self {
+        Self::from_metadata_settings(settings).unwrap_or_else(|e| Self {
+            deferred_error: Some(e.to_string()),
+            ..Self::default()
+        })
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        match &self.deferred_error {
+            Some(error) => Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                "Invalid DuckLake write settings: {error}"
+            ))),
+            None => Ok(()),
+        }
+    }
+
+    pub(crate) fn with_overrides(mut self, overrides: &Self) -> Self {
+        if overrides.compression.is_some() {
+            self.compression = overrides.compression;
+        }
+        if overrides.parquet_version.is_some() {
+            self.parquet_version = overrides.parquet_version;
+        }
+        if overrides.max_row_group_rows.is_some() {
+            self.max_row_group_rows = overrides.max_row_group_rows;
+        }
+        if overrides.max_row_group_bytes.is_some() {
+            self.max_row_group_bytes = overrides.max_row_group_bytes;
+        }
+        if overrides.target_file_size.is_some() {
+            self.target_file_size = overrides.target_file_size;
+        }
+        if overrides.max_open_partitions.is_some() {
+            self.max_open_partitions = overrides.max_open_partitions;
+        }
+        if overrides.upload_concurrency.is_some() {
+            self.upload_concurrency = overrides.upload_concurrency;
+        }
+        if overrides.sort_on_insert.is_some() {
+            self.sort_on_insert = overrides.sort_on_insert;
+        }
+        if overrides.hive_file_pattern.is_some() {
+            self.hive_file_pattern = overrides.hive_file_pattern;
+        }
+        if overrides.auto_compact.is_some() {
+            self.auto_compact = overrides.auto_compact;
+        }
+        if overrides.rewrite_delete_threshold.is_some() {
+            self.rewrite_delete_threshold = overrides.rewrite_delete_threshold;
+        }
+        self
+    }
+}
+
+fn setting_usize(
+    settings: &HashMap<String, String>,
+    key: &str,
+    default: Option<usize>,
+) -> Result<Option<usize>> {
+    settings
+        .get(key)
+        .map(|value| {
+            value.parse::<usize>().map_err(|e| {
+                crate::error::DuckLakeError::InvalidConfig(format!(
+                    "Invalid ducklake_metadata {key} value '{value}': {e}"
+                ))
+            })
+        })
+        .transpose()
+        .map(|value| value.or(default))
+}
+
+fn setting_i32(settings: &HashMap<String, String>, key: &str) -> Result<Option<i32>> {
+    settings
+        .get(key)
+        .map(|value| {
+            value.parse::<i32>().map_err(|e| {
+                crate::error::DuckLakeError::InvalidConfig(format!(
+                    "Invalid ducklake_metadata {key} value '{value}': {e}"
+                ))
+            })
+        })
+        .transpose()
+}
+
+fn setting_f64(
+    settings: &HashMap<String, String>,
+    key: &str,
+    default: Option<f64>,
+) -> Result<Option<f64>> {
+    let value = settings
+        .get(key)
+        .map(|value| {
+            value.parse::<f64>().map_err(|e| {
+                crate::error::DuckLakeError::InvalidConfig(format!(
+                    "Invalid ducklake_metadata {key} value '{value}': {e}"
+                ))
+            })
+        })
+        .transpose()?
+        .or(default);
+    if value.is_some_and(|value| !(0.0..=1.0).contains(&value)) {
+        return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+            "ducklake_metadata {key} must be in [0.0, 1.0]"
+        )));
+    }
+    Ok(value)
+}
+
+fn setting_parquet_version(settings: &HashMap<String, String>) -> Result<Option<WriterVersion>> {
+    settings
+        .get("parquet_version")
+        .map(|value| match value.to_ascii_lowercase().as_str() {
+            "1" | "v1" => Ok(WriterVersion::PARQUET_1_0),
+            "2" | "v2" => Ok(WriterVersion::PARQUET_2_0),
+            _ => Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                "Invalid ducklake_metadata parquet_version '{value}'; expected 1, 2, V1, or V2"
+            ))),
+        })
+        .transpose()
+}
+
+fn setting_size(
+    settings: &HashMap<String, String>,
+    key: &str,
+    default: Option<usize>,
+) -> Result<Option<usize>> {
+    settings
+        .get(key)
+        .map(|value| parse_size(key, value))
+        .transpose()
+        .map(|value| value.or(default))
+}
+
+fn parse_size(key: &str, value: &str) -> Result<usize> {
+    let value = value.trim();
+    let digits = value.bytes().take_while(u8::is_ascii_digit).count();
+    let (number, unit) = value.split_at(digits);
+    if number.is_empty() {
+        return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+            "Invalid ducklake_metadata {key} size '{value}'"
+        )));
+    }
+    let number = number.parse::<usize>().map_err(|e| {
+        crate::error::DuckLakeError::InvalidConfig(format!(
+            "Invalid ducklake_metadata {key} size '{value}': {e}"
+        ))
+    })?;
+    let multiplier = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "kb" => 1_000,
+        "mb" => 1_000_000,
+        "gb" => 1_000_000_000,
+        "tb" => 1_000_000_000_000,
+        "kib" => 1 << 10,
+        "mib" => 1 << 20,
+        "gib" => 1 << 30,
+        "tib" => 1usize << 40,
+        _ => {
+            return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                "Invalid ducklake_metadata {key} size unit in '{value}'"
+            )));
+        },
+    };
+    number.checked_mul(multiplier).ok_or_else(|| {
+        crate::error::DuckLakeError::InvalidConfig(format!(
+            "ducklake_metadata {key} size '{value}' exceeds usize"
+        ))
+    })
+}
+
+fn setting_bool(
+    settings: &HashMap<String, String>,
+    key: &str,
+    default: bool,
+) -> Result<Option<bool>> {
+    let value = match settings.get(key) {
+        Some(value) => match value.to_ascii_lowercase().as_str() {
+            "true" => true,
+            "false" => false,
+            _ => {
+                return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                    "Invalid ducklake_metadata {key} value '{value}'; expected true or false"
+                )));
+            },
+        },
+        None => default,
+    };
+    Ok(Some(value))
+}
+
+fn setting_compression(name: &str, level: Option<i32>) -> Result<Compression> {
+    let invalid = |e: parquet::errors::ParquetError| {
+        crate::error::DuckLakeError::InvalidConfig(format!(
+            "Invalid ducklake_metadata parquet_compression_level {}: {e}",
+            level.unwrap_or_default()
+        ))
+    };
+    match name.to_ascii_lowercase().as_str() {
+        "uncompressed" => Ok(Compression::UNCOMPRESSED),
+        "snappy" => Ok(Compression::SNAPPY),
+        "gzip" => Ok(Compression::GZIP(GzipLevel::default())),
+        "brotli" => Ok(Compression::BROTLI(BrotliLevel::default())),
+        "zstd" => Ok(Compression::ZSTD(match level {
+            None | Some(0) => ZstdLevel::default(),
+            Some(level) => ZstdLevel::try_new(level).map_err(invalid)?,
+        })),
+        "lz4" | "lz4_raw" => Ok(Compression::LZ4_RAW),
+        _ => Err(crate::error::DuckLakeError::InvalidConfig(format!(
+            "Unsupported ducklake_metadata parquet_compression '{name}'"
+        ))),
+    }
 }
 
 /// Options shared by streaming and partitioned table writes.
@@ -142,6 +407,7 @@ pub struct DuckLakeTableWriter {
     /// override via [`DuckLakeTableWriter::with_compression`] to trade write
     /// CPU for ~2x smaller files (e.g. `LZ4`, `SNAPPY`, `ZSTD`).
     compression: Compression,
+    writer_version: WriterVersion,
     /// Optional max rows per parquet row group. `None` leaves the parquet
     /// default. Set via [`DuckLakeTableWriter::with_max_row_group_rows`].
     max_row_group_rows: Option<usize>,
@@ -166,6 +432,8 @@ pub struct DuckLakeTableWriter {
     /// Defaults to [`DEFAULT_MAX_OPEN_PARTITIONS`]; override via
     /// [`DuckLakeTableWriter::with_max_open_partitions`].
     max_open_partitions: usize,
+    sort_on_insert: bool,
+    hive_file_pattern: bool,
 }
 
 impl DuckLakeTableWriter {
@@ -181,11 +449,14 @@ impl DuckLakeTableWriter {
             object_store,
             base_key_path: key_path,
             compression: Compression::UNCOMPRESSED,
+            writer_version: WriterVersion::PARQUET_2_0,
             max_row_group_rows: None,
             max_row_group_bytes: None,
             upload_concurrency: DEFAULT_UPLOAD_CONCURRENCY,
             target_file_size: DEFAULT_TARGET_FILE_SIZE,
             max_open_partitions: DEFAULT_MAX_OPEN_PARTITIONS,
+            sort_on_insert: true,
+            hive_file_pattern: true,
         })
     }
 
@@ -253,6 +524,9 @@ impl DuckLakeTableWriter {
         if let Some(compression) = options.compression {
             self.compression = compression;
         }
+        if let Some(writer_version) = options.parquet_version {
+            self.writer_version = writer_version;
+        }
         if let Some(rows) = options.max_row_group_rows {
             self.max_row_group_rows = Some(rows);
         }
@@ -268,6 +542,12 @@ impl DuckLakeTableWriter {
         if let Some(files) = options.upload_concurrency {
             self.upload_concurrency = files.max(1);
         }
+        if let Some(sort_on_insert) = options.sort_on_insert {
+            self.sort_on_insert = sort_on_insert;
+        }
+        if let Some(hive_file_pattern) = options.hive_file_pattern {
+            self.hive_file_pattern = hive_file_pattern;
+        }
         self
     }
 
@@ -275,7 +555,7 @@ impl DuckLakeTableWriter {
     /// writer's configured compression and row-group caps.
     fn build_writer_props(&self) -> WriterProperties {
         let mut builder = WriterProperties::builder()
-            .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
+            .set_writer_version(self.writer_version)
             .set_compression(self.compression);
         if let Some(rows) = self.max_row_group_rows {
             builder = builder.set_max_row_group_row_count(Some(rows));
@@ -517,7 +797,7 @@ impl DuckLakeTableWriter {
         // at once, so an uncapped large vector column builds multi-GiB row
         // groups that OOM readers. Both default to the parquet default (unset).
         let mut props_builder = WriterProperties::builder()
-            .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
+            .set_writer_version(self.writer_version)
             .set_compression(self.compression);
         if let Some(rows) = self.max_row_group_rows {
             props_builder = props_builder.set_max_row_group_row_count(Some(rows));
@@ -568,6 +848,7 @@ impl DuckLakeTableWriter {
                             target_file_size: self.target_file_size,
                             max_open: self.max_open_partitions,
                             upload_concurrency: self.upload_concurrency,
+                            hive_file_pattern: self.hive_file_pattern,
                             open: Vec::new(),
                             staged: Vec::new(),
                         })
@@ -733,7 +1014,7 @@ impl DuckLakeTableWriter {
         // Stream to a local staging file, then multipart-upload it — the same
         // bounded-memory path `finish()` uses for data files.
         let props = WriterProperties::builder()
-            .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
+            .set_writer_version(self.writer_version)
             .set_compression(self.compression)
             .build();
         let temp = NamedTempFile::new()?;
@@ -873,7 +1154,7 @@ impl DuckLakeTableWriter {
         };
 
         let mut props_builder = WriterProperties::builder()
-            .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
+            .set_writer_version(self.writer_version)
             .set_compression(self.compression);
         if let Some(rows) = self.max_row_group_rows {
             props_builder = props_builder.set_max_row_group_row_count(Some(rows));
@@ -1198,7 +1479,7 @@ impl DuckLakeTableWriter {
         //
         // Skipped when the caller already arranged the rows (`!resolve_layout` — the
         // SQL INSERT path, whose plan carries a SortExec for this same spec).
-        let sorted_owned: Vec<RecordBatch> = if resolve_layout {
+        let sorted_owned: Vec<RecordBatch> = if resolve_layout && self.sort_on_insert {
             let lengths: Vec<usize> = batches.iter().map(|b| b.num_rows()).collect();
             let sorted = crate::sort::sort_batches_by_spec(
                 batches.to_vec(),
@@ -1215,7 +1496,7 @@ impl DuckLakeTableWriter {
         } else {
             Vec::new()
         };
-        let batches: &[RecordBatch] = if resolve_layout {
+        let batches: &[RecordBatch] = if resolve_layout && self.sort_on_insert {
             &sorted_owned
         } else {
             batches
@@ -1316,7 +1597,11 @@ impl DuckLakeTableWriter {
         for (values, batches) in groups {
             // Readable Hive-style relative subpath; files land under the table dir
             // and are registered relative to it.
-            let rel = crate::partition::hive_subpath(key_names, values);
+            let rel = if self.hive_file_pattern {
+                crate::partition::hive_subpath(key_names, values)
+            } else {
+                String::new()
+            };
             let rel_prefix = if rel.is_empty() {
                 None
             } else {
@@ -1676,6 +1961,7 @@ struct PartitionSink {
     props: WriterProperties,
     target_file_size: usize,
     max_open: usize,
+    hive_file_pattern: bool,
     /// One roller per partition with a file in progress, oldest first (eviction takes
     /// from the front). Paired with the partition values its files carry.
     open: Vec<(Vec<Option<String>>, RollingFileWriter)>,
@@ -1720,7 +2006,11 @@ impl PartitionSink {
                         self.staged.push((evicted_values, staged));
                     }
                 }
-                let rel = crate::partition::hive_subpath(&self.key_names, values);
+                let rel = if self.hive_file_pattern {
+                    crate::partition::hive_subpath(&self.key_names, values)
+                } else {
+                    String::new()
+                };
                 self.open.push((
                     values.to_vec(),
                     RollingFileWriter::new(
@@ -2595,6 +2885,140 @@ mod tests {
     use super::*;
     use arrow::array::{Decimal128Array, Int32Array, StringArray, StringViewArray, StructArray};
     use arrow::datatypes::DataType;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("gzip", "22", Compression::GZIP(GzipLevel::default()))]
+    #[case("brotli", "12", Compression::BROTLI(BrotliLevel::default()))]
+    #[case("snappy", "-1", Compression::SNAPPY)]
+    fn compression_level_only_applies_to_zstd(
+        #[case] codec: &str,
+        #[case] level: &str,
+        #[case] expected: Compression,
+    ) {
+        let settings = HashMap::from([
+            ("parquet_compression".to_string(), codec.to_string()),
+            ("parquet_compression_level".to_string(), level.to_string()),
+        ]);
+
+        let options = DuckLakeWriteOptions::from_metadata_settings(&settings).unwrap();
+
+        assert_eq!(options.compression, Some(expected));
+    }
+
+    #[rstest]
+    fn zstd_zero_uses_the_parquet_default_level() {
+        let settings = HashMap::from([
+            ("parquet_compression".to_string(), "zstd".to_string()),
+            ("parquet_compression_level".to_string(), "0".to_string()),
+        ]);
+
+        let options = DuckLakeWriteOptions::from_metadata_settings(&settings).unwrap();
+
+        assert_eq!(
+            options.compression,
+            Some(Compression::ZSTD(ZstdLevel::default()))
+        );
+    }
+
+    #[rstest]
+    fn zstd_without_a_level_uses_the_ducklake_default() {
+        let settings = HashMap::from([("parquet_compression".to_string(), "zstd".to_string())]);
+
+        let options = DuckLakeWriteOptions::from_metadata_settings(&settings).unwrap();
+
+        assert_eq!(
+            options.compression,
+            Some(Compression::ZSTD(ZstdLevel::try_new(3).unwrap()))
+        );
+    }
+
+    #[rstest]
+    fn invalid_write_setting_is_deferred_until_validation() {
+        let settings = HashMap::from([
+            ("parquet_compression".to_string(), "zstd".to_string()),
+            ("parquet_compression_level".to_string(), "23".to_string()),
+        ]);
+
+        let options = DuckLakeWriteOptions::from_metadata_settings_deferred(&settings);
+
+        assert!(options.validate().is_err());
+    }
+
+    #[rstest]
+    fn metadata_options_include_parquet_version_and_rewrite_threshold() {
+        let settings = HashMap::from([
+            ("parquet_version".to_string(), "V1".to_string()),
+            ("rewrite_delete_threshold".to_string(), "0.75".to_string()),
+        ]);
+
+        let options = DuckLakeWriteOptions::from_metadata_settings(&settings).unwrap();
+
+        assert_eq!(options.parquet_version, Some(WriterVersion::PARQUET_1_0));
+        assert_eq!(options.rewrite_delete_threshold, Some(0.75));
+    }
+
+    #[test]
+    fn metadata_write_options_apply_ducklake_defaults_and_units() {
+        let settings = HashMap::from([
+            ("parquet_compression".to_string(), "zstd".to_string()),
+            ("parquet_compression_level".to_string(), "5".to_string()),
+            (
+                "parquet_row_group_size_bytes".to_string(),
+                "2 MiB".to_string(),
+            ),
+            ("target_file_size".to_string(), "5MB".to_string()),
+            ("sort_on_insert".to_string(), "false".to_string()),
+            ("hive_file_pattern".to_string(), "false".to_string()),
+            ("auto_compact".to_string(), "false".to_string()),
+        ]);
+
+        let options = DuckLakeWriteOptions::from_metadata_settings(&settings).unwrap();
+
+        assert_eq!(
+            options.compression,
+            Some(Compression::ZSTD(ZstdLevel::try_new(5).unwrap()))
+        );
+        assert_eq!(options.max_row_group_rows, Some(122_880));
+        assert_eq!(options.max_row_group_bytes, Some(2 * 1_048_576));
+        assert_eq!(options.target_file_size, Some(5_000_000));
+        assert_eq!(options.max_open_partitions, None);
+        assert_eq!(options.sort_on_insert, Some(false));
+        assert_eq!(options.hive_file_pattern, Some(false));
+        assert_eq!(options.auto_compact, Some(false));
+    }
+
+    #[test]
+    fn explicit_write_options_override_catalog_settings_per_field() {
+        let stored = DuckLakeWriteOptions::from_metadata_settings(&HashMap::from([
+            ("parquet_compression".to_string(), "zstd".to_string()),
+            ("target_file_size".to_string(), "5MB".to_string()),
+        ]))
+        .unwrap();
+        let explicit = DuckLakeWriteOptions {
+            compression: Some(Compression::LZ4_RAW),
+            sort_on_insert: Some(false),
+            ..Default::default()
+        };
+
+        let options = stored.with_overrides(&explicit);
+
+        assert_eq!(options.compression, Some(Compression::LZ4_RAW));
+        assert_eq!(options.target_file_size, Some(5_000_000));
+        assert_eq!(options.sort_on_insert, Some(false));
+        assert_eq!(options.hive_file_pattern, Some(true));
+    }
+
+    #[test]
+    fn metadata_lz4_uses_the_standard_parquet_codec() {
+        let options = DuckLakeWriteOptions::from_metadata_settings(&HashMap::from([(
+            "parquet_compression".to_string(),
+            "lz4".to_string(),
+        )]))
+        .unwrap();
+
+        assert_eq!(options.compression, Some(Compression::LZ4_RAW));
+    }
 
     #[test]
     fn test_arrow_schema_to_column_defs() {

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -234,6 +234,7 @@ impl ExecutionPlan for DuckLakeUpdateExec {
                 .runtime_env()
                 .object_store(object_store_url.as_ref())?;
             let table_writer = DuckLakeTableWriter::new(writer, object_store)
+                .map(|writer| writer.with_options(table.write_options()))
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
             // Rewrite each source file's matching rows and author its cumulative

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -19,6 +19,7 @@ use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use rstest::rstest;
 use sqlx::sqlite::SqlitePool;
 use sqlx::{AssertSqlSafe, Row};
 use tempfile::TempDir;
@@ -2426,18 +2427,12 @@ async fn merge_inherits_the_tables_write_options() {
     seed(&temp, vec![1, 2, 3], vec![10, 20, 30]).await;
     append(&temp, vec![4, 5, 6], vec![40, 50, 60]).await;
 
-    let result = run_merge_with_write_options(
-        &temp,
-        DuckLakeWriteOptions {
-            compression: Some(Compression::LZ4),
-            // Two rows per group over six: enough that a single group is
-            // unmistakably the writer default rather than a coincidence.
-            max_row_group_rows: Some(2),
-            ..Default::default()
-        },
-        MergeOptions::default(),
-    )
-    .await;
+    let mut write_options = DuckLakeWriteOptions::default();
+    write_options.compression = Some(Compression::LZ4);
+    // Two rows per group over six: enough that a single group is
+    // unmistakably the writer default rather than a coincidence.
+    write_options.max_row_group_rows = Some(2);
+    let result = run_merge_with_write_options(&temp, write_options, MergeOptions::default()).await;
     assert_eq!(result.files_processed, 2);
     assert_eq!(result.files_created, 1);
 
@@ -2456,6 +2451,71 @@ async fn merge_inherits_the_tables_write_options() {
         codecs.iter().all(|c| *c == Compression::LZ4),
         "merged file written {codecs:?}, not the table's configured codec"
     );
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_compact_false_skips_explicit_merge() {
+    use datafusion_ducklake::DuckLakeWriteOptions;
+
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2, 3], vec![10, 20, 30]).await;
+    append(&temp, vec![4, 5, 6], vec![40, 50, 60]).await;
+    let mut write_options = DuckLakeWriteOptions::default();
+    write_options.auto_compact = Some(false);
+
+    let result = run_merge_with_write_options(&temp, write_options, MergeOptions::default()).await;
+
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 0,
+            files_created: 0,
+            rows_written: 0,
+        }
+    );
+    let p = pool(&temp).await;
+    let live_files: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL")
+            .fetch_one(&p)
+            .await
+            .unwrap();
+    assert_eq!(live_files, 2);
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn scoped_rewrite_threshold_replaces_the_default_selector() {
+    use datafusion_ducklake::DuckLakeWriteOptions;
+
+    let temp = TempDir::new().unwrap();
+    seed(
+        &temp,
+        (1..=10).collect(),
+        (1..=10).map(|value| value * 10).collect(),
+    )
+    .await;
+    let writer = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+    let provider = SqliteMetadataProvider::new(&db_url(&temp)).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let context = SessionContext::new();
+    context.register_catalog("ducklake", Arc::new(catalog));
+    context
+        .sql("DELETE FROM ducklake.main.t WHERE id <= 8")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut write_options = DuckLakeWriteOptions::default();
+    write_options.rewrite_delete_threshold = Some(0.75);
+
+    let result =
+        run_rewrite_with_write_options(&temp, write_options, RewriteOptions::default()).await;
+
+    assert_eq!(result.files_processed, 1);
+    assert_eq!(result.files_created, 1);
+    assert_eq!(result.rows_written, 2);
 }
 
 /// The same for `rewrite_data_files`, which is a second writer construction and
@@ -2478,13 +2538,12 @@ async fn rewrite_inherits_the_tables_write_options() {
 
     // Naming the file rewrites it regardless of its delete fraction, which is
     // what makes this a rewrite rather than a merge.
+    let mut write_options = DuckLakeWriteOptions::default();
+    write_options.compression = Some(Compression::LZ4);
+    write_options.max_row_group_rows = Some(2);
     let result = run_rewrite_with_write_options(
         &temp,
-        DuckLakeWriteOptions {
-            compression: Some(Compression::LZ4),
-            max_row_group_rows: Some(2),
-            ..Default::default()
-        },
+        write_options,
         RewriteOptions {
             data_file_ids: Some(vec![file_id]),
             ..Default::default()

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -66,6 +66,7 @@ mod renamed_columns_tests;
 mod row_count_tests;
 mod row_id_tests;
 mod rowid_physical_position_tests;
+mod scoped_settings_tests;
 mod sorted_write_duckdb_tests;
 mod sorted_write_tests;
 mod sql_delete_postgres_tests;

--- a/tests/it/multicatalog_provider_tests.rs
+++ b/tests/it/multicatalog_provider_tests.rs
@@ -16,6 +16,7 @@ use datafusion_ducklake::{
     MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter,
     initialize_multicatalog_schema,
 };
+use rstest::rstest;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::sync::Arc;
 use testcontainers::ContainerAsync;
@@ -675,4 +676,30 @@ async fn file_listing_filter_falls_open_on_a_catalog_without_statistics() {
 
 fn listed_ids(files: &[DuckLakeFileMetadata]) -> Vec<i64> {
     files.iter().map(|file| file.file.data_file_id).collect()
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn catalog_setting_deterministically_overrides_shared_global_setting() -> anyhow::Result<()> {
+    let (pool, _container) = spin_up_postgres().await?;
+    let manager = MulticatalogManager::new(pool.clone());
+    let catalog_id = manager.create_catalog("settings_test").await?;
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value, scope, scope_id) VALUES \
+         ('parquet_compression', 'snappy', NULL, NULL), \
+         ('parquet_compression', 'zstd', 'catalog', $1)",
+    )
+    .bind(catalog_id)
+    .execute(&pool)
+    .await?;
+
+    let provider = MulticatalogProvider::with_pool_and_id(pool, catalog_id).await?;
+    let settings = provider.get_metadata_settings(None, None)?;
+
+    assert_eq!(
+        settings.get("parquet_compression").map(String::as_str),
+        Some("zstd")
+    );
+    Ok(())
 }

--- a/tests/it/scoped_settings_tests.rs
+++ b/tests/it/scoped_settings_tests.rs
@@ -1,0 +1,376 @@
+//! Scoped DuckLake catalog-setting integration tests.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite", feature = "metadata-duckdb"))]
+
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use datafusion_ducklake::metadata_provider::MetadataProvider;
+use datafusion_ducklake::{
+    ColumnDef, DuckLakeCatalog, DuckdbMetadataProvider, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter, WriteMode,
+};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::basic::Compression;
+use rstest::rstest;
+use sqlx::SqlitePool;
+use tempfile::TempDir;
+
+fn assert_parquet_v1_zstd(path: &Path) {
+    let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap()).unwrap();
+    let metadata = reader.metadata();
+    assert_eq!(
+        metadata.file_metadata().version(),
+        1,
+        "unexpected Parquet version for {}",
+        path.display()
+    );
+    let compression = metadata.row_groups()[0].columns()[0].compression();
+    assert!(
+        matches!(compression, Compression::ZSTD(_)),
+        "unexpected compression {compression:?} for {}",
+        path.display()
+    );
+}
+
+async fn writable_context(connection: &str) -> SessionContext {
+    let provider = SqliteMetadataProvider::new(connection).await.unwrap();
+    let writer = SqliteMetadataWriter::new(connection).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let context = SessionContext::new();
+    context.register_catalog("lake", Arc::new(catalog));
+    context
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn writable_open_adds_scope_id_once_and_preserves_global_settings() {
+    let temp = TempDir::new().unwrap();
+    let database = temp.path().join("legacy.db");
+    let connection = format!("sqlite:{}?mode=rwc", database.display());
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    sqlx::query("CREATE TABLE ducklake_metadata (key VARCHAR NOT NULL, value VARCHAR NOT NULL)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value) VALUES ('data_path', '/preserved/path')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, None)
+            .unwrap()
+            .get("data_path")
+            .map(String::as_str),
+        Some("/preserved/path")
+    );
+
+    let writer = SqliteMetadataWriter::new_with_init(&connection)
+        .await
+        .unwrap();
+    writer
+        .set_global_setting("parquet_compression", "zstd")
+        .unwrap();
+    SqliteMetadataWriter::new_with_init(&connection)
+        .await
+        .unwrap();
+
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    let scope_columns: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('ducklake_metadata') \
+         WHERE name IN ('scope', 'scope_id')",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let data_path: String = sqlx::query_scalar(
+        "SELECT value FROM ducklake_metadata WHERE key = 'data_path' AND scope IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(scope_columns, 2);
+    assert_eq!(data_path, "/preserved/path");
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, None)
+            .unwrap()
+            .get("parquet_compression")
+            .map(String::as_str),
+        Some("zstd")
+    );
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn table_scoped_parquet_options_control_insert_update_and_delete_files() {
+    let temp = TempDir::new().unwrap();
+    let database = temp.path().join("catalog.db");
+    let data = temp.path().join("data");
+    std::fs::create_dir(&data).unwrap();
+    let connection = format!("sqlite:{}?mode=rwc", database.display());
+
+    let writer = SqliteMetadataWriter::new_with_init(&connection)
+        .await
+        .unwrap();
+    writer.set_data_path(data.to_str().unwrap()).unwrap();
+    let columns = vec![ColumnDef::new("id", "int64", false).unwrap()];
+    let setup = writer
+        .begin_write_transaction("main", "events", &columns, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "main",
+            "events",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value, scope, scope_id) \
+         VALUES ('parquet_compression', 'zstd', 'table', ?), \
+                ('parquet_version', 'V1', 'table', ?)",
+    )
+    .bind(setup.table_id)
+    .bind(setup.table_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let context = SessionContext::new();
+    context.register_catalog("lake", Arc::new(catalog));
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    context
+        .register_batch(
+            "source",
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap(),
+        )
+        .unwrap();
+    context
+        .sql("INSERT INTO lake.main.events SELECT * FROM source")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let files = provider
+        .get_table_files_for_select(setup.table_id, snapshot)
+        .unwrap();
+    assert_eq!(files.len(), 1);
+    let table_path = data.join("main/events");
+    assert_parquet_v1_zstd(&table_path.join(&files[0].file.path));
+
+    let context = writable_context(&connection).await;
+    context
+        .sql("UPDATE lake.main.events SET id = id + 10 WHERE id = 1")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let files = provider
+        .get_table_files_for_select(setup.table_id, snapshot)
+        .unwrap();
+    assert_eq!(files.len(), 2);
+    for file in &files {
+        assert_parquet_v1_zstd(&table_path.join(&file.file.path));
+        if let Some(delete_file) = &file.delete_file {
+            assert_parquet_v1_zstd(&table_path.join(&delete_file.path));
+        }
+    }
+    assert_eq!(
+        files
+            .iter()
+            .filter(|file| file.delete_file.is_some())
+            .count(),
+        1
+    );
+
+    let context = writable_context(&connection).await;
+    context
+        .sql("DELETE FROM lake.main.events WHERE id = 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let files = provider
+        .get_table_files_for_select(setup.table_id, snapshot)
+        .unwrap();
+    let delete_files: Vec<_> = files
+        .iter()
+        .filter_map(|file| file.delete_file.as_ref())
+        .collect();
+    assert_eq!(delete_files.len(), 1);
+    assert_parquet_v1_zstd(&table_path.join(&delete_files[0].path));
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_write_setting_does_not_block_reads() {
+    let temp = TempDir::new().unwrap();
+    let database = temp.path().join("catalog.db");
+    let data = temp.path().join("data");
+    std::fs::create_dir(&data).unwrap();
+    let connection = format!("sqlite:{}?mode=rwc", database.display());
+    let writer = SqliteMetadataWriter::new_with_init(&connection)
+        .await
+        .unwrap();
+    writer.set_data_path(data.to_str().unwrap()).unwrap();
+    let columns = vec![ColumnDef::new("id", "int64", false).unwrap()];
+    let setup = writer
+        .begin_write_transaction("main", "events", &columns, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "main",
+            "events",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value, scope, scope_id) \
+         VALUES ('parquet_compression', 'zstd', 'table', ?), \
+                ('parquet_compression_level', '23', 'table', ?)",
+    )
+    .bind(setup.table_id)
+    .bind(setup.table_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let context = SessionContext::new();
+    context.register_catalog("lake", Arc::new(catalog));
+    let batches = context
+        .sql("SELECT count(*) FROM lake.main.events")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0),
+        0
+    );
+
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    context
+        .register_batch(
+            "source",
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1]))]).unwrap(),
+        )
+        .unwrap();
+    let error = match context
+        .sql("INSERT INTO lake.main.events SELECT * FROM source")
+        .await
+    {
+        Ok(frame) => frame.collect().await.unwrap_err().to_string(),
+        Err(e) => e.to_string(),
+    };
+    assert!(error.contains("Invalid DuckLake write settings"), "{error}");
+}
+
+#[test]
+fn official_duckdb_settings_resolve_with_table_precedence() {
+    let temp = TempDir::new().unwrap();
+    let catalog_path = temp.path().join("official.ducklake");
+    let data_path = temp.path().join("data");
+    let connection = duckdb::Connection::open_in_memory().unwrap();
+    connection.execute("INSTALL ducklake", []).unwrap();
+    connection.execute("LOAD ducklake", []).unwrap();
+    connection
+        .execute(
+            &format!(
+                "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}')",
+                catalog_path.display(),
+                data_path.display()
+            ),
+            [],
+        )
+        .unwrap();
+    connection
+        .execute("CREATE TABLE lake.events (id BIGINT)", [])
+        .unwrap();
+    connection
+        .execute(
+            "CALL lake.set_option('parquet_compression', 'uncompressed')",
+            [],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "CALL lake.set_option('parquet_compression', 'lz4', schema => 'main')",
+            [],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "CALL lake.set_option('parquet_compression', 'zstd', table_name => 'events')",
+            [],
+        )
+        .unwrap();
+    connection.execute("DETACH lake", []).unwrap();
+    drop(connection);
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap()).unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let schema = provider
+        .get_schema_by_name("main", snapshot)
+        .unwrap()
+        .unwrap();
+    let table = provider
+        .get_table_by_name(schema.schema_id, "events", snapshot)
+        .unwrap()
+        .unwrap();
+    let settings = provider
+        .get_metadata_settings(Some(schema.schema_id), Some(table.table_id))
+        .unwrap();
+
+    assert_eq!(
+        settings.get("parquet_compression").map(String::as_str),
+        Some("zstd")
+    );
+}

--- a/tests/it/sorted_write_tests.rs
+++ b/tests/it/sorted_write_tests.rs
@@ -74,10 +74,8 @@ async fn setup() -> Env {
 async fn write_ctx(conn_str: &str, target_file_size: usize, batch_size: usize) -> SessionContext {
     let writer = SqliteMetadataWriter::new_with_init(conn_str).await.unwrap();
     let provider = SqliteMetadataProvider::new(conn_str).await.unwrap();
-    let options = DuckLakeWriteOptions {
-        target_file_size: Some(target_file_size),
-        ..Default::default()
-    };
+    let mut options = DuckLakeWriteOptions::default();
+    options.target_file_size = Some(target_file_size);
     let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer))
         .unwrap()
         .with_write_options(options);


### PR DESCRIPTION
### Summary

Resolve `ducklake_metadata` values per key with Table over Schema over Global
precedence across SQLite, DuckDB, MySQL, single-catalog PostgreSQL, and
multicatalog PostgreSQL. Catalog-derived settings flow through the shared table
write options used by inserts, updates, merge compaction, and rewrite
compaction; explicit Rust options remain the final overlay.

The review update keeps reads available when a write-only setting is invalid,
migrates the true legacy two-column metadata shape, makes multicatalog
catalog-over-global precedence deterministic, and consumes the previously
parsed `auto_compact` setting. It also adds `parquet_version` and
`rewrite_delete_threshold`, implements the missing single-catalog PostgreSQL
global setter, marks `DuckLakeWriteOptions` non-exhaustive, and documents the
changed catalog-backed Parquet layout defaults.

The follow-up preserves resolved table options through UPDATE's read-only scan
clone and applies them when DELETE constructs its positional-delete writer.
INSERT, UPDATE, DELETE, and maintenance therefore use one table-scoped Parquet
format and compression contract.

```mermaid
flowchart LR
    Metadata["ducklake_metadata rows"] --> Resolve["Resolve each key"]
    Global["Global"] --> Resolve
    Schema["Matching schema"] --> Resolve
    Table["Matching table"] --> Resolve
    Resolve --> Deferred["Retain deferred write validation"]
    Explicit["Explicit Rust options"] --> Effective["Effective table options"]
    Deferred --> Effective
    Effective --> Read["Reads remain available"]
    Effective --> Insert["INSERT, UPDATE, and DELETE"]
    Effective --> Compact["Merge and rewrite"]
```

The diagram shows settings resolution, explicit overrides, deferred validation,
and the read and mutation consumers.

### Setting behavior

| Setting | DuckLake default | Applied behavior |
| --- | --- | --- |
| `parquet_compression` | `snappy` | Selects the Parquet codec; `lz4` maps to `LZ4_RAW`. |
| `parquet_compression_level` | `3` | Applies only to ZSTD; `0` selects parquet-rs's default level. |
| `parquet_version` | `V1` | Selects Parquet V1 or V2 for every data and delete writer path; when absent, the crate retains its existing V2 writer default. |
| `parquet_row_group_size` | `122880` | Caps rows per row group. |
| `parquet_row_group_size_bytes` | Unset | Caps uncompressed bytes per row group when present. |
| `target_file_size` | `512MB` | Controls insert rollover and the table writer used by compaction. |
| `sort_on_insert` | `true` | Enables or suppresses the insert sort plan. |
| `hive_file_pattern` | `true` | Enables or suppresses Hive-style partition directories. |
| `auto_compact` | `true` | Gates merge and rewrite maintenance for the table. |
| `rewrite_delete_threshold` | `0.95` | Replaces the default rewrite selector; a non-default explicit Rust threshold wins. |

Catalog-backed writes therefore now default to Snappy, 122,880 rows per row
group, and a 512 MB target. This differs from the previous uncompressed,
Parquet-default row-group layout and can change file sizes.

### Review resolutions

- Invalid ZSTD levels are stored as a deferred table write error. `SELECT`
  still opens and scans the table; insert, update, merge, or rewrite reports the
  setting before mutation.
- Compression levels are parsed only for ZSTD. DuckLake's legal `0` value maps
  to parquet-rs's default level; GZIP and Brotli use their codec defaults.
- Writable initialization adds both `scope` and `scope_id` to a legacy
  `ducklake_metadata(key, value)` table and is idempotent. Read-only providers
  query only `key` and `value` when either scope column is unavailable.
- A matching `scope = 'catalog'` row is ordered after shared globals before the
  map overlay, eliminating arbitrary duplicate-key precedence.
- `set_global_setting` is implemented by the standard PostgreSQL writer as well
  as the other writers.
- `DuckLakeWriteOptions` is non-exhaustive and its `None` documentation now
  describes an unchanged receiving writer rather than uncompressed output.
- UPDATE clones retain the resolved write options, and DELETE applies those
  options to positional-delete writers. A regression inspects every resulting
  data and delete footer after all three SQL mutations.
- `COMPATIBILITY.md` records that an absent `parquet_version` retains the
  crate's existing V2 default while DuckDB `COPY` defaults to V1.

### Commit and branch

- Branch: `ducklake-scoped-settings-pr`.
- Commit: `7edb6f97229d895d4919a4109a3b6a8de180fba8` (`feat: honor scoped DuckLake settings`).
- Base: upstream `main` at
  `a2360b1bd01ce88a3331a71cb2d8eadea98531de`, the merge of
  [PR #263](https://github.com/datafusion-contrib/datafusion-ducklake/pull/263).
- Shape: one incremental scoped-settings commit directly over `main`.
- Remote: `ata/ducklake-scoped-settings-pr`.
- Pull request:
  [#271](https://github.com/datafusion-contrib/datafusion-ducklake/pull/271).

### Verification

- `cargo fmt --all`: passed.
- `cargo check --tests --all-features`: passed.
- `cargo test --all-features scoped_settings -- --nocapture`: 4 passed,
  including V1/ZSTD footer checks across INSERT, UPDATE, and DELETE.
- `cargo test --all-features table_writer::tests -- --nocapture`: 17 passed.
- `cargo test --all-features auto_compact_false_skips_explicit_merge -- --nocapture`: passed.
- `cargo test --all-features scoped_rewrite_threshold_replaces_the_default_selector -- --nocapture`: passed.
- `cargo test --no-default-features --features multicatalog-postgres,write-postgres catalog_setting_deterministically_overrides_shared_global_setting -- --nocapture`: passed against a disposable PostgreSQL container.
- `cargo test --all-features`: 431 library tests and 437 integration tests
  passed; 201 service-gated integration tests were ignored as configured; 8
  doctests passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `openspec validate ducklake-spec-parity --strict`: passed.
- `markdownlint-cli2` on this summary: passed.
- `mermaid-lint` on this summary: passed.

### Specification proof

| DuckLake rule | Implementation invariant | Discriminating proof |
| --- | --- | --- |
| [`ducklake_metadata`](https://ducklake.select/docs/stable/specification/tables/ducklake_metadata) stores global, schema, and table settings with `scope_id`. | Providers resolve only matching scopes; writable backends migrate both missing scope columns. | The legacy SQLite fixture starts with only `key` and `value`, reads before migration, opens writable twice, and preserves values. |
| [Configuration precedence](https://ducklake.select/docs/stable/duckdb/usage/configuration) gives more-specific scopes priority. | Each key overlays Global, Schema, then Table; multicatalog rows overlay shared globals deterministically. | SQLite and DuckDB precedence tests pass; a live PostgreSQL test inserts duplicate global and catalog keys and observes the catalog value. |
| [Parquet options](https://ducklake.select/docs/stable/duckdb/usage/configuration) define compression, version, row-group, and file-size settings. | All Parquet writer sites receive the resolved version and layout; UPDATE clones preserve it and DELETE applies it to positional-delete output. Levels are ZSTD-only and validation is deferred to mutation. | Unit cases cover ZSTD `0`, default `3`, non-ZSTD levels, version parsing, and deferred invalid settings. An integration test proves `SELECT` succeeds before mutation rejects an invalid setting, then inspects V1/ZSTD data and delete footers across INSERT, UPDATE, and DELETE. |
| [`hive_file_pattern`](https://ducklake.select/docs/stable/duckdb/advanced_features/partitioning) controls partition-directory naming. | Buffered, streaming, update, and compaction writes share the resolved partition-path policy. | Existing partition-aware insert and compaction suites exercise the shared writer options. |
| [`rewrite_delete_threshold`](https://ducklake.select/docs/stable/duckdb/maintenance/rewrite_data_files) controls automatic rewrite selection. | The resolved threshold replaces `RewriteOptions::default()` while a non-default explicit threshold remains authoritative. | A 0.8-deleted file rewrites at a scoped 0.75 threshold although the built-in 0.95 default would skip it. |
| [`auto_compact`](https://ducklake.select/docs/stable/duckdb/maintenance/merge_adjacent_files) excludes a table from maintenance. | Merge and rewrite return a no-op before changing metadata when the resolved value is false. | A two-file merge test observes exact zero metrics and two unchanged live files. |

### Reference implementation

The implementation was checked against official DuckLake source at commit
[`7c0eafc`](https://github.com/duckdb/ducklake/tree/7c0eafc80413c311aabd47c71044f3b1318cc342):

- Option validation and accepted values in
  [`ducklake_set_option.cpp`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/functions/ducklake_set_option.cpp).
- Parquet options passed to `COPY` in
  [`ducklake_insert.cpp`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_insert.cpp).
- `auto_compact` and `rewrite_delete_threshold` maintenance behavior in
  [`ducklake_compaction_functions.cpp`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/functions/ducklake_compaction_functions.cpp).

The pinned parquet-rs 59.2.0 accepts ZSTD levels 1 through 22. DuckLake level
`0` is intentionally translated to parquet-rs's default rather than rejected.
The existing crate default remains Parquet V2 when `parquet_version` is absent;
the configured setting is no longer ignored.

### Review boundary

This PR owns scoped metadata resolution, backward-compatible metadata-scope
migration, catalog-backed writer defaults and consumers, and their tests and
documentation. It does not update or rewrite later stacked PR branches.
