### PR TITLE
Complete DuckDB and MySQL metadata writers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ concurrency:
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
+  DUCKDB_CLI_VERSION: "1.5.5"
   RUSTC_WRAPPER: "sccache"
   # Incremental artifacts are useless on a fresh CI runner and inflate the target
   # directory that the cache below has to carry, so keep them out of it. (This is
@@ -217,6 +218,18 @@ jobs:
       # `write-sqlite` pulls in the writer and sqlite-provider tests,
       # which are `#![cfg]`-gated; without it cargo compiles them to
       # zero-test binaries.
+      - name: Install DuckDB CLI (macOS)
+        if: steps.changes.outputs.code == 'true' && runner.os == 'macOS'
+        shell: bash
+        run: |
+          duckdb_archive="$RUNNER_TEMP/duckdb.gz"
+          curl --fail --location --retry 3 --output "$duckdb_archive" \
+            "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_CLI_VERSION}/duckdb_cli-osx-universal.gz"
+          gzip --decompress --stdout "$duckdb_archive" > "$RUNNER_TEMP/duckdb"
+          chmod +x "$RUNNER_TEMP/duckdb"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/duckdb" --version
+
       - name: Run tests (macOS; Linux is covered by test-full)
         if: steps.changes.outputs.code == 'true' && runner.os == 'macOS'
         run: cargo test --features "skip-tests-with-docker write-sqlite"
@@ -445,6 +458,18 @@ jobs:
       # `skip-tests-with-docker` is NOT set, so the container-backed suites run.
       # Multicatalog (the runtimedb-specific layer, gated on `write-postgres`) is
       # intentionally excluded here — its test files stay in-tree but don't run.
+      - name: Install DuckDB CLI
+        if: steps.changes.outputs.code == 'true'
+        shell: bash
+        run: |
+          duckdb_archive="$RUNNER_TEMP/duckdb.gz"
+          curl --fail --location --retry 3 --output "$duckdb_archive" \
+            "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_CLI_VERSION}/duckdb_cli-linux-amd64.gz"
+          gzip --decompress --stdout "$duckdb_archive" > "$RUNNER_TEMP/duckdb"
+          chmod +x "$RUNNER_TEMP/duckdb"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/duckdb" --version
+
       - name: Run single-catalog test suite
         if: steps.changes.outputs.code == 'true'
         run: cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite write-sqlite"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   DUCKDB_CLI_VERSION: "1.5.5"
+  DUCKDB_CLI_MACOS_SHA256: "cbd6e7d472c33083db32e1e78d71ab9eefb32da872c349423294de370b8f4ca9"
+  DUCKDB_CLI_LINUX_SHA256: "c61f21485e6e41d3a0c28ce9904ea18346309cf427b4cf9479bc3564348dc885"
   RUSTC_WRAPPER: "sccache"
   # Incremental artifacts are useless on a fresh CI runner and inflate the target
   # directory that the cache below has to carry, so keep them out of it. (This is
@@ -225,6 +227,7 @@ jobs:
           duckdb_archive="$RUNNER_TEMP/duckdb.gz"
           curl --fail --location --retry 3 --output "$duckdb_archive" \
             "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_CLI_VERSION}/duckdb_cli-osx-universal.gz"
+          printf '%s  %s\n' "$DUCKDB_CLI_MACOS_SHA256" "$duckdb_archive" | shasum -a 256 -c -
           gzip --decompress --stdout "$duckdb_archive" > "$RUNNER_TEMP/duckdb"
           chmod +x "$RUNNER_TEMP/duckdb"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
@@ -465,6 +468,7 @@ jobs:
           duckdb_archive="$RUNNER_TEMP/duckdb.gz"
           curl --fail --location --retry 3 --output "$duckdb_archive" \
             "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_CLI_VERSION}/duckdb_cli-linux-amd64.gz"
+          printf '%s  %s\n' "$DUCKDB_CLI_LINUX_SHA256" "$duckdb_archive" | shasum -a 256 -c -
           gzip --decompress --stdout "$duckdb_archive" > "$RUNNER_TEMP/duckdb"
           chmod +x "$RUNNER_TEMP/duckdb"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every live file (#293).
 - Scoped DuckLake settings resolve per key with table-over-schema-over-global precedence on
   every metadata backend; SQL writes and compaction honour the resolved values (#271).
+- SQL `DELETE` can commit Parquet-resident and catalog-inlined rows in one
+  snapshot on all four write backends; DuckDB and MySQL now implement combined
+  deletes and exact inline-aware truncate counts (#273).
+
+- Scoped settings now govern writer compression, row groups, rollover, sorting,
+  partition paths, and the inclusive `data_inlining_row_limit`; supported small
+  writes stay in metadata with stable row IDs and snapshot visibility (#272).
+
 - `DuckLakeTableWriter::with_upload_concurrency` and `DuckLakeWriteOptions::upload_concurrency`
   set how many finished data files a rolling or partitioned write uploads at once, default 4.
   Written output is identical at any setting (#280).
@@ -54,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offers no public constructor for one, so these two execs are effectively crate-internal now.
   `ROW_POS_COLUMN_NAME` is also only a *base* name: a scan whose file already has a column of
   that name uses a suffixed variant, so locating the column by name is no longer reliable (#130).
+- Small writes inline only when `supports_data_inlining` accepts the schema;
+  unsupported schemas fall back to Parquet. `UPDATE` and row-lineage scans reject
+  visible inlined rows with a clear flush-or-disable remedy (#272).
+
 - **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. Add
   `..Default::default()` to exhaustive struct literals; no catalog or data migration (#280).
 - Rolling and partitioned writes upload up to 4 files at once, raising peak write memory
@@ -87,6 +99,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delete file, with no `NanPruningBarrierExec` above it, silently dropping NaN rows (#130).
 - The internal physical-position column could bind to a catalog column of the same name in the
   CDC feeds, making them report the wrong rows (#130).
+- MySQL allocates data and delete file IDs consistently from catalog counters,
+  avoiding collisions across append, update, delete, and compaction paths (#273).
+- DuckDB and MySQL mutation flows now record `changes_made` entries for every
+  data-modifying snapshot (#273).
+- A first write after an abandoned staged table now commits and seeds table stats
+  instead of failing with a permanent `Conflict` (#273).
+
+- SQLite and MySQL inline encodings now round-trip floats and binary values
+  exactly (#272).
+- Inline commits honor expected-base, commit-metadata, and partition-spec fences
+  and preserve existing snapshot-change tokens (#272).
+- MySQL creates inline-table DDL before opening the write transaction, avoiding
+  implicit partial commits (#272).
+
 - `NULL` sentinels, BLOB decoding, expression-default reads, and legacy schema migration (#259).
 - Name-mapped Hive columns retain values through `DELETE`, `UPDATE`, and compaction;
   mapped CDC reads no longer return NULL after column renames. Map keys and nested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / rewrite paths explicitly (#130).
 
 ### Changed
-- Upgrade bundled DuckDB and the CI CLI to 1.5.5; Parquet fixtures explicitly disable default small-write inlining.
+- Upgrade bundled DuckDB and the CI CLI to 1.5.5; Parquet fixtures explicitly disable default small-write inlining (#273).
 
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ducklake.upload_staged_file` spans now overlap in wall-clock time (#280).
 
 ### Fixed
-- Read legacy global schema-version ledgers without assuming per-table provenance.
+- Read legacy global schema-version ledgers without assuming per-table provenance (#273).
 
 - Fix DuckDB compaction skipping eligible data files and retain historical row visibility (#273).
 - Invalid write-only catalog settings no longer block table reads; they fail when a write or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix DuckDB compaction skipping eligible data files and retain historical row visibility (#273).
 - Invalid write-only catalog settings no longer block table reads; they fail when a write or
   maintenance operation is planned (#271).
 - Legacy two-column `ducklake_metadata` tables migrate both scope columns losslessly (#271).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / rewrite paths explicitly (#130).
 
 ### Changed
+- Upgrade the bundled DuckDB and CI CLI to 1.5.5; Parquet fixtures explicitly disable default small-write inlining.
 
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).
@@ -82,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ducklake.upload_staged_file` spans now overlap in wall-clock time (#280).
 
 ### Fixed
+- Read legacy global schema-version ledgers without assuming per-table provenance.
 
 - Fix DuckDB compaction skipping eligible data files and retain historical row visibility (#273).
 - Invalid write-only catalog settings no longer block table reads; they fail when a write or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   snapshot on all four write backends; DuckDB and MySQL now implement combined
   deletes and exact inline-aware truncate counts (#273).
 
-- Scoped settings now govern writer compression, row groups, rollover, sorting,
-  partition paths, and the inclusive `data_inlining_row_limit`; supported small
-  writes stay in metadata with stable row IDs and snapshot visibility (#272).
-
 - `DuckLakeTableWriter::with_upload_concurrency` and `DuckLakeWriteOptions::upload_concurrency`
   set how many finished data files a rolling or partitioned write uploads at once, default 4.
   Written output is identical at any setting (#280).
@@ -42,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / rewrite paths explicitly (#130).
 
 ### Changed
-- Upgrade the bundled DuckDB and CI CLI to 1.5.5; Parquet fixtures explicitly disable default small-write inlining.
+- Upgrade bundled DuckDB and the CI CLI to 1.5.5; Parquet fixtures explicitly disable default small-write inlining.
 
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).
@@ -63,10 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offers no public constructor for one, so these two execs are effectively crate-internal now.
   `ROW_POS_COLUMN_NAME` is also only a *base* name: a scan whose file already has a column of
   that name uses a suffixed variant, so locating the column by name is no longer reliable (#130).
-- Small writes inline only when `supports_data_inlining` accepts the schema;
-  unsupported schemas fall back to Parquet. `UPDATE` and row-lineage scans reject
-  visible inlined rows with a clear flush-or-disable remedy (#272).
-
 - **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. Add
   `..Default::default()` to exhaustive struct literals; no catalog or data migration (#280).
 - Rolling and partitioned writes upload up to 4 files at once, raising peak write memory
@@ -108,13 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   data-modifying snapshot (#273).
 - A first write after an abandoned staged table now commits and seeds table stats
   instead of failing with a permanent `Conflict` (#273).
-
-- SQLite and MySQL inline encodings now round-trip floats and binary values
-  exactly (#272).
-- Inline commits honor expected-base, commit-metadata, and partition-spec fences
-  and preserve existing snapshot-change tokens (#272).
-- MySQL creates inline-table DDL before opening the write transaction, avoiding
-  implicit partial commits (#272).
 
 - `NULL` sentinels, BLOB decoding, expression-default reads, and legacy schema migration (#259).
 - Name-mapped Hive columns retain values through `DELETE`, `UPDATE`, and compaction;

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -11,19 +11,16 @@ backends, object stores, types, capabilities, and current limitations. The
 
 ## Catalog backends
 
-DuckLake stores catalog metadata in a SQL database. Reads are supported on all four
-backends below; writes (`INSERT`, `DROP TABLE`, maintenance) are currently implemented
-for SQLite and PostgreSQL only. SQL `CREATE TABLE`/CTAS works on the SQLite
-single-catalog path; the PostgreSQL path is the experimental multi-catalog layout (see
-below) where tables are created via `DuckLakeTableWriter` and then appended to with
-`INSERT INTO`.
+DuckLake stores catalog metadata in a SQL database. Reads and writes are supported on all
+four backends below. DuckDB, SQLite, and MySQL use the standard single-catalog layout. The
+PostgreSQL path uses the experimental multi-catalog layout described below.
 
 | Backend    | Read | Write | Multi-catalog | Feature flags                                          |
 |------------|:----:|:-----:|:-------------:|--------------------------------------------------------|
-| DuckDB     |  ✅  |  ❌   |      ❌       | `metadata-duckdb` (default)                            |
+| DuckDB     |  ✅  |  ✅   |      ❌       | `metadata-duckdb` (default), `write-duckdb`            |
 | SQLite     |  ✅  |  ✅   |      ❌       | `metadata-sqlite`, `write-sqlite`                      |
 | PostgreSQL |  ✅  |  ✅   |      ✅       | `metadata-postgres`, `write-postgres`, `multicatalog-postgres` |
-| MySQL      |  ✅  |  ❌   |      ❌       | `metadata-mysql`                                       |
+| MySQL      |  ✅  |  ✅   |      ❌       | `metadata-mysql`, `write-mysql`                        |
 
 The listed PostgreSQL features do not select a TLS provider. Plain local connections work without
 one. For TLS, also enable one of `tls-native-tls`, `tls-rustls-aws-lc-rs`, or
@@ -87,8 +84,10 @@ AWS‑LC, install the intended process‑wide Rustls `CryptoProvider` before cre
 | `metadata-postgres`      | PostgreSQL catalog read backend                                          |         |
 | `metadata-mysql`         | MySQL catalog read backend                                               |         |
 | `write`                  | Base write support (INSERT, CTAS, maintenance API); needs a write backend|         |
+| `write-duckdb`           | Write to standard single-catalog DuckDB catalogs                        |         |
 | `write-sqlite`           | Write to SQLite catalogs (`write` + `metadata-sqlite`)                   |         |
 | `write-postgres`         | Write to PostgreSQL catalogs (`write` + `metadata-postgres` + multi-catalog) |     |
+| `write-mysql`            | Write to standard single-catalog MySQL catalogs                         |         |
 | `multicatalog-postgres`  | Read multiple catalogs from one PostgreSQL store                         |         |
 | `tls-native-tls`         | Use native TLS for SQLx PostgreSQL connections                           |         |
 | `tls-rustls-aws-lc-rs`   | Use Rustls with AWS‑LC for SQLx PostgreSQL connections                   |         |
@@ -142,8 +141,8 @@ provider, run writer initialization with a schema-migration role before reading.
 | `CREATE TABLE AS SELECT` (SQL DDL; SQLite single-catalog only — not on the PostgreSQL multi-catalog path) | 🟧 |
 | `DROP TABLE` (via `MetadataWriter`)                     |   ✅   |
 | Row-level deletes (Merge-On-Read delete files, read)    |   ✅   |
-| SQL `DELETE FROM t [WHERE ...]` (positional deletes + metadata-only truncate; SQLite & PostgreSQL) | ✅ |
-| SQL `UPDATE t SET c = e [, ...] [WHERE p]` (rewrite + positional delete, one snapshot; SQLite & PostgreSQL) | ✅ |
+| SQL `DELETE FROM t [WHERE ...]` (positional + inlined-row deletes, mixed in one snapshot + inline-aware metadata-only truncate; all write backends) | ✅ |
+| SQL `UPDATE t SET c = e [, ...] [WHERE p]` (rewrite + positional delete, one snapshot; all write backends; refuses on tables with visible inlined rows — see Data inlining under Limitations) | ✅ |
 | Snapshot-based consistency (bound at catalog creation)  |   ✅   |
 | Filter pushdown to Parquet (row-group / page pruning)   |   ✅   |
 | Filter pushdown into the catalog file listing — per-column statistics narrow the metadata query, so planning a selective scan or keyed mutation does not list every live file | ✅ |
@@ -197,7 +196,7 @@ settings, including `execution.time_zone`, are not inherited.
 
 ## Write concurrency
 
-Both write backends use the same **commit-time** model: a write's snapshot id, all its
+All write backends use the same **commit-time** model: a write's snapshot id, all its
 metadata rows, and its publication are written in **one transaction**, with the snapshot id
 assigned at commit (so per-catalog id order == commit order) and nothing visible until that
 transaction commits. There are no "dormant" (committed-but-unpublished) rows, so reads never
@@ -224,7 +223,7 @@ Known edges:
   is not detected. Use `Replace` for overwrite semantics.
 - A **fileless same-schema `Replace`** (an empty-table overwrite that writes no data file and
   changes no column) leaves no per-table footprint, so it resolves **last-writer-wins** rather
-  than abort-on-conflict (both backends). Data-bearing and schema-changing replaces are
+  than abort-on-conflict (all write backends). Data-bearing and schema-changing replaces are
   conflict-checked.
 - A **column type change is rejected on a data write** (`Replace` **and** `Append`) — this is
   a **behavior change**: previously a type change on `Replace` was silently dropped (the column
@@ -236,26 +235,16 @@ Known edges:
 - **Schema evolution is versioned.** A promote leaves two `ducklake_column` rows sharing one
   `column_id` (old retired via `end_snapshot`, new live), matching upstream. On the
   **PostgreSQL multicatalog** layout this is enforced by a composite PK + a partial unique
-  index; on the **SQLite single-catalog** layout `ducklake_column` matches upstream's bare
-  shape (no PK) and the one-live-version invariant is enforced in the writer + tests. Catalogs
+  index; on the **DuckDB, SQLite, and MySQL single-catalog** layouts, `ducklake_column` matches
+  upstream's bare shape (no PK), and the one-live-version invariant is enforced in the writer
+  and tests. Catalogs
   created by an earlier version are migrated in place on open (idempotent, lossless).
-- **`schema_version` is maintained on both write layouts.** SQLite and PostgreSQL both carry
-  `schema_version` on `ducklake_snapshot` and a `ducklake_schema_versions` ledger table, bumped
-  on a schema change (table create, column add/remove/reorder, type promotion) and carried
-  forward on a pure data write — matching upstream's `if (SchemaChangesMade()) schema_version++`.
-  Both deliberately omit upstream's `next_catalog_id` / `next_file_id` snapshot columns (this
-  library allocates ids from its own counters, never from the snapshot row). This applies to
-  **partition ids** too: `ducklake_partition_info.partition_id` is allocated from a
-  library-owned counter (`next_partition_id` on SQLite/MySQL, an autoincrement/sequence on
-  DuckDB, an IDENTITY on Postgres), *not* from `next_catalog_id` as the current spec assigns
-  it. The ids are internally consistent (`ducklake_partition_info` ↔ `ducklake_partition_column`
-  ↔ `ducklake_data_file.partition_id` ↔ `ducklake_file_partition_value`), so any reader resolves
-  a partitioned table correctly; the caveat is only that a DuckLake/DuckDB *writer* that later
-  allocates ids from `next_catalog_id` on the same catalog could collide with these. Because of
-  that omission a SQLite catalog is DuckLake-*design*-faithful but **not yet a drop-in DuckDB
-  catalog** — DuckDB's writer expects those allocator columns. Full DuckDB write-compat
-  (adopting the snapshot allocators uniformly for all ids, partitions included) is a tracked
-  follow-up.
+- **`schema_version` is maintained on every write layout.** DuckDB, SQLite, MySQL, and both
+  PostgreSQL layouts carry `schema_version` on `ducklake_snapshot` and a
+  `ducklake_schema_versions` ledger table. A schema change bumps it and a pure data write carries
+  it forward, matching upstream's `if (SchemaChangesMade()) schema_version++`. These branches
+  deliberately retain their existing counter or sequence allocation instead of adding the
+  separate Group 9 snapshot-allocator change.
 - A single `Replace` is assumed to register **one** data file (the current writer path); the
   conflict check is not designed for multiple `register_data_file` calls sharing one base.
 - Two concurrent `CREATE TABLE` of the same name on the PostgreSQL multi-catalog path are
@@ -278,7 +267,6 @@ Known edges:
 
 ## Limitations
 
-- **Write backends:** DuckDB and MySQL are read-only; writes require SQLite or PostgreSQL.
 - **Catalog-side filter pushdown declines a few type/backend combinations.** A
   pushed-down filter narrows the file-listing query using per-column statistics,
   but the comparison runs in the catalog engine, so some types decline it and
@@ -316,20 +304,25 @@ Known edges:
   fields are materialized on every read path. DuckDB's writer does not produce nested
   partition mappings, but a hand-written or third-party catalog can; this crate returns
   an explicit error instead of reading a physical value or NULL under that shape.
+- **Negative NaN orders differently than in DuckDB.** DuckDB normalizes NaN — `-NaN = NaN`
+  is true and either sign sorts above every value. DataFusion compares floats with arrow's
+  `total_cmp`, which is sign-sensitive, so `-NaN` sorts *below* every value including
+  `-Infinity`. A query like `WHERE x < -1e308` therefore returns `-NaN` rows here and none
+  in DuckDB. This is inherited from arrow and affects results, not just pruning; float
+  min/max statistics are gated on `contains_nan` in **both** directions to stay consistent
+  with it, where official DuckLake gates only the max.
+- **PostgreSQL has standard single-catalog and experimental multi-catalog writers.** DuckDB,
+  SQLite, MySQL, and single-catalog PostgreSQL use standard metadata; multicatalog PostgreSQL uses
+  the library-specific catalog-id layout.
 - **No `AS OF` syntax:** select a catalog snapshot by ID with
   `DuckLakeCatalog::with_snapshot`, by UTC timestamp with
   `DuckLakeCatalog::with_snapshot_at`, or select one table per query with
-  `ducklake_table_at`. Timestamp selection uses the latest snapshot at or before the
-  requested time. For snapshots with the same timestamp, an as‑of or change‑data end
-  bound selects the highest ID, while a change‑data start bound selects the lowest ID.
-- **One mutation per session, then re-open the catalog.** Because a catalog pins its
-  snapshot at creation and never refreshes, a `SessionContext` observes a single generation
-  for its lifetime. After an `UPDATE`/`DELETE`/`INSERT` commits, the same session keeps
-  reading the pre-mutation state; a `SELECT` won't see the change, a just-inserted row can't
-  be updated, and a **second `UPDATE`/`DELETE` re-touching a file the first modified aborts
-  with a conflict** (the compare-and-swap that also guards genuine concurrency — it is what
-  prevents a stale rewrite from resurrecting superseded rows). Re-open the catalog (or create
-  a fresh `SessionContext`) between mutating statements so it binds to the latest snapshot.
+  `ducklake_table_at`. Timestamp selection uses the latest snapshot at or before the requested
+  time. For snapshots with the same timestamp, an as-of or change-data end bound selects the
+  highest ID, while a change-data start bound selects the lowest ID.
+- **One mutation per session, then re-open the catalog.** A catalog pins its snapshot at creation.
+  Re-open the catalog or create a fresh `SessionContext` after a mutation so later statements bind
+  the committed snapshot.
 - **The change feed is degraded on encrypted (PME) catalogs.**
   `ducklake_table_changes` still works on encrypted catalogs for inserted rows, but a
   range containing an `UPDATE` surfaces its rewritten rows as plain `insert`s rather

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -129,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,20 +140,20 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-row 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "arrow-string 56.2.0",
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-row 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "arrow-string 58.4.0",
 ]
 
 [[package]]
@@ -181,16 +179,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
@@ -209,18 +207,20 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
- "ahash 0.8.12",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "ahash",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
  "chrono",
  "half",
- "hashbrown 0.16.1",
- "num",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-buffer 59.2.0",
  "arrow-data 59.2.0",
  "arrow-schema 59.2.0",
@@ -244,13 +244,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint 0.4.6",
+ "num-traits",
 ]
 
 [[package]]
@@ -267,22 +268,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
@@ -325,14 +327,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -391,15 +394,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
 ]
 
 [[package]]
@@ -417,14 +420,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
  "half",
 ]
 
@@ -443,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -462,16 +465,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
- "ahash 0.8.12",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "num",
+ "ahash",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -480,7 +483,7 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array 59.2.0",
  "arrow-buffer 59.2.0",
  "arrow-data 59.2.0",
@@ -490,17 +493,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -970,18 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,29 +1063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,28 +1088,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "byteorder"
@@ -1306,6 +1252,8 @@ version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
+ "crossterm 0.27.0",
+ "crossterm 0.28.1",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width 0.2.2",
@@ -1479,6 +1427,39 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.4",
+ "parking_lot",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2369,6 +2350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,18 +2413,18 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duckdb"
-version = "1.4.1"
+version = "1.10505.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a093eed1c714143b257b95fa323e38527fabf05fbf02bb0d5d2045275ffdaef"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.4.0",
  "cast",
+ "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
- "rust_decimal",
  "strum 0.27.2",
 ]
 
@@ -2736,12 +2728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,9 +2955,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3610,9 +3593,9 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.1"
+version = "1.10505.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b93c3ff279601516f01531cadf2ccba50394fbb5f7bf685c6e6b9b07c8dca6f"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
 dependencies = [
  "cc",
  "flate2",
@@ -3620,7 +3603,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "ureq",
  "vcpkg",
+ "zip",
 ]
 
 [[package]]
@@ -3682,6 +3667,12 @@ dependencies = [
  "clap",
  "escape8259",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3799,20 +3790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint 0.4.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,28 +3830,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -4040,7 +3995,7 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array 59.2.0",
  "arrow-buffer 59.2.0",
  "arrow-data 59.2.0",
@@ -4269,26 +4224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,29 +4310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
@@ -4410,16 +4328,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4556,15 +4464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4632,35 +4531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rsa"
 version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,22 +4578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal"
-version = "1.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8975fc98059f365204d635119cf9c5a60ae67b841ed49b5422a9a7e56cdfac0"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,6 +4594,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -4747,7 +4614,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -4770,6 +4637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4900,12 +4768,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -5599,17 +5461,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -5651,12 +5502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,7 +5521,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -6068,6 +5913,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,6 +5951,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6757,22 +6636,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -6886,10 +6756,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 tempfile = { version = "3.14", optional = true }
 
 # Metadata providers (optional)
-duckdb = { version = "1.4.1", optional = true }
+duckdb = { version = "1.10505.0", optional = true }
 sqlx = { version = "0.9", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -196,10 +196,9 @@ Writer output is configurable (Parquet compression, row-group sizing by row coun
 byte size). See [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake) for the
 writer options.
 
-> Writing to a **standard, single-catalog** DuckLake store (the spec-compliant layout) is
-> supported today for **SQLite** via `SqliteMetadataWriter` (feature `write-sqlite`) and for
-> **PostgreSQL** via `PostgresSingleCatalogMetadataWriter` (feature `write-postgres`), where
-> SQL `CREATE TABLE AS SELECT` and `INSERT INTO` both work. See
+> Writing to a **standard, single-catalog** DuckLake store is supported through
+> `DuckdbMetadataWriter`, `SqliteMetadataWriter`, `MySqlMetadataWriter`, and
+> `PostgresSingleCatalogMetadataWriter` with their matching `write-*` features. See
 > [`tests/it/sql_write_tests.rs`](tests/it/sql_write_tests.rs) and
 > [`tests/it/postgres_single_catalog_write_tests.rs`](tests/it/postgres_single_catalog_write_tests.rs).
 
@@ -314,7 +313,8 @@ current limitations, see **[COMPATIBILITY.md](COMPATIBILITY.md)**.
 
 A few highlights worth knowing up front:
 
-- Reads work on DuckDB, SQLite, PostgreSQL, and MySQL; **writes are SQLite/PostgreSQL only**.
+- Reads and writes work on DuckDB, SQLite, PostgreSQL, and MySQL. PostgreSQL uses the
+  experimental multi-catalog write layout.
 - Object stores: local filesystem and S3-compatible (S3, MinIO).
 - Snapshots can be selected through `DuckLakeCatalog` (by id or timestamp) or per query with
   `ducklake_table_at`; DataFusion does not support `AS OF` syntax.

--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ current limitations, see **[COMPATIBILITY.md](COMPATIBILITY.md)**.
 
 A few highlights worth knowing up front:
 
-- Reads and writes work on DuckDB, SQLite, PostgreSQL, and MySQL. PostgreSQL uses the
-  experimental multi-catalog write layout.
+- Reads and writes work on DuckDB, SQLite, PostgreSQL, and MySQL. PostgreSQL supports the standard
+  single-catalog layout, recommended by default, and an experimental multi-catalog layout.
 - Object stores: local filesystem and S3-compatible (S3, MinIO).
 - Snapshots can be selected through `DuckLakeCatalog` (by id or timestamp) or per query with
   `ducklake_table_at`; DataFusion does not support `AS OF` syntax.

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -161,6 +161,27 @@ pub async fn cleanup_old_files_sqlite(
 }
 
 /// Physically delete files scheduled by
+/// [`DuckdbMetadataWriter::expire_snapshots`] and remove their bookkeeping rows.
+/// Returns resolved absolute paths deleted (or, for `dry_run`, paths that would
+/// be deleted).
+///
+/// [`DuckdbMetadataWriter::expire_snapshots`]: crate::metadata_writer_duckdb::DuckdbMetadataWriter::expire_snapshots
+#[cfg(feature = "write-duckdb")]
+pub async fn cleanup_old_files_duckdb(
+    writer: &crate::metadata_writer_duckdb::DuckdbMetadataWriter,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = crate::metadata_writer::MetadataWriter::get_data_path(writer)?;
+    let files = writer.list_scheduled_for_deletion(&criteria)?;
+    run_cleanup(&data_path, files, object_store, dry_run, |ids| async move {
+        writer.remove_scheduled(&ids)
+    })
+    .await
+}
+
+/// Physically delete files scheduled by
 /// [`MulticatalogManager::expire_snapshots_in_catalog`] for `catalog_name` and remove their
 /// bookkeeping rows. Returns the resolved absolute paths deleted (or, for `dry_run`, the
 /// paths that would be deleted).
@@ -284,6 +305,20 @@ async fn run_orphan_cleanup(
 #[cfg(feature = "write-sqlite")]
 pub async fn delete_orphaned_files_sqlite(
     writer: &crate::metadata_writer_sqlite::SqliteMetadataWriter,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = crate::metadata_writer::MetadataWriter::get_data_path(writer)?;
+    let referenced = writer.list_referenced_paths()?;
+    run_orphan_cleanup(&data_path, referenced, object_store, criteria, dry_run).await
+}
+
+/// List the DuckDB catalog's `data_path` and delete every unreferenced Parquet
+/// file.
+#[cfg(feature = "write-duckdb")]
+pub async fn delete_orphaned_files_duckdb(
+    writer: &crate::metadata_writer_duckdb::DuckdbMetadataWriter,
     object_store: Arc<dyn ObjectStore>,
     criteria: CleanupCriteria,
     dry_run: bool,

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -45,6 +45,14 @@ pub const SQL_GET_TABLE_COLUMNS: &str =
        AND (? < end_snapshot OR end_snapshot IS NULL)
      ORDER BY column_order";
 
+#[cfg(any(feature = "metadata-duckdb", feature = "metadata-sqlite"))]
+pub(crate) const SQL_FILE_SCHEMA_VERSION: &str = "(SELECT sv.schema_version
+                  FROM ducklake_schema_versions sv
+                  WHERE sv.table_id = data.table_id
+                    AND sv.begin_snapshot <= data.begin_snapshot
+                  ORDER BY sv.begin_snapshot DESC
+                  LIMIT 1)";
+
 pub const SQL_GET_DATA_FILES: &str = "
     SELECT
         data.data_file_id,

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -1,4 +1,5 @@
 use crate::DuckLakeError;
+use crate::metadata_provider::SQL_FILE_SCHEMA_VERSION;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
@@ -335,9 +336,11 @@ fn query_data_file_page(
     after_data_file_id: i64,
     limit: i64,
     filters: &[RenderedColumnFilter],
+    capabilities: SchemaCapabilities,
 ) -> Result<Vec<DuckLakeTableFile>, duckdb::Error> {
     let base = data_files_sql_filtered(table_id, filters)
         .unwrap_or_else(|| SQL_GET_DATA_FILES.to_string());
+    let base = file_provenance_sql(&base, capabilities);
     // The statistics conditions sit inside the query, ahead of the LIMIT, and
     // the keyset ordering is untouched. Filtering the page after fetching it
     // would break the cursor `FileMetadataPages` drives: a page whose
@@ -393,9 +396,9 @@ fn query_data_file_page(
                     delete_file,
                     row_id_start: row.get(6)?,
                     snapshot_id: Some(snapshot_id),
-                    begin_snapshot: None,
-                    schema_version: None,
-                    partial_max: None,
+                    begin_snapshot: row.get(16)?,
+                    schema_version: row.get(17)?,
+                    partial_max: row.get(18)?,
                     max_row_count: row.get(7)?,
                     delete_count,
                     partition_id: None,
@@ -562,6 +565,8 @@ struct SchemaCapabilities {
     column_default_value_type: bool,
     /// `ducklake_column.default_value_dialect` exists.
     column_default_value_dialect: bool,
+    /// The per-table schema-version ledger exists.
+    schema_versions: bool,
 }
 
 impl SchemaCapabilities {
@@ -574,6 +579,7 @@ impl SchemaCapabilities {
             && self.column_default_value
             && self.column_default_value_type
             && self.column_default_value_dialect
+            && self.schema_versions
     }
 }
 
@@ -721,7 +727,8 @@ impl DuckdbMetadataProvider {
             column_default_value,
             column_default_value_type,
             column_default_value_dialect,
-        ): (bool, bool, bool, bool, bool, bool, bool, bool) = conn.query_row(
+            schema_versions,
+        ): (bool, bool, bool, bool, bool, bool, bool, bool, bool) = conn.query_row(
             "SELECT
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file')
                 WHERE name = 'partial_max') > 0,
@@ -738,7 +745,9 @@ impl DuckdbMetadataProvider {
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
                 WHERE name = 'default_value_type') > 0,
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
-                WHERE name = 'default_value_dialect') > 0",
+                WHERE name = 'default_value_dialect') > 0,
+               (SELECT COUNT(*) FROM information_schema.tables
+                WHERE table_name = 'ducklake_schema_versions') > 0",
             [],
             |row| {
                 Ok((
@@ -750,6 +759,7 @@ impl DuckdbMetadataProvider {
                     row.get(5)?,
                     row.get(6)?,
                     row.get(7)?,
+                    row.get(8)?,
                 ))
             },
         )?;
@@ -762,6 +772,7 @@ impl DuckdbMetadataProvider {
             column_default_value,
             column_default_value_type,
             column_default_value_dialect,
+            schema_versions,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -1024,7 +1035,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
         snapshot_id: i64,
     ) -> crate::Result<Vec<DuckLakeTableFile>> {
         let conn = self.connection();
-        let mut stmt = conn.prepare(SQL_GET_DATA_FILES)?;
+        let sql = file_provenance_sql(SQL_GET_DATA_FILES, self.schema_capabilities(&conn)?);
+        let mut stmt = conn.prepare(&sql)?;
 
         let files = stmt
             .query_map(
@@ -1069,9 +1081,9 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         delete_file,
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
-                        begin_snapshot: None,
-                        schema_version: None,
-                        partial_max: None,
+                        begin_snapshot: row.get(16)?,
+                        schema_version: row.get(17)?,
+                        partial_max: row.get(18)?,
                         max_row_count: record_count,
                         delete_count,
                         partition_id: None,
@@ -1277,6 +1289,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
         let rendered = filter
             .and_then(|filter| filter.render(&DuckdbStatsDialect))
             .unwrap_or_default();
+        let capabilities = self.schema_capabilities(&conn)?;
         let files = match query_data_file_page(
             &conn,
             table_id,
@@ -1284,6 +1297,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
             after_data_file_id,
             limit,
             &rendered,
+            capabilities,
         ) {
             Ok(files) => files,
             // The filter is advisory, so a catalog the narrowed query cannot run
@@ -1302,7 +1316,15 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     table_id,
                     "statistics-filtered file listing failed; listing every file"
                 );
-                query_data_file_page(&conn, table_id, snapshot_id, after_data_file_id, limit, &[])?
+                query_data_file_page(
+                    &conn,
+                    table_id,
+                    snapshot_id,
+                    after_data_file_id,
+                    limit,
+                    &[],
+                    capabilities,
+                )?
             },
             Err(error) => return Err(error.into()),
         };
@@ -1788,7 +1810,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
 
     fn list_all_files(&self, snapshot_id: i64) -> crate::Result<Vec<FileWithTable>> {
         let conn = self.connection();
-        let mut stmt = conn.prepare(SQL_LIST_ALL_FILES)?;
+        let sql = file_provenance_sql(SQL_LIST_ALL_FILES, self.schema_capabilities(&conn)?);
+        let mut stmt = conn.prepare(&sql)?;
 
         let files = stmt
             .query_map(
@@ -1847,9 +1870,9 @@ impl MetadataProvider for DuckdbMetadataProvider {
                             delete_file,
                             row_id_start: None,
                             snapshot_id: None,
-                            begin_snapshot: None,
-                            schema_version: None,
-                            partial_max: None,
+                            begin_snapshot: row.get(15)?,
+                            schema_version: row.get(16)?,
+                            partial_max: row.get(17)?,
                             max_row_count,
                             delete_count: None,
                             partition_id: None,
@@ -2006,6 +2029,24 @@ fn parse_partial_file_info_max(info: &str) -> Option<i64> {
         .and_then(|snap| snap.trim().parse::<i64>().ok())
 }
 
+fn file_provenance_sql(sql: &str, capabilities: SchemaCapabilities) -> String {
+    let schema_version = if capabilities.schema_versions {
+        SQL_FILE_SCHEMA_VERSION
+    } else {
+        "NULL"
+    };
+    let partial_max = if capabilities.data_file_partial_max {
+        "data.partial_max"
+    } else {
+        "NULL"
+    };
+    sql.replacen(
+        "\n    FROM ",
+        &format!(",\n        data.begin_snapshot,\n        {schema_version},\n        {partial_max}\n    FROM "),
+        1,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -2031,6 +2072,18 @@ mod tests {
     use duckdb::{Connection, params};
     use std::collections::BTreeSet;
     use tempfile::TempDir;
+
+    const LEGACY_CAPABILITIES: SchemaCapabilities = SchemaCapabilities {
+        data_file_partial_max: false,
+        delete_file_partial_max: false,
+        inlined_data_tables: false,
+        views: false,
+        column_initial_default: false,
+        column_default_value: false,
+        column_default_value_type: false,
+        column_default_value_dialect: false,
+        schema_versions: false,
+    };
 
     /// Render `filters` for the DuckDB dialect and splice them into the
     /// data-file listing, for a single Int32 column with the given `column_id`.
@@ -2287,7 +2340,7 @@ mod tests {
             .render(&DuckdbStatsDialect)
             .expect("filter renders for DuckDB");
 
-        let error = query_data_file_page(&conn, 3, 0, i64::MIN, 10, &rendered)
+        let error = query_data_file_page(&conn, 3, 0, i64::MIN, 10, &rendered, LEGACY_CAPABILITIES)
             .expect_err("the CTE cannot read a table that is not there");
         assert!(
             is_missing_statistics_table(&error),
@@ -2304,7 +2357,7 @@ mod tests {
              statistics table: {error}"
         );
 
-        let files = query_data_file_page(&conn, 3, 0, i64::MIN, 10, &[])
+        let files = query_data_file_page(&conn, 3, 0, i64::MIN, 10, &[], LEGACY_CAPABILITIES)
             .expect("the unfiltered retry still lists every file");
         assert_eq!(files.len(), 1);
     }
@@ -2362,6 +2415,7 @@ mod tests {
             column_default_value: false,
             column_default_value_type: false,
             column_default_value_dialect: false,
+            schema_versions: false,
         };
 
         let table_defaults = conn.query_row(
@@ -2424,6 +2478,7 @@ mod tests {
 
     /// The DDL a paged listing reads, minus every table it does not touch.
     const PAGE_LISTING_SCHEMA: &str = "
+        CREATE TABLE ducklake_column (column_id BIGINT);
         CREATE TABLE ducklake_data_file (
             data_file_id BIGINT, table_id BIGINT, begin_snapshot BIGINT,
             end_snapshot BIGINT, path VARCHAR, path_is_relative BOOLEAN,
@@ -2447,6 +2502,127 @@ mod tests {
     /// The provider opens read-only, so the writing connection is closed before
     /// it is constructed. The `TempDir` comes back with it because dropping it
     /// deletes the catalog.
+    #[test]
+    fn file_provenance_tracks_each_files_origin_schema() {
+        let (_dir, provider) = provider_over(
+            "CREATE TABLE ducklake_schema_versions (table_id BIGINT, begin_snapshot BIGINT, schema_version BIGINT);
+             CREATE TABLE ducklake_schema (schema_id BIGINT, schema_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT);
+             CREATE TABLE ducklake_table (table_id BIGINT, schema_id BIGINT, table_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT);
+             INSERT INTO ducklake_schema VALUES (1, 'main', 1, NULL);
+             INSERT INTO ducklake_table VALUES (3, 1, 'events', 1, NULL);
+             INSERT INTO ducklake_schema_versions VALUES (3, 1, 7), (3, 4, 9), (3, 8, 11), (99, 1, 31);
+             ALTER TABLE ducklake_data_file ADD COLUMN partial_max BIGINT;
+             INSERT INTO ducklake_data_file
+                 (data_file_id, table_id, begin_snapshot, path, path_is_relative,
+                  file_size_bytes, row_id_start, record_count, mapping_id, partial_max)
+             VALUES (10, 3, 2, 'ten.parquet', true, 100, 0, 2, 55, 3),
+                    (20, 3, 5, 'twenty.parquet', true, 120, 2, 3, 66, 6);
+             INSERT INTO ducklake_file_column_stats
+                 (data_file_id, table_id, column_id, column_size_bytes, value_count,
+                  null_count, min_value, max_value, contains_nan)
+             VALUES (10, 3, 7, 8, 2, 0, '1', '2', false),
+                    (20, 3, 7, 12, 3, 0, '3', '5', false);",
+        );
+        let files = provider.get_table_files_for_select(3, 9).unwrap();
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| (
+                    file.data_file_id,
+                    file.file.mapping_id,
+                    file.row_id_start,
+                    file.max_row_count,
+                    file.begin_snapshot,
+                    file.schema_version,
+                    file.partial_max
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (10, Some(55), Some(0), Some(2), Some(2), Some(7), Some(3)),
+                (20, Some(66), Some(2), Some(3), Some(5), Some(9), Some(6))
+            ]
+        );
+        let first = provider
+            .get_table_file_metadata_page(3, 9, None, 1)
+            .unwrap();
+        let second = provider
+            .get_table_file_metadata_page(3, 9, Some(10), 1)
+            .unwrap();
+        assert_eq!(
+            (
+                first[0].file.begin_snapshot,
+                first[0].file.schema_version,
+                first[0].file.partial_max
+            ),
+            (Some(2), Some(7), Some(3))
+        );
+        assert_eq!(
+            (
+                second[0].file.begin_snapshot,
+                second[0].file.schema_version,
+                second[0].file.partial_max
+            ),
+            (Some(5), Some(9), Some(6))
+        );
+        let filtered = provider
+            .get_table_file_metadata_page_filtered(
+                3,
+                9,
+                None,
+                10,
+                Some(&int32_filter(Operator::Gt, 2)),
+            )
+            .unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            (
+                filtered[0].file.data_file_id,
+                filtered[0].file.begin_snapshot,
+                filtered[0].file.schema_version,
+                filtered[0].file.partial_max
+            ),
+            (20, Some(5), Some(9), Some(6))
+        );
+        let all = provider.list_all_files(9).unwrap();
+        assert_eq!(
+            all.iter()
+                .map(|entry| (
+                    entry.file.data_file_id,
+                    entry.file.begin_snapshot,
+                    entry.file.schema_version,
+                    entry.file.partial_max
+                ))
+                .collect::<Vec<_>>(),
+            vec![(10, Some(2), Some(7), Some(3)), (20, Some(5), Some(9), Some(6))]
+        );
+        let historical = provider.get_table_files_for_select(3, 3).unwrap();
+        assert_eq!(historical.len(), 1);
+        assert_eq!(
+            (historical[0].begin_snapshot, historical[0].schema_version),
+            (Some(2), Some(7))
+        );
+    }
+
+    #[test]
+    fn legacy_file_provenance_keeps_unknown_schema_version() {
+        let (_dir, provider) = provider_over(
+            "            INSERT INTO ducklake_data_file (data_file_id, table_id, begin_snapshot, path, path_is_relative, file_size_bytes, record_count)            VALUES (10, 3, 2, 'ten.parquet', true, 100, 2);",
+        );
+        let files = provider.get_table_files_for_select(3, 3).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            (files[0].begin_snapshot, files[0].schema_version),
+            (Some(2), None)
+        );
+        let page = provider
+            .get_table_file_metadata_page(3, 3, None, 1)
+            .unwrap();
+        assert_eq!(
+            (page[0].file.begin_snapshot, page[0].file.schema_version),
+            (Some(2), None)
+        );
+    }
+
     fn provider_over(setup: &str) -> (TempDir, DuckdbMetadataProvider) {
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("catalog.duckdb");
@@ -2595,7 +2771,7 @@ mod tests {
         let conn = Connection::open_in_memory().expect("in-memory DuckDB");
         conn.execute_batch(PAGE_LISTING_SCHEMA)
             .expect("catalog schema");
-        let error = query_data_file_page(&conn, 3, 0, i64::MIN, 10, &rendered)
+        let error = query_data_file_page(&conn, 3, 0, i64::MIN, 10, &rendered, LEGACY_CAPABILITIES)
             .expect_err("DuckDB cannot parse the alias");
         // The point of the widening: the old guard would have re-raised this.
         assert!(

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -746,8 +746,8 @@ impl DuckdbMetadataProvider {
                 WHERE name = 'default_value_type') > 0,
                (SELECT COUNT(*) FROM pragma_table_info('ducklake_column')
                 WHERE name = 'default_value_dialect') > 0,
-               (SELECT COUNT(*) FROM information_schema.tables
-                WHERE table_name = 'ducklake_schema_versions') > 0",
+               (SELECT COUNT(*) FROM information_schema.columns
+                WHERE table_name = 'ducklake_schema_versions' AND column_name = 'table_id') > 0",
             [],
             |row| {
                 Ok((
@@ -2497,11 +2497,6 @@ mod tests {
             column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT,
             min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN);";
 
-    /// A file-backed catalog built by `setup`, then opened by the provider.
-    ///
-    /// The provider opens read-only, so the writing connection is closed before
-    /// it is constructed. The `TempDir` comes back with it because dropping it
-    /// deletes the catalog.
     #[test]
     fn file_provenance_tracks_each_files_origin_schema() {
         let (_dir, provider) = provider_over(
@@ -2605,24 +2600,38 @@ mod tests {
 
     #[test]
     fn legacy_file_provenance_keeps_unknown_schema_version() {
-        let (_dir, provider) = provider_over(
-            "            INSERT INTO ducklake_data_file (data_file_id, table_id, begin_snapshot, path, path_is_relative, file_size_bytes, record_count)            VALUES (10, 3, 2, 'ten.parquet', true, 100, 2);",
-        );
-        let files = provider.get_table_files_for_select(3, 3).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(
-            (files[0].begin_snapshot, files[0].schema_version),
-            (Some(2), None)
-        );
-        let page = provider
-            .get_table_file_metadata_page(3, 3, None, 1)
-            .unwrap();
-        assert_eq!(
-            (page[0].file.begin_snapshot, page[0].file.schema_version),
-            (Some(2), None)
-        );
+        for ledger in [
+            "",
+            "CREATE TABLE ducklake_schema_versions (begin_snapshot BIGINT, schema_version BIGINT);
+             INSERT INTO ducklake_schema_versions VALUES (0, 0), (1, 1);",
+        ] {
+            let (_dir, provider) = provider_over(&format!(
+                "{ledger}
+                 INSERT INTO ducklake_data_file
+                     (data_file_id, table_id, begin_snapshot, path, path_is_relative, file_size_bytes, record_count)
+                 VALUES (10, 3, 2, 'ten.parquet', true, 100, 2);"
+            ));
+            let files = provider.get_table_files_for_select(3, 3).unwrap();
+            assert_eq!(files.len(), 1);
+            assert_eq!(
+                (files[0].begin_snapshot, files[0].schema_version),
+                (Some(2), None)
+            );
+            let page = provider
+                .get_table_file_metadata_page(3, 3, None, 1)
+                .unwrap();
+            assert_eq!(
+                (page[0].file.begin_snapshot, page[0].file.schema_version),
+                (Some(2), None)
+            );
+        }
     }
 
+    /// A file-backed catalog built by `setup`, then opened by the provider.
+    ///
+    /// The provider opens read-only, so the writing connection is closed before
+    /// it is constructed. The `TempDir` comes back with it because dropping it
+    /// deletes the catalog.
     fn provider_over(setup: &str) -> (TempDir, DuckdbMetadataProvider) {
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("catalog.duckdb");

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -1,6 +1,7 @@
 //! SQLite metadata provider for DuckLake catalogs.
 
 use crate::Result;
+use crate::metadata_provider::SQL_FILE_SCHEMA_VERSION;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
@@ -897,12 +898,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 "NULL"
             };
             let schema_version_expr = if caps.schema_versions {
-                "(SELECT sv.schema_version
-                  FROM ducklake_schema_versions sv
-                  WHERE sv.table_id = data.table_id
-                    AND sv.begin_snapshot <= data.begin_snapshot
-                  ORDER BY sv.begin_snapshot DESC
-                  LIMIT 1)"
+                SQL_FILE_SCHEMA_VERSION
             } else {
                 "NULL"
             };
@@ -1111,12 +1107,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 "NULL"
             };
             let schema_version_expr = if caps.schema_versions {
-                "(SELECT sv.schema_version
-                  FROM ducklake_schema_versions sv
-                  WHERE sv.table_id = data.table_id
-                    AND sv.begin_snapshot <= data.begin_snapshot
-                  ORDER BY sv.begin_snapshot DESC
-                  LIMIT 1)"
+                SQL_FILE_SCHEMA_VERSION
             } else {
                 "NULL"
             };

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -5,7 +5,9 @@
 
 use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
 use crate::{DuckLakeError, Result};
-use arrow::datatypes::DataType;
+use arrow::array::{Array, FixedSizeBinaryArray};
+use arrow::datatypes::{DataType, Schema as ArrowSchema};
+use arrow::record_batch::RecordBatch;
 use std::collections::{HashMap, HashSet};
 
 /// Maximum allowed length for catalog entity names (schemas, tables, columns).
@@ -144,6 +146,50 @@ impl SnapshotCommitMetadata {
         }
         Ok(())
     }
+}
+
+pub(crate) fn inlined_text_value(array: &dyn Array, row: usize) -> Result<String> {
+    if array.data_type() == &DataType::FixedSizeBinary(16) {
+        let bytes = array
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("Arrow data type and array implementation agree")
+            .value(row);
+        return uuid::Uuid::from_slice(bytes)
+            .map(|value| value.to_string())
+            .map_err(|error| DuckLakeError::InvalidConfig(format!("invalid UUID bytes: {error}")));
+    }
+    Ok(arrow::util::display::array_value_to_string(array, row)?)
+}
+
+pub(crate) fn scalar_type_supports_inlining(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Null
+            | DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Decimal128(_, _)
+            | DataType::Date32
+            | DataType::Time64(arrow::datatypes::TimeUnit::Microsecond)
+            | DataType::Timestamp(_, _)
+            | DataType::Interval(arrow::datatypes::IntervalUnit::MonthDayNano)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+            | DataType::Binary
+            | DataType::LargeBinary
+            | DataType::BinaryView
+            | DataType::FixedSizeBinary(_)
+    )
 }
 
 /// Column definition for creating or updating a table's schema.
@@ -987,6 +1033,15 @@ pub struct CommitIds {
     pub table_id: i64,
 }
 
+/// Stable identity of one visible inlined row selected for deletion.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InlinedRowRef {
+    /// Physical `ducklake_inlined_data_*` table registered for the table.
+    pub table_name: String,
+    /// Stable DuckLake row id within that table.
+    pub row_id: i64,
+}
+
 /// Result of a transactional write setup operation.
 #[derive(Debug)]
 pub struct WriteSetupResult {
@@ -1369,6 +1424,48 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         )
     }
 
+    /// Whether this writer can store a small insert with `schema`'s column
+    /// types inlined in the catalog ([`Self::register_inlined_data`]) such that
+    /// its own inline read path decodes them back exactly. The write path
+    /// consults this before routing a row-bearing write at or below the scoped
+    /// `data_inlining_row_limit`: a writer that returns `false` keeps the
+    /// Parquet path instead of failing the write (or corrupting a round trip),
+    /// since when to inline is writer policy under the DuckLake specification.
+    fn supports_data_inlining(&self, _schema: &ArrowSchema) -> bool {
+        false
+    }
+
+    /// Store a small insert in the catalog instead of writing a Parquet file.
+    ///
+    /// Implementations create or reuse the per-`(table_id, schema_version)`
+    /// physical table, register it in `ducklake_inlined_data_tables`, insert the
+    /// rows with their stable row ids and snapshot bounds, update table stats,
+    /// record `commit_metadata` and the snapshot change ledger (appending to any
+    /// DDL entries already recorded for the snapshot), and — when
+    /// `expected_base_snapshot_id` is set and `mode` is not Replace — abort with
+    /// [`crate::DuckLakeError::Conflict`] if the table's data-file generation
+    /// changed since that snapshot, all in the same transaction as the snapshot
+    /// commit.
+    #[allow(clippy::too_many_arguments)]
+    fn register_inlined_data(
+        &self,
+        _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        _batches: &[RecordBatch],
+        _mode: WriteMode,
+        _base_snapshot: i64,
+        _columns: &[ColumnDef],
+        _column_ids: &[i64],
+        _commit_metadata: &SnapshotCommitMetadata,
+        _expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        Err(DuckLakeError::InvalidConfig(
+            "data inlining is not supported by this metadata writer".to_string(),
+        ))
+    }
+
     /// Register a positional delete file for a single data file, superseding any
     /// prior live delete file for it (at most one is live per data file).
     ///
@@ -1598,6 +1695,59 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         Err(DuckLakeError::InvalidConfig(
             "positional DELETE is not supported on this metadata backend".to_string(),
         ))
+    }
+
+    /// End visible inlined rows in one new snapshot. Implementations must fence
+    /// every row against `base_snapshot`, set `end_snapshot` only while it is
+    /// still live, and decrement the current table row count atomically.
+    fn commit_inlined_deletes(
+        &self,
+        _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+        _rows: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        Err(DuckLakeError::InvalidConfig(
+            "inlined-row DELETE is not supported on this metadata backend".to_string(),
+        ))
+    }
+
+    /// Apply positional and inlined-row deletes in one snapshot. The default
+    /// dispatches when only one storage form is present; backends supporting a
+    /// table that mixes both forms override this for an atomic combined commit.
+    fn commit_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        base_snapshot: i64,
+        positional: &[DeleteFileEntry],
+        inlined: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        match (positional.is_empty(), inlined.is_empty()) {
+            (false, true) => self.commit_positional_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                positional,
+            ),
+            (true, false) => self.commit_inlined_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                inlined,
+            ),
+            (false, false) => Err(DuckLakeError::InvalidConfig(
+                "combined positional and inlined-row DELETE is not supported on this metadata backend"
+                    .to_string(),
+            )),
+            (true, true) => Err(DuckLakeError::InvalidConfig(
+                "commit_deletes requires at least one delete".to_string(),
+            )),
+        }
     }
 
     /// Commit a compaction (`merge_adjacent_files` / `rewrite_data_files`) in
@@ -1886,6 +2036,30 @@ mod tests {
     /// case, so these tests exercise arity/index/transform rules in isolation.
     fn utf8_types(n: usize) -> Vec<Option<DataType>> {
         vec![Some(DataType::Utf8); n]
+    }
+
+    #[test]
+    fn scalar_inlining_support_matches_round_trip_contract() {
+        for data_type in [
+            DataType::Int8,
+            DataType::Float64,
+            DataType::Decimal128(38, 16),
+            DataType::Date32,
+            DataType::Time64(arrow::datatypes::TimeUnit::Microsecond),
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, Some("UTC".into())),
+            DataType::Interval(arrow::datatypes::IntervalUnit::MonthDayNano),
+            DataType::LargeUtf8,
+            DataType::LargeBinary,
+            DataType::FixedSizeBinary(16),
+        ] {
+            assert!(scalar_type_supports_inlining(&data_type), "{data_type}");
+        }
+        assert!(!scalar_type_supports_inlining(&DataType::Time64(
+            arrow::datatypes::TimeUnit::Nanosecond,
+        )));
+        assert!(!scalar_type_supports_inlining(&DataType::List(Arc::new(
+            Field::new("item", DataType::Int64, true),
+        ))));
     }
 
     #[test]

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -5,12 +5,11 @@
 //! that DuckDB's own `ducklake` extension — and this crate's
 //! [`crate::DuckdbMetadataProvider`] — can read back what it writes.
 //!
-//! Scope is deliberately narrow (see `write-duckdb` feature): **legacy /
-//! single-catalog only** — INSERT / REPLACE / CREATE TABLE (including zero-row).
-//! No deletes, no upsert, no compaction, no partitioning, no multicatalog. The
-//! erroring trait defaults for [`MetadataWriter::promote_column_type`] and
-//! [`MetadataWriter::set_delete_file`] are inherited, and
-//! [`MetadataWriter::catalog_id`] returns `None`.
+//! Scope is the legacy, single-catalog layout selected by `write-duckdb`.
+//! Inserts, replacements, positional deletes, updates, compaction, truncate,
+//! append restoration, type promotion, and snapshot expiry share the SQLite
+//! writer's transaction and conflict semantics. Multicatalog remains specific
+//! to PostgreSQL, and [`MetadataWriter::catalog_id`] returns `None`.
 //!
 //! ## How this differs from the SQLite writer
 //!
@@ -38,16 +37,224 @@
 
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
+use crate::maintenance::{
+    CleanupCriteria, ExpireCriteria, ExpiredSnapshot, ScheduledFile, format_sql_timestamp,
+};
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, ExistingCatalogColumn, MetadataWriter,
-    SnapshotCommitMetadata, WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs,
-    catalog_column_type_equal, catalog_column_type_requires_migration, catalog_columns_differ,
-    quote_snapshot_name, quote_snapshot_table, table_write_changes, top_level_column_ids,
-    validate_name,
+    ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
+    DeleteFileEntry, DeleteFileInfo, ExistingCatalogColumn, InlinedRowRef, MetadataWriter,
+    SnapshotCommitMetadata, SourceRetirement, WriteMode, WriteSetupResult, assign_column_ids,
+    catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
+    catalog_columns_differ, quote_snapshot_name, quote_snapshot_table, table_write_changes,
+    top_level_column_ids, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
-use duckdb::{Connection, OptionalExt, Transaction, params};
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, FixedSizeBinaryArray,
+    Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    IntervalMonthDayNanoArray, LargeBinaryArray, LargeStringArray, StringArray,
+    Time64MicrosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+    TimestampNanosecondArray, TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array,
+    UInt64Array,
+};
+use arrow::datatypes::{DataType, TimeUnit as ArrowTimeUnit};
+use arrow::record_batch::RecordBatch;
+use duckdb::types::{TimeUnit as DuckdbTimeUnit, Value};
+use duckdb::{Connection, OptionalExt, Transaction, params, params_from_iter};
 use std::sync::{Arc, Mutex, MutexGuard};
+
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn inlined_duckdb_value(array: &dyn Array, row: usize) -> Result<Value> {
+    if array.is_null(row) {
+        return Ok(Value::Null);
+    }
+    macro_rules! value {
+        ($array:ty, $variant:ident) => {
+            Value::$variant(
+                array
+                    .as_any()
+                    .downcast_ref::<$array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row),
+            )
+        };
+    }
+    Ok(match array.data_type() {
+        DataType::Boolean => value!(BooleanArray, Boolean),
+        DataType::Int8 => value!(Int8Array, TinyInt),
+        DataType::Int16 => value!(Int16Array, SmallInt),
+        DataType::Int32 => value!(Int32Array, Int),
+        DataType::Int64 => value!(Int64Array, BigInt),
+        DataType::UInt8 => value!(UInt8Array, UTinyInt),
+        DataType::UInt16 => value!(UInt16Array, USmallInt),
+        DataType::UInt32 => value!(UInt32Array, UInt),
+        DataType::UInt64 => value!(UInt64Array, UBigInt),
+        DataType::Float32 => value!(Float32Array, Float),
+        DataType::Float64 => value!(Float64Array, Double),
+        DataType::Date32 => value!(Date32Array, Date32),
+        DataType::Time64(ArrowTimeUnit::Microsecond) => Value::Time64(
+            DuckdbTimeUnit::Microsecond,
+            array
+                .as_any()
+                .downcast_ref::<Time64MicrosecondArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row),
+        ),
+        DataType::Timestamp(ArrowTimeUnit::Nanosecond, _) => Value::BigInt(
+            array
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row),
+        ),
+        DataType::Timestamp(unit, _) => {
+            let (unit, value) = match unit {
+                ArrowTimeUnit::Second => (
+                    DuckdbTimeUnit::Second,
+                    array
+                        .as_any()
+                        .downcast_ref::<TimestampSecondArray>()
+                        .expect("Arrow data type and array implementation agree")
+                        .value(row),
+                ),
+                ArrowTimeUnit::Millisecond => (
+                    DuckdbTimeUnit::Millisecond,
+                    array
+                        .as_any()
+                        .downcast_ref::<TimestampMillisecondArray>()
+                        .expect("Arrow data type and array implementation agree")
+                        .value(row),
+                ),
+                ArrowTimeUnit::Microsecond => (
+                    DuckdbTimeUnit::Microsecond,
+                    array
+                        .as_any()
+                        .downcast_ref::<TimestampMicrosecondArray>()
+                        .expect("Arrow data type and array implementation agree")
+                        .value(row),
+                ),
+                ArrowTimeUnit::Nanosecond => unreachable!("handled above"),
+            };
+            Value::Timestamp(unit, value)
+        },
+        DataType::Interval(arrow::datatypes::IntervalUnit::MonthDayNano) => {
+            let value = array
+                .as_any()
+                .downcast_ref::<IntervalMonthDayNanoArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row);
+            Value::Interval {
+                months: value.months,
+                days: value.days,
+                nanos: value.nanoseconds,
+            }
+        },
+        DataType::Utf8 => Value::Text(
+            array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_owned(),
+        ),
+        DataType::LargeUtf8 => Value::Text(
+            array
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_owned(),
+        ),
+        DataType::Binary => Value::Blob(
+            array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+        ),
+        DataType::LargeBinary => Value::Blob(
+            array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+        ),
+        DataType::BinaryView => Value::Blob(
+            array
+                .as_any()
+                .downcast_ref::<BinaryViewArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+        ),
+        DataType::FixedSizeBinary(size) if *size != 16 => Value::Blob(
+            array
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+        ),
+        _ => Value::Text(crate::metadata_writer::inlined_text_value(array, row)?),
+    })
+}
+
+/// Scalar types the DuckDB inline path preserves through catalog normalization.
+/// Backend-native DDL spellings are used when DuckLake type names are aliases.
+/// Nested values remain on the Parquet path until their SQL representation has
+/// a matching parser.
+fn duckdb_type_inlines(data_type: &DataType) -> bool {
+    crate::metadata_writer::scalar_type_supports_inlining(data_type)
+}
+
+fn inlined_duckdb_type(data_type: &DataType, ducklake_type: &str) -> String {
+    match data_type {
+        DataType::Int8 => "TINYINT".to_string(),
+        DataType::Float32 => "FLOAT".to_string(),
+        DataType::Float64 => "DOUBLE".to_string(),
+        DataType::Date32 => "DATE".to_string(),
+        DataType::Time64(ArrowTimeUnit::Microsecond) => "TIME".to_string(),
+        DataType::Timestamp(ArrowTimeUnit::Second, _) => "TIMESTAMP_S".to_string(),
+        DataType::Timestamp(ArrowTimeUnit::Millisecond, _) => "TIMESTAMP_MS".to_string(),
+        DataType::Timestamp(ArrowTimeUnit::Microsecond, _) => "TIMESTAMP".to_string(),
+        DataType::Timestamp(ArrowTimeUnit::Nanosecond, _) => "TIMESTAMP_NS".to_string(),
+        DataType::Interval(arrow::datatypes::IntervalUnit::MonthDayNano) => "INTERVAL".to_string(),
+        _ => ducklake_type.to_string(),
+    }
+}
+
+fn inlined_duckdb_value_sql(data_type: &DataType, ducklake_type: &str) -> String {
+    if matches!(data_type, DataType::Timestamp(ArrowTimeUnit::Nanosecond, _)) {
+        "make_timestamp_ns(?)".to_string()
+    } else {
+        format!(
+            "CAST(? AS {})",
+            inlined_duckdb_type(data_type, ducklake_type),
+        )
+    }
+}
+
+fn id_list(ids: &[i64]) -> String {
+    ids.iter()
+        .map(i64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+const RESOLVED_PATH: &str = "CASE
+    WHEN NOT df.path_is_relative THEN df.path
+    WHEN NOT t.path_is_relative THEN t.path || '/' || df.path
+    ELSE s.path || '/' || t.path || '/' || df.path
+END";
+
+const REL_FLAG: &str =
+    "(CASE WHEN df.path_is_relative AND t.path_is_relative AND s.path_is_relative
+           THEN true ELSE false END)";
 
 /// DuckLake catalog DDL for DuckDB.
 ///
@@ -76,7 +283,9 @@ CREATE TABLE IF NOT EXISTS ducklake_metadata (
 CREATE TABLE IF NOT EXISTS ducklake_snapshot (
     snapshot_id BIGINT PRIMARY KEY,
     snapshot_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    schema_version BIGINT NOT NULL DEFAULT 0
+    schema_version BIGINT NOT NULL DEFAULT 0,
+    next_catalog_id BIGINT NOT NULL DEFAULT 1,
+    next_file_id BIGINT NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
@@ -96,6 +305,7 @@ CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
 
 CREATE TABLE IF NOT EXISTS ducklake_schema (
     schema_id BIGINT PRIMARY KEY DEFAULT nextval('ducklake_schema_id_seq'),
+    schema_uuid UUID DEFAULT uuid(),
     schema_name VARCHAR NOT NULL,
     path VARCHAR NOT NULL DEFAULT '',
     path_is_relative BOOLEAN NOT NULL DEFAULT true,
@@ -105,6 +315,7 @@ CREATE TABLE IF NOT EXISTS ducklake_schema (
 
 CREATE TABLE IF NOT EXISTS ducklake_table (
     table_id BIGINT PRIMARY KEY DEFAULT nextval('ducklake_table_id_seq'),
+    table_uuid UUID DEFAULT uuid(),
     schema_id BIGINT NOT NULL,
     table_name VARCHAR NOT NULL,
     path VARCHAR NOT NULL DEFAULT '',
@@ -128,6 +339,79 @@ CREATE TABLE IF NOT EXISTS ducklake_view (
     dialect VARCHAR,
     sql VARCHAR,
     column_aliases VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_tag (
+    object_id BIGINT,
+    begin_snapshot BIGINT,
+    end_snapshot BIGINT,
+    key VARCHAR,
+    value VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_column_tag (
+    table_id BIGINT,
+    column_id BIGINT,
+    begin_snapshot BIGINT,
+    end_snapshot BIGINT,
+    key VARCHAR,
+    value VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_file_variant_stats (
+    data_file_id BIGINT,
+    table_id BIGINT,
+    column_id BIGINT,
+    variant_path VARCHAR,
+    shredded_type VARCHAR,
+    column_size_bytes BIGINT,
+    value_count BIGINT,
+    null_count BIGINT,
+    min_value VARCHAR,
+    max_value VARCHAR,
+    contains_nan BOOLEAN,
+    extra_stats VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_column_mapping (
+    mapping_id BIGINT,
+    table_id BIGINT,
+    type VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_name_mapping (
+    mapping_id BIGINT,
+    column_id BIGINT,
+    source_name VARCHAR,
+    target_field_id BIGINT,
+    parent_column BIGINT,
+    is_partition BOOLEAN
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_macro (
+    schema_id BIGINT,
+    macro_id BIGINT,
+    macro_name VARCHAR,
+    begin_snapshot BIGINT,
+    end_snapshot BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_macro_impl (
+    macro_id BIGINT,
+    impl_id BIGINT,
+    dialect VARCHAR,
+    sql VARCHAR,
+    type VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_macro_parameters (
+    macro_id BIGINT,
+    impl_id BIGINT,
+    column_id BIGINT,
+    parameter_name VARCHAR,
+    parameter_type VARCHAR,
+    default_value VARCHAR,
+    default_value_type VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_column (
@@ -159,8 +443,19 @@ CREATE TABLE IF NOT EXISTS ducklake_data_file (
     mapping_id BIGINT,
     begin_snapshot BIGINT NOT NULL,
     end_snapshot BIGINT,
+    file_order BIGINT,
+    file_format VARCHAR,
+    partial_max BIGINT,
     -- References ducklake_partition_info.partition_id; NULL when unpartitioned.
     partition_id BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
+    snapshot_id BIGINT PRIMARY KEY,
+    changes_made VARCHAR NOT NULL,
+    author VARCHAR,
+    commit_message VARCHAR,
+    commit_extra_info VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_table_stats (
@@ -168,6 +463,20 @@ CREATE TABLE IF NOT EXISTS ducklake_table_stats (
     record_count BIGINT NOT NULL DEFAULT 0,
     next_row_id BIGINT NOT NULL DEFAULT 0,
     file_size_bytes BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
+    table_id BIGINT NOT NULL,
+    table_name VARCHAR NOT NULL,
+    schema_version BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
+    snapshot_id BIGINT PRIMARY KEY,
+    changes_made VARCHAR NOT NULL,
+    author VARCHAR,
+    commit_message VARCHAR,
+    commit_extra_info VARCHAR
 );
 
 -- Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
@@ -202,12 +511,14 @@ CREATE TABLE IF NOT EXISTS ducklake_delete_file (
     table_id BIGINT NOT NULL,
     path VARCHAR NOT NULL,
     path_is_relative BOOLEAN NOT NULL DEFAULT true,
+    format VARCHAR,
     file_size_bytes BIGINT NOT NULL,
     footer_size BIGINT,
     encryption_key VARCHAR,
     delete_count BIGINT,
     begin_snapshot BIGINT NOT NULL,
-    end_snapshot BIGINT
+    end_snapshot BIGINT,
+    partial_max BIGINT
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
@@ -303,6 +614,177 @@ impl DuckdbMetadataWriter {
     fn connection(&self) -> MutexGuard<'_, Connection> {
         self.conn.lock().expect("DuckDB connection mutex poisoned")
     }
+
+    /// Expire snapshots and remove catalog rows no longer reachable from a
+    /// surviving snapshot. Physical files are queued for later cleanup.
+    pub fn expire_snapshots(&self, criteria: ExpireCriteria) -> Result<Vec<ExpiredSnapshot>> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let most_recent: Option<i64> = tx.query_row(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot",
+            [],
+            |row| row.get(0),
+        )?;
+        let Some(most_recent) = most_recent else {
+            tx.commit()?;
+            return Ok(Vec::new());
+        };
+        let candidates = match criteria {
+            ExpireCriteria::Versions(versions) => {
+                let versions = versions
+                    .into_iter()
+                    .filter(|snapshot| *snapshot != 0 && *snapshot != most_recent)
+                    .collect::<Vec<_>>();
+                if versions.is_empty() {
+                    tx.commit()?;
+                    return Ok(Vec::new());
+                }
+                let mut statement = tx.prepare(&format!(
+                    "SELECT snapshot_id, CAST(snapshot_time AS VARCHAR)
+                     FROM ducklake_snapshot WHERE snapshot_id IN ({}) ORDER BY snapshot_id",
+                    id_list(&versions)
+                ))?;
+                statement
+                    .query_map([], |row| {
+                        Ok(ExpiredSnapshot {
+                            snapshot_id: row.get(0)?,
+                            snapshot_time: row.get(1)?,
+                        })
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?
+            },
+            ExpireCriteria::OlderThan(cutoff) => {
+                let mut statement = tx.prepare(
+                    "SELECT snapshot_id, CAST(snapshot_time AS VARCHAR)
+                     FROM ducklake_snapshot
+                     WHERE snapshot_id != 0 AND snapshot_id != ?
+                       AND snapshot_time < CAST(? AS TIMESTAMP)
+                     ORDER BY snapshot_id",
+                )?;
+                statement
+                    .query_map(params![most_recent, format_sql_timestamp(&cutoff)], |row| {
+                        Ok(ExpiredSnapshot {
+                            snapshot_id: row.get(0)?,
+                            snapshot_time: row.get(1)?,
+                        })
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?
+            },
+        };
+        if candidates.is_empty() {
+            tx.commit()?;
+            return Ok(Vec::new());
+        }
+        let expire_ids = candidates
+            .iter()
+            .map(|snapshot| snapshot.snapshot_id)
+            .collect::<Vec<_>>();
+        tx.execute_batch(&format!(
+            "DELETE FROM ducklake_snapshot WHERE snapshot_id IN ({})",
+            id_list(&expire_ids)
+        ))?;
+
+        let dead_tables = {
+            let mut statement = tx.prepare(
+                "SELECT t.table_id FROM ducklake_table t
+                 WHERE t.end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= t.begin_snapshot AND snapshot_id < t.end_snapshot)
+                 AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_table t2
+                     WHERE t2.table_id = t.table_id
+                       AND (t2.end_snapshot IS NULL OR EXISTS (
+                           SELECT 1 FROM ducklake_snapshot
+                           WHERE snapshot_id >= t2.begin_snapshot
+                             AND snapshot_id < t2.end_snapshot)))",
+            )?;
+            statement
+                .query_map([], |row| row.get::<_, i64>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        let dead_table_filter = if dead_tables.is_empty() {
+            "false".to_string()
+        } else {
+            format!("df.table_id IN ({})", id_list(&dead_tables))
+        };
+        let dead_data_files = {
+            let mut statement = tx.prepare(&format!(
+                "SELECT df.data_file_id FROM ducklake_data_file df
+                 WHERE ({dead_table_filter}) OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
+            ))?;
+            statement
+                .query_map([], |row| row.get::<_, i64>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        if !dead_data_files.is_empty() {
+            let ids = id_list(&dead_data_files);
+            tx.execute_batch(&format!(
+                "INSERT INTO ducklake_files_scheduled_for_deletion
+                     (data_file_id, path, path_is_relative)
+                 SELECT df.data_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                 FROM ducklake_data_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE df.data_file_id IN ({ids});
+                 DELETE FROM ducklake_data_file WHERE data_file_id IN ({ids})"
+            ))?;
+        }
+        let dead_data_filter = if dead_data_files.is_empty() {
+            "false".to_string()
+        } else {
+            format!("df.data_file_id IN ({})", id_list(&dead_data_files))
+        };
+        let dead_delete_table_filter = if dead_tables.is_empty() {
+            "false".to_string()
+        } else {
+            format!("df.table_id IN ({})", id_list(&dead_tables))
+        };
+        let dead_delete_files = {
+            let mut statement = tx.prepare(&format!(
+                "SELECT df.delete_file_id FROM ducklake_delete_file df
+                 WHERE ({dead_data_filter}) OR ({dead_delete_table_filter})
+                    OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                        SELECT 1 FROM ducklake_snapshot
+                        WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
+            ))?;
+            statement
+                .query_map([], |row| row.get::<_, i64>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        if !dead_delete_files.is_empty() {
+            let ids = id_list(&dead_delete_files);
+            tx.execute_batch(&format!(
+                "INSERT INTO ducklake_files_scheduled_for_deletion
+                     (data_file_id, path, path_is_relative)
+                 SELECT df.delete_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                 FROM ducklake_delete_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE df.delete_file_id IN ({ids});
+                 DELETE FROM ducklake_delete_file WHERE delete_file_id IN ({ids})"
+            ))?;
+        }
+        if !dead_tables.is_empty() {
+            let ids = id_list(&dead_tables);
+            tx.execute_batch(&format!(
+                "DELETE FROM ducklake_table WHERE table_id IN ({ids});
+                 DELETE FROM ducklake_table_stats WHERE table_id IN ({ids});
+                 DELETE FROM ducklake_column WHERE table_id IN ({ids});
+                 DELETE FROM ducklake_schema_versions WHERE table_id IN ({ids})"
+            ))?;
+        }
+        tx.execute_batch(
+            "DELETE FROM ducklake_schema
+             WHERE end_snapshot IS NOT NULL AND NOT EXISTS (
+                 SELECT 1 FROM ducklake_snapshot
+                 WHERE snapshot_id >= ducklake_schema.begin_snapshot
+                   AND snapshot_id < ducklake_schema.end_snapshot)",
+        )?;
+        tx.commit()?;
+        Ok(candidates)
+    }
 }
 
 /// Atomically reserve `n` consecutive ids from a monotonic counter row in
@@ -321,6 +803,21 @@ fn reserve_ids(tx: &Transaction<'_>, key: &str, n: i64) -> Result<i64> {
         |row| row.get(0),
     )?;
     Ok(last)
+}
+
+fn reserve_sequence_ids(tx: &Transaction<'_>, sequence: &str, n: i64) -> Result<Vec<i64>> {
+    let sql = format!("SELECT nextval('{sequence}')");
+    (0..n)
+        .map(|_| tx.query_row(&sql, [], |row| row.get(0)).map_err(Into::into))
+        .collect()
+}
+
+fn reserve_file_ids(tx: &Transaction<'_>, n: i64) -> Result<Vec<i64>> {
+    reserve_sequence_ids(tx, "ducklake_data_file_id_seq", n)
+}
+
+fn reserve_delete_file_ids(tx: &Transaction<'_>, n: i64) -> Result<Vec<i64>> {
+    reserve_sequence_ids(tx, "ducklake_delete_file_id_seq", n)
 }
 
 /// Insert the next `ducklake_snapshot` row in commit order, carrying
@@ -384,6 +881,7 @@ fn record_snapshot_changes(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn record_table_write_changes(
     tx: &Transaction<'_>,
     snapshot_id: i64,
@@ -391,6 +889,7 @@ fn record_table_write_changes(
     schema_name: &str,
     table_name: &str,
     mode: WriteMode,
+    has_deletes: bool,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
     let (schema_begin_snapshot, table_begin_snapshot): (i64, i64) = tx.query_row(
@@ -409,7 +908,7 @@ fn record_table_write_changes(
         params![table_id, snapshot_id],
         |row| row.get(0),
     )?;
-    let replaced_existing_data: bool = tx.query_row(
+    let mut replaced_existing_data: bool = tx.query_row(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
             WHERE table_id = ? AND end_snapshot = ?
@@ -417,6 +916,27 @@ fn record_table_write_changes(
         params![table_id, snapshot_id],
         |row| row.get(0),
     )?;
+    if !replaced_existing_data {
+        // A Replace over inline-only prior data ends inline rows, not files.
+        let inlined_tables: Vec<String> = {
+            let mut statement = tx.prepare(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+            )?;
+            statement
+                .query_map(params![table_id], |row| row.get::<_, String>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        for inlined_table in inlined_tables {
+            let sql = format!(
+                "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot = ?)",
+                quote_ident(&inlined_table)
+            );
+            if tx.query_row(&sql, params![snapshot_id], |row| row.get(0))? {
+                replaced_existing_data = true;
+                break;
+            }
+        }
+    }
 
     let mut changes = Vec::new();
     if schema_begin_snapshot == snapshot_id {
@@ -436,7 +956,7 @@ fn record_table_write_changes(
     changes.push(table_write_changes(
         table_id,
         mode,
-        false,
+        has_deletes,
         replaced_existing_data,
     ));
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata)
@@ -517,6 +1037,28 @@ fn detect_replace_conflict(tx: &Transaction<'_>, table_id: i64, base_snapshot: i
              snapshot {base_snapshot}; aborting (retry the write against the new generation)"
         )));
     }
+    let mut statement =
+        tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+    let table_names = statement
+        .query_map(params![table_id], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(statement);
+    for table_name in table_names {
+        let conflicts: i64 = tx.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {} WHERE begin_snapshot > ? OR end_snapshot > ?",
+                quote_ident(&table_name)
+            ),
+            params![base_snapshot, base_snapshot],
+            |row| row.get(0),
+        )?;
+        if conflicts > 0 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "Replace on table {table_id} conflicts with inlined data committed since \
+                 snapshot {base_snapshot}; aborting"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -524,12 +1066,77 @@ fn detect_replace_conflict(tx: &Transaction<'_>, table_id: i64, base_snapshot: i
 /// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard spares
 /// files registered for *this* snapshot. `next_row_id` is left untouched (rowids
 /// stay monotonic across the table's lifetime). Mirrors the SQLite writer.
+fn detect_new_inlined_deletes(
+    tx: &Transaction<'_>,
+    table_id: i64,
+    base_snapshot: i64,
+    data_file_ids: &[i64],
+) -> Result<()> {
+    if data_file_ids.is_empty() {
+        return Ok(());
+    }
+
+    let table = crate::metadata_provider::inlined_delete_table_name(table_id)?;
+    let exists: bool = tx.query_row(
+        "SELECT COUNT(*) > 0 FROM information_schema.tables WHERE table_name = ?",
+        params![table.as_str()],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        return Ok(());
+    }
+
+    let conflict: i64 = tx.query_row(
+        &format!(
+            "SELECT COUNT(*) FROM {} newer
+             WHERE newer.file_id IN ({})
+               AND (newer.begin_snapshot IS NULL OR (
+                 newer.begin_snapshot > ?
+                 AND (newer.row_id IS NULL OR NOT EXISTS (
+                   SELECT 1 FROM {} prior
+                   WHERE prior.file_id = newer.file_id
+                     AND prior.row_id = newer.row_id
+                     AND prior.begin_snapshot <= ?
+                 ))
+               ))",
+            quote_ident(&table),
+            id_list(data_file_ids),
+            quote_ident(&table),
+        ),
+        params![base_snapshot, base_snapshot],
+        |row| row.get(0),
+    )?;
+    if conflict > 0 {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "table {table_id} gained an inlined delete on a source file since snapshot \
+             {base_snapshot}; re-open the catalog and re-plan"
+        )));
+    }
+    Ok(())
+}
+
 fn retire_prior_generation(tx: &Transaction<'_>, table_id: i64, snapshot_id: i64) -> Result<()> {
     tx.execute(
         "UPDATE ducklake_data_file SET end_snapshot = ?
          WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot < ?",
         params![snapshot_id, table_id, snapshot_id],
     )?;
+    let mut statement =
+        tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+    let table_names = statement
+        .query_map(params![table_id], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(statement);
+    for table_name in table_names {
+        tx.execute(
+            &format!(
+                "UPDATE {} SET end_snapshot = ? \
+                 WHERE end_snapshot IS NULL AND begin_snapshot < ?",
+                quote_ident(&table_name)
+            ),
+            params![snapshot_id, snapshot_id],
+        )?;
+    }
     tx.execute(
         "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = ?",
         params![table_id],
@@ -602,6 +1209,33 @@ fn insert_partition_metadata(
     Ok(())
 }
 
+fn live_columns_for_stats(
+    tx: &Transaction<'_>,
+    table_id: i64,
+) -> Result<(Vec<ColumnDef>, Vec<i64>)> {
+    let mut statement = tx.prepare(
+        "SELECT column_id, column_name, column_type
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )?;
+    let rows = statement.query_map(params![table_id], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    let mut columns = Vec::new();
+    let mut column_ids = Vec::new();
+    for row in rows {
+        let (column_id, name, ducklake_type) = row?;
+        column_ids.push(column_id);
+        columns.push(ColumnDef::new(name, ducklake_type, true)?);
+    }
+    Ok((columns, column_ids))
+}
+
 /// Recompute `ducklake_table_column_stats` from the table's live files and
 /// replace the stored rows. See the SQLite writer's equivalent for the rationale.
 fn recompute_table_column_stats(
@@ -669,6 +1303,136 @@ fn recompute_table_column_stats(
                 g.max_value,
             ],
         )?;
+    }
+    Ok(())
+}
+
+fn apply_delete_entry(
+    tx: &Transaction<'_>,
+    table_id: i64,
+    base_snapshot: i64,
+    snapshot_id: i64,
+    entry: &DeleteFileEntry,
+) -> Result<()> {
+    let target_live: Option<i64> = tx
+        .query_row(
+            "SELECT 1 FROM ducklake_data_file
+             WHERE data_file_id = ? AND end_snapshot IS NULL",
+            params![entry.data_file_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if target_live.is_none() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "UPDATE/DELETE on data file {} could not commit: the file is no longer live as of \
+             the catalog's current head (retired since snapshot {base_snapshot}); re-open the \
+             catalog at the latest snapshot and retry",
+            entry.data_file_id
+        )));
+    }
+    let current_delete: Option<i64> = tx
+        .query_row(
+            "SELECT delete_file_id FROM ducklake_delete_file
+             WHERE data_file_id = ? AND end_snapshot IS NULL",
+            params![entry.data_file_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if current_delete != entry.expected_prev_delete_file {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "UPDATE/DELETE on data file {} could not commit: its live delete file changed from \
+             {:?} to {current_delete:?} since snapshot {base_snapshot}; re-open the catalog at \
+             the latest snapshot and retry",
+            entry.data_file_id, entry.expected_prev_delete_file
+        )));
+    }
+    if let Some(delete_file_id) = entry.expected_prev_delete_file {
+        tx.execute(
+            "UPDATE ducklake_delete_file SET end_snapshot = ?
+             WHERE delete_file_id = ? AND end_snapshot IS NULL",
+            params![snapshot_id, delete_file_id],
+        )?;
+    }
+    let delete_file_id = reserve_delete_file_ids(tx, 1)?[0];
+    tx.execute(
+        "INSERT INTO ducklake_delete_file
+             (delete_file_id, data_file_id, table_id, path, path_is_relative,
+              file_size_bytes, footer_size, delete_count, begin_snapshot)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        params![
+            delete_file_id,
+            entry.data_file_id,
+            table_id,
+            entry.delete.path.as_str(),
+            entry.delete.path_is_relative,
+            entry.delete.file_size_bytes,
+            entry.delete.footer_size,
+            entry.delete.delete_count,
+            snapshot_id
+        ],
+    )?;
+    Ok(())
+}
+
+/// The physical `ducklake_inlined_data_*` tables registered for the table.
+/// Mirrors the SQLite writer's `inlined_table_names`.
+fn inlined_table_names(tx: &Transaction<'_>, table_id: i64) -> Result<Vec<String>> {
+    let mut statement =
+        tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+    let names = statement
+        .query_map(params![table_id], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(names)
+}
+
+/// Count the table's still-visible inlined rows across its registered physical
+/// tables. Mirrors the SQLite writer's `live_inlined_row_count`.
+fn live_inlined_row_count(tx: &Transaction<'_>, table_id: i64) -> Result<i64> {
+    let mut total = 0;
+    for table_name in inlined_table_names(tx, table_id)? {
+        let sql = format!(
+            "SELECT COUNT(*) FROM {} WHERE end_snapshot IS NULL",
+            quote_ident(&table_name)
+        );
+        total += tx.query_row(&sql, [], |row| row.get::<_, i64>(0))?;
+    }
+    Ok(total)
+}
+
+/// End the referenced inlined rows at `snapshot_id`, fencing each against
+/// `base_snapshot`. Mirrors the SQLite writer's `apply_inlined_deletes`
+/// (used by the combined `commit_deletes` path).
+fn apply_inlined_deletes(
+    tx: &Transaction<'_>,
+    table_id: i64,
+    snapshot_id: i64,
+    base_snapshot: i64,
+    rows: &[InlinedRowRef],
+) -> Result<()> {
+    let registered = inlined_table_names(tx, table_id)?
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    for row in rows {
+        if !registered.contains(&row.table_name) {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} belongs to an unregistered table '{}'",
+                row.row_id, row.table_name
+            )));
+        }
+        let affected = tx.execute(
+            &format!(
+                "UPDATE {} SET end_snapshot = ? \
+                 WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+                quote_ident(&row.table_name)
+            ),
+            params![snapshot_id, row.row_id, base_snapshot],
+        )?;
+        if affected != 1 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                row.row_id, row.table_name
+            )));
+        }
     }
     Ok(())
 }
@@ -851,7 +1615,86 @@ fn finalize_snapshot(
     Ok(snapshot_id)
 }
 
+impl DuckdbMetadataWriter {
+    pub(crate) fn list_scheduled_for_deletion(
+        &self,
+        criteria: &CleanupCriteria,
+    ) -> Result<Vec<ScheduledFile>> {
+        let conn = self.connection();
+        let (sql, cutoff) = match criteria {
+            CleanupCriteria::All => (
+                "SELECT data_file_id, path, path_is_relative \
+                 FROM ducklake_files_scheduled_for_deletion",
+                None,
+            ),
+            CleanupCriteria::OlderThan(cutoff) => (
+                "SELECT data_file_id, path, path_is_relative \
+                 FROM ducklake_files_scheduled_for_deletion \
+                 WHERE schedule_start < CAST(? AS TIMESTAMP)",
+                Some(format_sql_timestamp(cutoff)),
+            ),
+        };
+        let mut statement = conn.prepare(sql)?;
+        let decode = |row: &duckdb::Row<'_>| {
+            Ok(ScheduledFile {
+                data_file_id: row.get(0)?,
+                path: row.get(1)?,
+                path_is_relative: row.get(2)?,
+            })
+        };
+        let files = if let Some(cutoff) = cutoff {
+            statement
+                .query_map([cutoff], decode)?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        } else {
+            statement
+                .query_map([], decode)?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        Ok(files)
+    }
+
+    pub(crate) fn remove_scheduled(&self, ids: &[i64]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let conn = self.connection();
+        conn.execute_batch(&format!(
+            "DELETE FROM ducklake_files_scheduled_for_deletion \
+             WHERE data_file_id IN ({})",
+            id_list(ids),
+        ))?;
+        Ok(())
+    }
+
+    pub(crate) fn list_referenced_paths(&self) -> Result<Vec<(String, bool)>> {
+        let conn = self.connection();
+        let sql = format!(
+            "SELECT {RESOLVED_PATH} AS path, {REL_FLAG} AS path_is_relative \
+             FROM ducklake_data_file AS df \
+             JOIN ducklake_table AS t ON t.table_id = df.table_id \
+             JOIN ducklake_schema AS s ON s.schema_id = t.schema_id \
+             UNION ALL \
+             SELECT {RESOLVED_PATH} AS path, {REL_FLAG} AS path_is_relative \
+             FROM ducklake_delete_file AS df \
+             JOIN ducklake_table AS t ON t.table_id = df.table_id \
+             JOIN ducklake_schema AS s ON s.schema_id = t.schema_id \
+             UNION ALL \
+             SELECT path, path_is_relative \
+             FROM ducklake_files_scheduled_for_deletion",
+        );
+        let mut statement = conn.prepare(&sql)?;
+        let paths = statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(paths)
+    }
+}
+
 impl MetadataWriter for DuckdbMetadataWriter {
+    fn supports_update(&self) -> bool {
+        true
+    }
     fn create_snapshot(&self) -> Result<i64> {
         let mut conn = self.connection();
         let tx = conn.transaction()?;
@@ -964,6 +1807,76 @@ impl MetadataWriter for DuckdbMetadataWriter {
         )?;
         tx.commit()?;
         Ok((table_id, true))
+    }
+
+    fn promote_column_type(
+        &self,
+        table_id: i64,
+        column_name: &str,
+        new_ducklake_type: &str,
+    ) -> Result<i64> {
+        crate::types::ducklake_to_arrow_type(new_ducklake_type)?;
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _carried) = insert_snapshot(&tx)?;
+        let row: Option<(i64, String, i64, Option<bool>)> = tx
+            .query_row(
+                "SELECT column_id, column_type, column_order, nulls_allowed
+                 FROM ducklake_column
+                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                params![table_id, column_name],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+        let (column_id, current_type, column_order, nulls_allowed) = row.ok_or_else(|| {
+            crate::DuckLakeError::InvalidConfig(format!(
+                "promote_column_type: no live column '{column_name}' in table {table_id}"
+            ))
+        })?;
+        if crate::types::types_equal_canonical(&current_type, new_ducklake_type) {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "promote_column_type: column '{column_name}' is already type '{current_type}' (no change)"
+            )));
+        }
+        if !crate::types::is_promotable(&current_type, new_ducklake_type) {
+            return Err(crate::DuckLakeError::UnsupportedTypeChange {
+                operation: TypeChangeOperation::PromoteColumnType,
+                column: column_name.to_string(),
+                from: current_type,
+                to: new_ducklake_type.to_string(),
+            });
+        }
+
+        let schema_version = bump_schema_version(&tx, snapshot_id)?;
+        tx.execute(
+            "UPDATE ducklake_column SET end_snapshot = ?
+             WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+            params![snapshot_id, table_id, column_id],
+        )?;
+        tx.execute(
+            "INSERT INTO ducklake_column
+                 (column_id, begin_snapshot, end_snapshot, table_id, column_order,
+                  column_name, column_type, nulls_allowed)
+             VALUES (?, ?, NULL, ?, ?, ?, ?, ?)",
+            params![
+                column_id,
+                snapshot_id,
+                table_id,
+                column_order,
+                column_name,
+                new_ducklake_type,
+                nulls_allowed.unwrap_or(true)
+            ],
+        )?;
+        record_schema_version(&tx, snapshot_id, schema_version, table_id)?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("altered_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        tx.commit()?;
+        Ok(snapshot_id)
     }
 
     fn set_columns(
@@ -1156,6 +2069,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             schema_name,
             table_name,
             mode,
+            false,
             commit_metadata,
         )?;
         let schema_id: i64 = tx.query_row(
@@ -1291,6 +2205,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             schema_name,
             table_name,
             mode,
+            false,
             commit_metadata,
         )?;
         let schema_id: i64 = tx.query_row(
@@ -1304,6 +2219,817 @@ impl MetadataWriter for DuckdbMetadataWriter {
             schema_id,
             table_id,
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn supports_data_inlining(&self, schema: &arrow::datatypes::Schema) -> bool {
+        schema
+            .fields()
+            .iter()
+            .all(|field| duckdb_type_inlines(field.data_type()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_inlined_data(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        batches: &[RecordBatch],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        if record_count == 0 {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: batches must contain at least one row".to_string(),
+            ));
+        }
+        if batches
+            .iter()
+            .any(|batch| batch.num_columns() != columns.len())
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: batch schema does not match table columns".to_string(),
+            ));
+        }
+
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let snapshot_id =
+            finalize_snapshot(&tx, table_id, columns, column_ids, mode, base_snapshot)?;
+        if mode != WriteMode::Replace
+            && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+        {
+            detect_replace_conflict(&tx, table_id, expected_base_snapshot_id)?;
+        }
+        let schema_version: i64 = tx.query_row(
+            "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+            params![snapshot_id],
+            |row| row.get(0),
+        )?;
+        let physical_name = format!("ducklake_inlined_data_{table_id}_{schema_version}");
+
+        let mut ddl = format!(
+            "CREATE TABLE IF NOT EXISTS {} (\
+             row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+            quote_ident(&physical_name)
+        );
+        let schema = batches[0].schema();
+        for (column, field) in columns.iter().zip(schema.fields()) {
+            ddl.push_str(", ");
+            ddl.push_str(&quote_ident(column.name()));
+            ddl.push(' ');
+            ddl.push_str(&inlined_duckdb_type(
+                field.data_type(),
+                column.ducklake_type(),
+            ));
+        }
+        ddl.push(')');
+        tx.execute(&ddl, [])?;
+        tx.execute(
+            "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version)
+             SELECT ?, ?, ? WHERE NOT EXISTS (
+                 SELECT 1 FROM ducklake_inlined_data_tables
+                 WHERE table_id = ? AND schema_version = ?)",
+            params![table_id, physical_name.as_str(), schema_version, table_id, schema_version],
+        )?;
+        seed_stats_if_missing(&tx, table_id)?;
+        let mut row_id: i64 = tx.query_row(
+            "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+
+        let column_list = columns
+            .iter()
+            .map(|column| quote_ident(column.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let value_list = columns
+            .iter()
+            .zip(schema.fields())
+            .map(|(column, field)| {
+                inlined_duckdb_value_sql(field.data_type(), column.ducklake_type())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let insert_sql = format!(
+            "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) \
+             VALUES (?, ?, ?, {})",
+            quote_ident(&physical_name),
+            column_list,
+            value_list
+        );
+        for batch in batches {
+            for batch_row in 0..batch.num_rows() {
+                let mut values = Vec::with_capacity(columns.len() + 3);
+                values.push(Value::BigInt(row_id));
+                values.push(Value::BigInt(snapshot_id));
+                values.push(Value::Null);
+                for array in batch.columns() {
+                    values.push(inlined_duckdb_value(array.as_ref(), batch_row)?);
+                }
+                tx.execute(&insert_sql, params_from_iter(values))?;
+                row_id += 1;
+            }
+        }
+
+        let record_count = i64::try_from(record_count).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: record count exceeds i64".to_string(),
+            )
+        })?;
+        tx.execute(
+            "UPDATE ducklake_table_stats
+             SET next_row_id = next_row_id + ?, record_count = record_count + ?
+             WHERE table_id = ?",
+            params![record_count, record_count, table_id],
+        )?;
+        // The same composed ledger recording the Parquet path uses: DDL entries
+        // plus the write change, appended rather than clobbered.
+        record_table_write_changes(
+            &tx,
+            snapshot_id,
+            table_id,
+            schema_name,
+            table_name,
+            mode,
+            false,
+            commit_metadata,
+        )?;
+        let schema_id: i64 = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn commit_inlined_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        rows: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        if rows.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes requires at least one row".to_string(),
+            ));
+        }
+        if rows.iter().collect::<std::collections::HashSet<_>>().len() != rows.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes contains duplicate rows".to_string(),
+            ));
+        }
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let mut statement =
+            tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+        let registered = statement
+            .query_map(params![table_id], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
+        drop(statement);
+        for row in rows {
+            if !registered.contains(&row.table_name) {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "inlined row {} belongs to an unregistered table '{}'",
+                    row.row_id, row.table_name
+                )));
+            }
+            let affected = tx.execute(
+                &format!(
+                    "UPDATE {} SET end_snapshot = ? \
+                     WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+                    quote_ident(&row.table_name)
+                ),
+                params![snapshot_id, row.row_id, base_snapshot],
+            )?;
+            if affected != 1 {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                    row.row_id, row.table_name
+                )));
+            }
+        }
+        let deleted = i64::try_from(rows.len()).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes row count exceeds i64".to_string(),
+            )
+        })?;
+        tx.execute(
+            "UPDATE ducklake_table_stats
+             SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+            params![deleted, table_id],
+        )?;
+        let changes_made = format!("deleted_from_table:{table_id}");
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &changes_made,
+            &SnapshotCommitMetadata::default(),
+        )?;
+        let schema_id: i64 = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_delete_file(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        data_file_id: i64,
+        expected_prev_delete_file: Option<i64>,
+        base_snapshot: i64,
+        delete: &DeleteFileInfo,
+    ) -> Result<CommitIds> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        apply_delete_entry(
+            &tx,
+            table_id,
+            base_snapshot,
+            snapshot_id,
+            &DeleteFileEntry {
+                data_file_id,
+                expected_prev_delete_file,
+                delete: delete.clone(),
+            },
+        )?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("deleted_from_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        let schema_id = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        validate_delete_entries(mode, deletes)?;
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let snapshot_id =
+            finalize_snapshot(&tx, table_id, columns, column_ids, mode, base_snapshot)?;
+        let data_file_ids = deletes
+            .iter()
+            .map(|entry| entry.data_file_id)
+            .collect::<Vec<_>>();
+        detect_new_inlined_deletes(&tx, table_id, base_snapshot, &data_file_ids)?;
+        let live_partition_id: Option<i64> = tx.query_row(
+            "SELECT (SELECT partition_id FROM ducklake_partition_info
+                     WHERE table_id = ? AND end_snapshot IS NULL LIMIT 1)",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+        seed_stats_if_missing(&tx, table_id)?;
+        let row_id_start = tx.query_row(
+            "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+            params![table_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let data_file_id = reserve_file_ids(&tx, 1)?[0];
+        tx.execute(
+            "INSERT INTO ducklake_data_file
+                 (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, record_count, row_id_start, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                data_file_id,
+                table_id,
+                file.path.as_str(),
+                file.path_is_relative,
+                file.file_size_bytes,
+                file.footer_size,
+                file.record_count,
+                row_id_start,
+                snapshot_id,
+            ],
+        )?;
+        insert_file_column_stats(&tx, table_id, data_file_id, &file.column_stats)?;
+        insert_partition_metadata(&tx, table_id, data_file_id, file)?;
+        recompute_table_column_stats(&tx, table_id, columns, column_ids)?;
+        tx.execute(
+            "UPDATE ducklake_table_stats
+             SET next_row_id = next_row_id + ?, record_count = record_count + ?,
+                 file_size_bytes = file_size_bytes + ?
+             WHERE table_id = ?",
+            params![file.record_count, file.record_count, file.file_size_bytes, table_id],
+        )?;
+        for entry in deletes {
+            apply_delete_entry(&tx, table_id, base_snapshot, snapshot_id, entry)?;
+        }
+        record_table_write_changes(
+            &tx,
+            snapshot_id,
+            table_id,
+            schema_name,
+            table_name,
+            mode,
+            !deletes.is_empty(),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        let schema_id = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn commit_positional_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        deletes: &[DeleteFileEntry],
+    ) -> Result<CommitIds> {
+        if deletes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_positional_deletes requires at least one delete entry".to_string(),
+            ));
+        }
+        validate_delete_entries(WriteMode::Append, deletes)?;
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let data_file_ids = deletes
+            .iter()
+            .map(|entry| entry.data_file_id)
+            .collect::<Vec<_>>();
+        detect_new_inlined_deletes(&tx, table_id, base_snapshot, &data_file_ids)?;
+        for entry in deletes {
+            apply_delete_entry(&tx, table_id, base_snapshot, snapshot_id, entry)?;
+        }
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("deleted_from_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        let schema_id = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn commit_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        base_snapshot: i64,
+        positional: &[DeleteFileEntry],
+        inlined: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        // Mixed positional + inlined DELETE in ONE snapshot/transaction,
+        // mirroring the SQLite writer's override (the trait default refuses the
+        // combination). Single-form deletes keep their dedicated paths.
+        if inlined.is_empty() {
+            return self.commit_positional_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                positional,
+            );
+        }
+        if positional.is_empty() {
+            return self.commit_inlined_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                inlined,
+            );
+        }
+        validate_delete_entries(WriteMode::Append, positional)?;
+        if inlined
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined.len()
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_deletes contains duplicate inlined rows".to_string(),
+            ));
+        }
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let data_file_ids = positional
+            .iter()
+            .map(|entry| entry.data_file_id)
+            .collect::<Vec<_>>();
+        detect_new_inlined_deletes(&tx, table_id, base_snapshot, &data_file_ids)?;
+        for entry in positional {
+            apply_delete_entry(&tx, table_id, base_snapshot, snapshot_id, entry)?;
+        }
+        apply_inlined_deletes(&tx, table_id, snapshot_id, base_snapshot, inlined)?;
+        let deleted = i64::try_from(inlined.len()).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig("commit_deletes row count exceeds i64".to_string())
+        })?;
+        tx.execute(
+            "UPDATE ducklake_table_stats
+             SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+            params![deleted, table_id],
+        )?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("deleted_from_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        let schema_id: i64 = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn commit_compaction(
+        &self,
+        table_id: i64,
+        base_snapshot: i64,
+        sources: &[CompactionSourceFile],
+        outputs: &[CompactionOutputFile],
+        retirement: SourceRetirement,
+    ) -> Result<CommitIds> {
+        if sources.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_compaction requires at least one source file".to_string(),
+            ));
+        }
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let source_ids = sources
+            .iter()
+            .map(|source| source.data_file_id)
+            .collect::<Vec<_>>();
+        detect_new_inlined_deletes(&tx, table_id, base_snapshot, &source_ids)?;
+        for source in sources {
+            let live: Option<i64> = tx
+                .query_row(
+                    "SELECT 1 FROM ducklake_data_file
+                     WHERE data_file_id = ? AND table_id = ? AND end_snapshot IS NULL",
+                    params![source.data_file_id, table_id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            if live.is_none() {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "compaction of table {table_id} could not commit: source data file {} is no \
+                     longer live since snapshot {base_snapshot}; re-open the catalog and re-plan",
+                    source.data_file_id
+                )));
+            }
+            let current_delete: Option<i64> = tx
+                .query_row(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = ? AND end_snapshot IS NULL",
+                    params![source.data_file_id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            if current_delete != source.delete_file_id {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "compaction of table {table_id} could not commit: the live delete file of \
+                     source data file {} changed from {:?} to {current_delete:?} since snapshot \
+                     {base_snapshot}; re-open the catalog and re-plan",
+                    source.data_file_id, source.delete_file_id
+                )));
+            }
+        }
+
+        let source_ids = sources
+            .iter()
+            .map(|source| source.data_file_id)
+            .collect::<Vec<_>>();
+        let source_ids = id_list(&source_ids);
+        match retirement {
+            SourceRetirement::Remove => {
+                tx.execute_batch(&format!(
+                    "INSERT INTO ducklake_files_scheduled_for_deletion
+                         (data_file_id, path, path_is_relative)
+                     SELECT df.data_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                     FROM ducklake_data_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     WHERE df.data_file_id IN ({source_ids});
+                     INSERT INTO ducklake_files_scheduled_for_deletion
+                         (data_file_id, path, path_is_relative)
+                     SELECT df.delete_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                     FROM ducklake_delete_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     WHERE df.data_file_id IN ({source_ids});
+                     DELETE FROM ducklake_delete_file WHERE data_file_id IN ({source_ids});
+                     DELETE FROM ducklake_data_file WHERE data_file_id IN ({source_ids});
+                     DELETE FROM ducklake_file_column_stats WHERE data_file_id IN ({source_ids});
+                     DELETE FROM ducklake_file_partition_value
+                     WHERE data_file_id IN ({source_ids})"
+                ))?;
+            },
+            SourceRetirement::Retire => {
+                tx.execute(
+                    &format!(
+                        "UPDATE ducklake_data_file SET end_snapshot = ?
+                         WHERE data_file_id IN ({source_ids}) AND end_snapshot IS NULL"
+                    ),
+                    params![snapshot_id],
+                )?;
+                tx.execute(
+                    &format!(
+                        "UPDATE ducklake_delete_file SET end_snapshot = ?
+                         WHERE data_file_id IN ({source_ids}) AND end_snapshot IS NULL"
+                    ),
+                    params![snapshot_id],
+                )?;
+            },
+        }
+
+        let output_count = i64::try_from(outputs.len()).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig(
+                "commit_compaction output count exceeds i64".to_string(),
+            )
+        })?;
+        let output_ids = reserve_file_ids(&tx, output_count)?;
+        for (output, data_file_id) in outputs.iter().zip(output_ids) {
+            let begin_snapshot = output.begin_snapshot.unwrap_or(snapshot_id);
+            tx.execute(
+                "INSERT INTO ducklake_data_file
+                     (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot, partial_max)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+                params![
+                    data_file_id,
+                    table_id,
+                    output.file.path.as_str(),
+                    output.file.path_is_relative,
+                    output.file.file_size_bytes,
+                    output.file.footer_size,
+                    output.file.record_count,
+                    begin_snapshot,
+                    output.partial_max,
+                ],
+            )?;
+            insert_file_column_stats(&tx, table_id, data_file_id, &output.file.column_stats)?;
+            insert_partition_metadata(&tx, table_id, data_file_id, &output.file)?;
+        }
+        seed_stats_if_missing(&tx, table_id)?;
+        tx.execute(
+            "UPDATE ducklake_table_stats SET
+                 record_count = (SELECT COALESCE(SUM(record_count), 0)
+                                 FROM ducklake_data_file
+                                 WHERE table_id = ? AND end_snapshot IS NULL),
+                 file_size_bytes = (SELECT COALESCE(SUM(file_size_bytes), 0)
+                                    FROM ducklake_data_file
+                                    WHERE table_id = ? AND end_snapshot IS NULL)
+             WHERE table_id = ?",
+            params![table_id, table_id, table_id],
+        )?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("compacted_table:{table_id}"),
+            &SnapshotCommitMetadata::new().with_message("datafusion compaction"),
+        )?;
+        let schema_id = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn retire_appends_since(&self, table_id: i64, base_snapshot: i64) -> Result<Option<i64>> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let impure_delete: Option<i64> = tx
+            .query_row(
+                "SELECT 1 FROM ducklake_delete_file
+                 WHERE table_id = ? AND begin_snapshot > ? LIMIT 1",
+                params![table_id, base_snapshot],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let impure_ended: Option<i64> = tx
+            .query_row(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND begin_snapshot <= ?
+                   AND end_snapshot IS NOT NULL AND end_snapshot > ? LIMIT 1",
+                params![table_id, base_snapshot, base_snapshot],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let impure_column: Option<i64> = tx
+            .query_row(
+                "SELECT 1 FROM ducklake_column
+                 WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?) LIMIT 1",
+                params![table_id, base_snapshot, base_snapshot],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let impure_partition: Option<i64> = tx
+            .query_row(
+                "SELECT 1 FROM ducklake_partition_info
+                 WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?) LIMIT 1",
+                params![table_id, base_snapshot, base_snapshot],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if impure_delete.is_some()
+            || impure_ended.is_some()
+            || impure_column.is_some()
+            || impure_partition.is_some()
+        {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "table {table_id}: changes since snapshot {base_snapshot} are not a pure append \
+                 (delete/replace/update or schema/partition change present); refusing to retire"
+            )));
+        }
+        let has_appended: Option<i64> = tx
+            .query_row(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot > ? LIMIT 1",
+                params![table_id, base_snapshot],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if has_appended.is_none() {
+            return Ok(None);
+        }
+        tx.execute(
+            "UPDATE ducklake_data_file SET end_snapshot = ?
+             WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot > ?",
+            params![snapshot_id, table_id, base_snapshot],
+        )?;
+        tx.execute(
+            "UPDATE ducklake_table_stats SET
+                 record_count = (SELECT COALESCE(SUM(record_count), 0)
+                                 FROM ducklake_data_file
+                                 WHERE table_id = ? AND end_snapshot IS NULL),
+                 file_size_bytes = (SELECT COALESCE(SUM(file_size_bytes), 0)
+                                    FROM ducklake_data_file
+                                    WHERE table_id = ? AND end_snapshot IS NULL)
+             WHERE table_id = ?",
+            params![table_id, table_id, table_id],
+        )?;
+        let (columns, column_ids) = live_columns_for_stats(&tx, table_id)?;
+        recompute_table_column_stats(&tx, table_id, &columns, &column_ids)?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("deleted_from_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        tx.commit()?;
+        Ok(Some(snapshot_id))
+    }
+
+    fn commit_truncate(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+    ) -> Result<u64> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let has_live_data: Option<i64> = tx
+            .query_row(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL LIMIT 1",
+                params![table_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let live_inlined = live_inlined_row_count(&tx, table_id)?;
+        if has_live_data.is_none() && live_inlined == 0 {
+            return Ok(0);
+        }
+        let gross: Option<i64> = tx
+            .query_row(
+                "SELECT record_count FROM ducklake_table_stats WHERE table_id = ?",
+                params![table_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let deleted = tx.query_row(
+            "SELECT COALESCE(SUM(delete_count), 0) FROM ducklake_delete_file
+             WHERE table_id = ? AND end_snapshot IS NULL",
+            params![table_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let live_rows = u64::try_from((gross.unwrap_or(0) - deleted).max(0)).unwrap_or(0);
+        tx.execute(
+            "UPDATE ducklake_data_file SET end_snapshot = ?
+             WHERE table_id = ? AND end_snapshot IS NULL",
+            params![snapshot_id, table_id],
+        )?;
+        for table_name in inlined_table_names(&tx, table_id)? {
+            tx.execute(
+                &format!(
+                    "UPDATE {} SET end_snapshot = ? WHERE end_snapshot IS NULL",
+                    quote_ident(&table_name)
+                ),
+                params![snapshot_id],
+            )?;
+        }
+        tx.execute(
+            "UPDATE ducklake_delete_file SET end_snapshot = ?
+             WHERE table_id = ? AND end_snapshot IS NULL",
+            params![snapshot_id, table_id],
+        )?;
+        tx.execute(
+            "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0
+             WHERE table_id = ?",
+            params![table_id],
+        )?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("deleted_from_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
+        tx.commit()?;
+        Ok(live_rows)
     }
 
     fn set_partition_spec(
@@ -1606,6 +3332,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             schema_name,
             table_name,
             mode,
+            false,
             &SnapshotCommitMetadata::default(),
         )?;
         let schema_id: i64 = tx.query_row(
@@ -1684,6 +3411,22 @@ impl MetadataWriter for DuckdbMetadataWriter {
         conn.execute_batch(
             "ALTER TABLE ducklake_metadata ADD COLUMN IF NOT EXISTS scope_id BIGINT",
         )?;
+        conn.execute_batch(
+            "ALTER TABLE ducklake_snapshot
+                 ADD COLUMN IF NOT EXISTS next_catalog_id BIGINT DEFAULT 1;
+             ALTER TABLE ducklake_snapshot
+                 ADD COLUMN IF NOT EXISTS next_file_id BIGINT DEFAULT 0;
+             ALTER TABLE ducklake_schema
+                 ADD COLUMN IF NOT EXISTS schema_uuid UUID DEFAULT uuid();
+             ALTER TABLE ducklake_table
+                 ADD COLUMN IF NOT EXISTS table_uuid UUID DEFAULT uuid();
+             ALTER TABLE ducklake_data_file
+                 ADD COLUMN IF NOT EXISTS file_order BIGINT;
+             ALTER TABLE ducklake_data_file
+                 ADD COLUMN IF NOT EXISTS file_format VARCHAR;
+             ALTER TABLE ducklake_delete_file
+                 ADD COLUMN IF NOT EXISTS format VARCHAR",
+        )?;
         // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id
         // (CREATE TABLE IF NOT EXISTS never alters an existing table). DuckDB supports
         // ADD COLUMN IF NOT EXISTS, so this is idempotent and lossless (NULL means
@@ -1692,7 +3435,9 @@ impl MetadataWriter for DuckdbMetadataWriter {
             "ALTER TABLE ducklake_data_file ADD COLUMN IF NOT EXISTS partition_id BIGINT",
         )?;
         conn.execute_batch(
-            "ALTER TABLE ducklake_snapshot_changes ALTER COLUMN changes_made DROP NOT NULL",
+            "ALTER TABLE ducklake_snapshot_changes ALTER COLUMN changes_made DROP NOT NULL;
+             ALTER TABLE ducklake_data_file ADD COLUMN IF NOT EXISTS partial_max BIGINT;
+             ALTER TABLE ducklake_delete_file ADD COLUMN IF NOT EXISTS partial_max BIGINT",
         )?;
         // Seed the monotonic column_id allocator (snapshot_id uses MAX+1, and
         // schema/table/data_file/delete_file ids use sequences, so none of those
@@ -1976,6 +3721,110 @@ mod tests {
         );
     }
 
+    fn test_writer(temp: &TempDir) -> DuckdbMetadataWriter {
+        let writer = DuckdbMetadataWriter::new_with_init(
+            temp.path().join("catalog.ducklake").to_str().unwrap(),
+        )
+        .unwrap();
+        writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
+        writer
+    }
+
+    fn int_column() -> Vec<ColumnDef> {
+        vec![ColumnDef::new("id", "int32", false).unwrap()]
+    }
+
+    fn append(
+        writer: &DuckdbMetadataWriter,
+        path: &str,
+        rows: i64,
+    ) -> (WriteSetupResult, CommitIds) {
+        let columns = int_column();
+        let setup = writer
+            .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+            .unwrap();
+        let commit = writer
+            .register_data_file(
+                setup.table_id,
+                "main",
+                "t",
+                setup.snapshot_id,
+                &DataFileInfo::new(path, rows * 10, rows),
+                WriteMode::Append,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+            )
+            .unwrap();
+        (setup, commit)
+    }
+
+    fn file_id(writer: &DuckdbMetadataWriter, path: &str) -> i64 {
+        writer
+            .connection()
+            .query_row(
+                "SELECT data_file_id FROM ducklake_data_file WHERE path = ?",
+                params![path],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    fn append_inlined(
+        writer: &DuckdbMetadataWriter,
+        values: &[i32],
+    ) -> (WriteSetupResult, CommitIds) {
+        let columns = int_column();
+        let setup = writer
+            .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+            .unwrap();
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values.to_vec()))])
+            .unwrap();
+        let commit = writer
+            .register_inlined_data(
+                setup.table_id,
+                "main",
+                "t",
+                setup.snapshot_id,
+                &[batch],
+                WriteMode::Append,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+                &SnapshotCommitMetadata::default(),
+                None,
+            )
+            .unwrap();
+        (setup, commit)
+    }
+
+    fn inlined_table(writer: &DuckdbMetadataWriter, table_id: i64) -> String {
+        writer
+            .connection()
+            .query_row(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+                params![table_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    fn changes_made(writer: &DuckdbMetadataWriter, snapshot_id: i64) -> Option<String> {
+        writer
+            .connection()
+            .query_row(
+                "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+                params![snapshot_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
     /// End-to-end round trip: write a small table through the real write path
     /// (begin_write_transaction + register_data_file), then read every catalog
     /// facet back through the DuckdbMetadataProvider and assert the snapshot,
@@ -2147,5 +3996,474 @@ mod tests {
         assert_eq!(records, 10, "record_count = 3 + 7");
         assert_eq!(next, 10, "next_row_id advances by sum of record_counts");
         assert_eq!(bytes, 350, "file_size_bytes accumulates");
+    }
+
+    #[test]
+    fn duckdb_delete_update_and_truncate_share_sqlite_semantics() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (first_setup, first_commit) = append(&writer, "source.parquet", 4);
+        let source_id = file_id(&writer, "source.parquet");
+        let first_delete = writer
+            .set_delete_file(
+                first_setup.table_id,
+                "main",
+                "t",
+                first_commit.snapshot_id + 1,
+                source_id,
+                None,
+                first_commit.snapshot_id,
+                &DeleteFileInfo::new("delete-1.parquet", 10, 1),
+            )
+            .unwrap();
+        let first_delete_id: i64 = writer
+            .connection()
+            .query_row(
+                "SELECT delete_file_id FROM ducklake_delete_file
+                 WHERE data_file_id = ? AND end_snapshot IS NULL",
+                params![source_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        let columns = int_column();
+        let update = writer
+            .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+            .unwrap();
+        let update_commit = writer
+            .register_data_file_with_deletes(
+                update.table_id,
+                "main",
+                "t",
+                update.snapshot_id,
+                &DataFileInfo::new("updated.parquet", 10, 1),
+                &[DeleteFileEntry {
+                    data_file_id: source_id,
+                    expected_prev_delete_file: Some(first_delete_id),
+                    delete: DeleteFileInfo::new("delete-2.parquet", 20, 2),
+                }],
+                WriteMode::Append,
+                update.base_snapshot_id,
+                &columns,
+                &update.column_ids,
+            )
+            .unwrap();
+        assert!(writer.supports_update());
+        assert_eq!(update_commit.snapshot_id, first_delete.snapshot_id + 1);
+        let (new_file_snapshot, old_delete_end, new_delete_snapshot): (i64, Option<i64>, i64) =
+            writer
+                .connection()
+                .query_row(
+                    "SELECT
+                    (SELECT begin_snapshot FROM ducklake_data_file WHERE path = 'updated.parquet'),
+                    (SELECT end_snapshot FROM ducklake_delete_file WHERE delete_file_id = ?),
+                    (SELECT begin_snapshot FROM ducklake_delete_file
+                     WHERE path = 'delete-2.parquet')",
+                    params![first_delete_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .unwrap();
+        assert_eq!(new_file_snapshot, update_commit.snapshot_id);
+        assert_eq!(old_delete_end, Some(update_commit.snapshot_id));
+        assert_eq!(new_delete_snapshot, update_commit.snapshot_id);
+        assert_eq!(
+            changes_made(&writer, first_delete.snapshot_id),
+            Some(format!("deleted_from_table:{}", first_setup.table_id))
+        );
+        assert_eq!(
+            changes_made(&writer, update_commit.snapshot_id),
+            Some(format!(
+                "deleted_from_table:{0},inserted_into_table:{0}",
+                first_setup.table_id
+            ))
+        );
+
+        let removed = writer
+            .commit_truncate(first_setup.table_id, "main", "t", update_commit.snapshot_id)
+            .unwrap();
+        assert_eq!(removed, 3);
+        let state: (i64, i64, i64) = writer
+            .connection()
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL),
+                    (SELECT COUNT(*) FROM ducklake_delete_file WHERE end_snapshot IS NULL),
+                    (SELECT record_count FROM ducklake_table_stats WHERE table_id = ?)",
+                params![first_setup.table_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(state, (0, 0, 0));
+    }
+
+    #[test]
+    fn duckdb_compaction_removes_sources_and_records_output() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, first) = append(&writer, "a.parquet", 2);
+        let (_, second) = append(&writer, "b.parquet", 3);
+        let sources = [
+            CompactionSourceFile {
+                data_file_id: file_id(&writer, "a.parquet"),
+                delete_file_id: None,
+            },
+            CompactionSourceFile {
+                data_file_id: file_id(&writer, "b.parquet"),
+                delete_file_id: None,
+            },
+        ];
+        let output = CompactionOutputFile {
+            file: DataFileInfo::new("merged.parquet", 45, 5),
+            begin_snapshot: Some(first.snapshot_id),
+            partial_max: Some(second.snapshot_id),
+        };
+        let commit = writer
+            .commit_compaction(
+                setup.table_id,
+                second.snapshot_id,
+                &sources,
+                &[output],
+                SourceRetirement::Remove,
+            )
+            .unwrap();
+        let state: (i64, i64, Option<i64>, Option<i64>, i64, String) = writer
+            .connection()
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM ducklake_data_file),
+                    (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion),
+                    (SELECT row_id_start FROM ducklake_data_file WHERE path = 'merged.parquet'),
+                    (SELECT partial_max FROM ducklake_data_file WHERE path = 'merged.parquet'),
+                    (SELECT record_count FROM ducklake_table_stats WHERE table_id = ?),
+                    (SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?)",
+                params![setup.table_id, commit.snapshot_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            state,
+            (
+                1,
+                2,
+                None,
+                Some(second.snapshot_id),
+                5,
+                format!("compacted_table:{}", setup.table_id),
+            )
+        );
+    }
+
+    #[test]
+    fn duckdb_restore_retires_only_the_append_delta() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, base) = append(&writer, "base.parquet", 2);
+        append(&writer, "appended.parquet", 3);
+        let restore = writer
+            .retire_appends_since(setup.table_id, base.snapshot_id)
+            .unwrap()
+            .unwrap();
+        let state: (Option<i64>, Option<i64>, i64, i64) = writer
+            .connection()
+            .query_row(
+                "SELECT
+                    (SELECT end_snapshot FROM ducklake_data_file WHERE path = 'base.parquet'),
+                    (SELECT end_snapshot FROM ducklake_data_file WHERE path = 'appended.parquet'),
+                    (SELECT record_count FROM ducklake_table_stats WHERE table_id = ?),
+                    (SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?)",
+                params![setup.table_id, setup.table_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(state, (None, Some(restore), 2, 5));
+        assert_eq!(
+            writer
+                .retire_appends_since(setup.table_id, base.snapshot_id)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn duckdb_promotes_column_with_stable_identity() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, _) = append(&writer, "a.parquet", 1);
+        let old_column_id: i64 = writer
+            .connection()
+            .query_row(
+                "SELECT column_id FROM ducklake_column WHERE end_snapshot IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let snapshot = writer
+            .promote_column_type(setup.table_id, "id", "int64")
+            .unwrap();
+        let versions: Vec<(i64, String, i64, Option<i64>)> = {
+            let conn = writer.connection();
+            let mut statement = conn
+                .prepare(
+                    "SELECT column_id, column_type, begin_snapshot, end_snapshot
+                     FROM ducklake_column ORDER BY begin_snapshot",
+                )
+                .unwrap();
+            statement
+                .query_map([], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+                })
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert_eq!(
+            versions,
+            vec![
+                (old_column_id, "int32".to_string(), 1, Some(snapshot)),
+                (old_column_id, "int64".to_string(), snapshot, None),
+            ]
+        );
+        assert!(
+            writer
+                .promote_column_type(setup.table_id, "id", "int16")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn duckdb_expiry_keeps_head_and_schedules_unreachable_files() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, first) = append(&writer, "a.parquet", 2);
+        writer
+            .commit_truncate(setup.table_id, "main", "t", first.snapshot_id)
+            .unwrap();
+        let head: i64 = writer
+            .connection()
+            .query_row(
+                "SELECT MAX(snapshot_id) FROM ducklake_snapshot",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let expired = writer
+            .expire_snapshots(ExpireCriteria::Versions(vec![first.snapshot_id, head]))
+            .unwrap();
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].snapshot_id, first.snapshot_id);
+        let state: (i64, i64, i64) = writer
+            .connection()
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM ducklake_snapshot),
+                    (SELECT COUNT(*) FROM ducklake_data_file),
+                    (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(state, (1, 0, 1));
+    }
+
+    #[test]
+    fn duckdb_truncate_ends_inline_only_table() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, commit) = append_inlined(&writer, &[1, 2]);
+        let removed = writer
+            .commit_truncate(setup.table_id, "main", "t", commit.snapshot_id)
+            .unwrap();
+        assert_eq!(removed, 2, "the two inline rows are the whole live table");
+        let truncate_snapshot = commit.snapshot_id + 1;
+        let physical = inlined_table(&writer, setup.table_id);
+        let (head, live, ended, record_count): (i64, i64, i64, i64) = writer
+            .connection()
+            .query_row(
+                &format!(
+                    "SELECT
+                        (SELECT MAX(snapshot_id) FROM ducklake_snapshot),
+                        (SELECT COUNT(*) FROM {physical} WHERE end_snapshot IS NULL),
+                        (SELECT COUNT(*) FROM {physical} WHERE end_snapshot = {truncate_snapshot}),
+                        (SELECT record_count FROM ducklake_table_stats WHERE table_id = {})",
+                    setup.table_id
+                ),
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (head, live, ended, record_count),
+            (truncate_snapshot, 0, 2, 0)
+        );
+        assert_eq!(
+            changes_made(&writer, truncate_snapshot),
+            Some(format!("deleted_from_table:{}", setup.table_id))
+        );
+        // Nothing left to truncate: idempotent no-op with no new snapshot.
+        assert_eq!(
+            writer
+                .commit_truncate(setup.table_id, "main", "t", truncate_snapshot)
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn duckdb_truncate_retires_files_and_ends_inline_rows() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, _) = append(&writer, "base.parquet", 3);
+        let (_, inline_commit) = append_inlined(&writer, &[10, 11]);
+        let removed = writer
+            .commit_truncate(setup.table_id, "main", "t", inline_commit.snapshot_id)
+            .unwrap();
+        assert_eq!(removed, 5, "3 parquet rows + 2 inline rows");
+        let truncate_snapshot = inline_commit.snapshot_id + 1;
+        let physical = inlined_table(&writer, setup.table_id);
+        let (file_end, live_inline, ended_inline, record_count): (Option<i64>, i64, i64, i64) =
+            writer
+                .connection()
+                .query_row(
+                    &format!(
+                        "SELECT
+                            (SELECT end_snapshot FROM ducklake_data_file
+                             WHERE path = 'base.parquet'),
+                            (SELECT COUNT(*) FROM {physical} WHERE end_snapshot IS NULL),
+                            (SELECT COUNT(*) FROM {physical}
+                             WHERE end_snapshot = {truncate_snapshot}),
+                            (SELECT record_count FROM ducklake_table_stats WHERE table_id = {})",
+                        setup.table_id
+                    ),
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .unwrap();
+        assert_eq!(
+            (file_end, live_inline, ended_inline, record_count),
+            (Some(truncate_snapshot), 0, 2, 0)
+        );
+        assert_eq!(
+            changes_made(&writer, truncate_snapshot),
+            Some(format!("deleted_from_table:{}", setup.table_id))
+        );
+    }
+
+    #[test]
+    fn duckdb_commit_deletes_mixes_positional_and_inlined_in_one_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, _) = append(&writer, "base.parquet", 3);
+        let (_, inline_commit) = append_inlined(&writer, &[10, 11]);
+        let source_id = file_id(&writer, "base.parquet");
+        let physical = inlined_table(&writer, setup.table_id);
+        // Inline rows follow the parquet file's 3 rows: row_ids 3 and 4.
+        let commit = writer
+            .commit_deletes(
+                setup.table_id,
+                "main",
+                "t",
+                inline_commit.snapshot_id,
+                &[DeleteFileEntry {
+                    data_file_id: source_id,
+                    expected_prev_delete_file: None,
+                    delete: DeleteFileInfo::new("delete-1.parquet", 10, 1),
+                }],
+                &[InlinedRowRef {
+                    table_name: physical.clone(),
+                    row_id: 3,
+                }],
+            )
+            .unwrap();
+        assert_eq!(commit.snapshot_id, inline_commit.snapshot_id + 1);
+        let (delete_begin, deleted_inline_end, other_inline_end, record_count): (
+            i64,
+            Option<i64>,
+            Option<i64>,
+            i64,
+        ) = writer
+            .connection()
+            .query_row(
+                &format!(
+                    "SELECT
+                        (SELECT begin_snapshot FROM ducklake_delete_file
+                         WHERE path = 'delete-1.parquet'),
+                        (SELECT end_snapshot FROM {physical} WHERE row_id = 3),
+                        (SELECT end_snapshot FROM {physical} WHERE row_id = 4),
+                        (SELECT record_count FROM ducklake_table_stats WHERE table_id = {})",
+                    setup.table_id
+                ),
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(delete_begin, commit.snapshot_id);
+        assert_eq!(deleted_inline_end, Some(commit.snapshot_id));
+        assert_eq!(other_inline_end, None);
+        assert_eq!(
+            record_count, 4,
+            "only the inline delete adjusts the gross count"
+        );
+        assert_eq!(
+            changes_made(&writer, commit.snapshot_id),
+            Some(format!("deleted_from_table:{}", setup.table_id))
+        );
+    }
+
+    #[test]
+    fn duckdb_positional_delete_snapshot_records_changes_made() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let (setup, base) = append(&writer, "a.parquet", 2);
+        let commit = writer
+            .commit_positional_deletes(
+                setup.table_id,
+                "main",
+                "t",
+                base.snapshot_id,
+                &[DeleteFileEntry {
+                    data_file_id: file_id(&writer, "a.parquet"),
+                    expected_prev_delete_file: None,
+                    delete: DeleteFileInfo::new("d.parquet", 10, 1),
+                }],
+            )
+            .unwrap();
+        assert_eq!(
+            changes_made(&writer, commit.snapshot_id),
+            Some(format!("deleted_from_table:{}", setup.table_id))
+        );
+    }
+
+    #[test]
+    fn duckdb_first_write_commits_after_abandoned_staging() {
+        let temp = TempDir::new().unwrap();
+        let writer = test_writer(&temp);
+        let columns = int_column();
+        // Stage the table but never write: it persists with zero live columns.
+        let staged = writer
+            .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+            .unwrap();
+        // The next write's commit creates the columns rather than conflicting.
+        let (setup, commit) = append(&writer, "a.parquet", 2);
+        assert_eq!(setup.table_id, staged.table_id);
+        assert_eq!(commit.snapshot_id, 1, "abandoned staging left no snapshot");
+        let live_columns: i64 = writer
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM ducklake_column
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+                params![setup.table_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(live_columns, 1);
     }
 }

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -2,13 +2,12 @@
 //!
 //! Single-catalog only — the legacy DuckLake v1.0 layout, mirroring
 //! [`crate::metadata_writer_sqlite::SqliteMetadataWriter`] rather than the
-//! multicatalog Postgres writer. It supports the write primitives the crate's
-//! table-write path needs (INSERT / REPLACE / CREATE TABLE) and deliberately
-//! does NOT support deletes, upserts, compaction, partitioning, type promotion,
-//! or multiple catalogs: [`MetadataWriter::promote_column_type`] and
-//! [`MetadataWriter::set_delete_file`] inherit their erroring defaults, and
-//! [`MetadataWriter::catalog_id`] inherits the `None` default (which keeps
-//! newly-written file paths in the `{data_path}/{schema}/{table}/…` layout).
+//! multicatalog Postgres writer. It supports the crate's write primitives,
+//! inlined data, positional deletes, updates, compaction, truncate, append
+//! restoration, type promotion, partition and sort metadata, and snapshot
+//! expiry. Multiple catalogs remain specific to PostgreSQL;
+//! [`MetadataWriter::catalog_id`] inherits the `None` default and keeps file
+//! paths in the `{data_path}/{schema}/{table}/…` layout.
 //!
 //! Requires a multi-threaded Tokio runtime (`#[tokio::test(flavor =
 //! "multi_thread")]`): the sync trait methods bridge async sqlx via
@@ -16,10 +15,12 @@
 //!
 //! ## MySQL dialect adaptations vs the SQLite template
 //!
-//! 1. **No `RETURNING`.** Auto-increment PK ids (`schema_id`, `table_id`,
-//!    `data_file_id`) are read back with `MySqlQueryResult::last_insert_id()`;
-//!    counter-allocated ids (`column_id`, `snapshot_id`) are read back with an
-//!    `UPDATE` followed by a `SELECT` in the same transaction (`reserve_ids`).
+//! 1. **No `RETURNING`.** Auto-increment PK ids (`schema_id`, `table_id`) are
+//!    read back with `MySqlQueryResult::last_insert_id()`; counter-allocated ids
+//!    (`column_id`, `snapshot_id`, `data_file_id`, `delete_file_id`) are read
+//!    back with an `UPDATE` followed by a `SELECT` in the same transaction
+//!    (`reserve_ids`). File ids come exclusively from the counters — never from
+//!    auto-increment — so every insert path shares one id space per table.
 //! 2. **DDL type mapping.** `INTEGER`→`BIGINT`, bounded names→`VARCHAR(1024)`,
 //!    long/path values→`TEXT`, `BOOLEAN`→`TINYINT(1)`. Every table is InnoDB so
 //!    transactions + `SELECT … FOR UPDATE`-style row locks actually serialize.
@@ -32,19 +33,187 @@
 
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
+use crate::maintenance::{ExpireCriteria, ExpiredSnapshot, format_sql_timestamp};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, ExistingCatalogColumn, MetadataWriter,
-    SnapshotCommitMetadata, WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs,
-    catalog_column_type_equal, catalog_column_type_requires_migration, catalog_columns_differ,
-    quote_snapshot_name, quote_snapshot_table, table_write_changes, top_level_column_ids,
-    validate_name,
+    ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
+    DeleteFileEntry, DeleteFileInfo, ExistingCatalogColumn, InlinedRowRef, MetadataWriter,
+    SnapshotCommitMetadata, SourceRetirement, WriteMode, WriteSetupResult, assign_column_ids,
+    catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
+    catalog_columns_differ, quote_snapshot_name, quote_snapshot_table, table_write_changes,
+    top_level_column_ids, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, BooleanArray, FixedSizeBinaryArray, Int8Array, Int16Array,
+    Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, StringArray, UInt8Array,
+    UInt16Array, UInt32Array,
+};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
 use sqlx::Row;
-use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
+use sqlx::mysql::{MySql, MySqlPool, MySqlPoolOptions};
+use sqlx::{AssertSqlSafe, QueryBuilder};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+fn id_list(ids: &[i64]) -> String {
+    ids.iter()
+        .map(i64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+const RESOLVED_PATH: &str = "CASE
+    WHEN NOT df.path_is_relative THEN df.path
+    WHEN NOT t.path_is_relative THEN CONCAT(t.path, '/', df.path)
+    ELSE CONCAT(s.path, '/', t.path, '/', df.path)
+END";
+
+const REL_FLAG: &str =
+    "(CASE WHEN df.path_is_relative AND t.path_is_relative AND s.path_is_relative
+           THEN 1 ELSE 0 END)";
+
+fn quote_ident(name: &str) -> String {
+    format!("`{}`", name.replace('`', "``"))
+}
+
+fn inlined_mysql_type(data_type: &DataType) -> &'static str {
+    match data_type {
+        DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32 => "BIGINT",
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => "LONGBLOB",
+        DataType::FixedSizeBinary(size) if *size != 16 => "LONGBLOB",
+        _ => "LONGTEXT",
+    }
+}
+
+/// Scalar types the MySQL inline path preserves through catalog normalization.
+/// Nested values remain on the Parquet path until their SQL representation has
+/// a matching parser.
+fn mysql_type_inlines(data_type: &DataType) -> bool {
+    crate::metadata_writer::scalar_type_supports_inlining(data_type)
+}
+
+fn push_inlined_mysql_value(
+    query: &mut QueryBuilder<MySql>,
+    array: &dyn Array,
+    row: usize,
+) -> Result<()> {
+    if array.is_null(row) {
+        query.push_bind(Option::<String>::None);
+        return Ok(());
+    }
+    macro_rules! signed {
+        ($array:ty) => {{
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<$array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row) as i64,
+            );
+        }};
+    }
+    macro_rules! unsigned {
+        ($array:ty) => {{
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<$array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row) as i64,
+            );
+        }};
+    }
+    match array.data_type() {
+        DataType::Boolean => {
+            let value = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row);
+            query.push_bind(i64::from(value));
+        },
+        DataType::Int8 => signed!(Int8Array),
+        DataType::Int16 => signed!(Int16Array),
+        DataType::Int32 => signed!(Int32Array),
+        DataType::Int64 => signed!(Int64Array),
+        DataType::UInt8 => unsigned!(UInt8Array),
+        DataType::UInt16 => unsigned!(UInt16Array),
+        DataType::UInt32 => unsigned!(UInt32Array),
+        DataType::Utf8 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_owned(),
+            );
+        },
+        DataType::LargeUtf8 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_owned(),
+            );
+        },
+        DataType::Binary => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        DataType::LargeBinary => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<LargeBinaryArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        DataType::BinaryView => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<BinaryViewArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        DataType::FixedSizeBinary(size) if *size != 16 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        _ => {
+            query.push_bind(crate::metadata_writer::inlined_text_value(array, row)?);
+        },
+    }
+    Ok(())
+}
 
 /// The DuckLake v1.0 catalog tables in MySQL dialect, one `CREATE TABLE` per
 /// entry. sqlx runs each `query()` as a single prepared statement on MySQL
@@ -54,10 +223,13 @@ const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 /// Columns and their order match the SQLite writer's `SQL_CREATE_SCHEMA` (and so
 /// upstream DuckLake) for catalog compatibility; only the SQL types are mapped
 /// to MySQL. Auto-increment PKs back the ids read via `last_insert_id()`
-/// (`schema_id`/`table_id`/`data_file_id`/`delete_file_id`). `snapshot_id` is a
-/// plain PK assigned from the `next_snapshot_id` counter, and `ducklake_column`
-/// is a bare table (no PK) so a versioned column can hold multiple rows sharing
-/// a `column_id`.
+/// (`schema_id`/`table_id`). `data_file_id`/`delete_file_id` keep their
+/// auto-increment declarations for pre-existing-catalog compatibility, but every
+/// insert passes an explicit id from the `next_file_id`/`next_delete_file_id`
+/// counters so the update/delete/compaction paths and appends share one id
+/// space. `snapshot_id` is a plain PK assigned from the `next_snapshot_id`
+/// counter, and `ducklake_column` is a bare table (no PK) so a versioned column
+/// can hold multiple rows sharing a `column_id`.
 const SQL_CREATE_TABLES: &[&str] = &[
     r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
         `key` VARCHAR(1024) NOT NULL,
@@ -100,11 +272,6 @@ const SQL_CREATE_TABLES: &[&str] = &[
         begin_snapshot BIGINT NOT NULL,
         end_snapshot BIGINT
     ) ENGINE = InnoDB"#,
-    // Bare table (no PRIMARY KEY), mirroring upstream `ducklake_column`: a column
-    // is versioned by `[begin_snapshot, end_snapshot)` and — although this writer
-    // never promotes types — the shape stays identical to SQLite/upstream so
-    // catalogs interoperate. The four `*default*` columns and `parent_column` are
-    // left NULL (no nested-type / column-default writes).
     r#"CREATE TABLE IF NOT EXISTS ducklake_view (
         view_id BIGINT,
         view_uuid VARCHAR(36),
@@ -116,6 +283,9 @@ const SQL_CREATE_TABLES: &[&str] = &[
         `sql` TEXT,
         column_aliases TEXT
     ) ENGINE = InnoDB"#,
+    // Bare table (no PRIMARY KEY), mirroring upstream `ducklake_column`: a column
+    // is versioned by `[begin_snapshot, end_snapshot)`, so type promotion can
+    // preserve its field id while retiring the prior version.
     r#"CREATE TABLE IF NOT EXISTS ducklake_column (
         column_id BIGINT,
         begin_snapshot BIGINT,
@@ -144,6 +314,7 @@ const SQL_CREATE_TABLES: &[&str] = &[
         mapping_id BIGINT,
         begin_snapshot BIGINT NOT NULL,
         end_snapshot BIGINT,
+        partial_max BIGINT,
         partition_id BIGINT
     ) ENGINE = InnoDB"#,
     // Per-table row-lineage + running totals. `next_row_id` allocates rowids
@@ -154,6 +325,11 @@ const SQL_CREATE_TABLES: &[&str] = &[
         record_count BIGINT NOT NULL DEFAULT 0,
         next_row_id BIGINT NOT NULL DEFAULT 0,
         file_size_bytes BIGINT NOT NULL DEFAULT 0
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
+        table_id BIGINT NOT NULL,
+        table_name VARCHAR(1024) NOT NULL,
+        schema_version BIGINT NOT NULL
     ) ENGINE = InnoDB"#,
     // Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
     // min/max use TEXT (bounds can be up to the encoder's length cap). Column
@@ -180,8 +356,8 @@ const SQL_CREATE_TABLES: &[&str] = &[
         max_value TEXT,
         extra_stats TEXT
     ) ENGINE = InnoDB"#,
-    // Created for catalog-shape parity and so the provider's LEFT JOINs resolve;
-    // this writer never inserts delete files (`set_delete_file` is unsupported).
+    // Delete files registered by the UPDATE/DELETE paths; ids come from the
+    // next_delete_file_id counter (the auto-increment is never consulted).
     r#"CREATE TABLE IF NOT EXISTS ducklake_delete_file (
         delete_file_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
         data_file_id BIGINT NOT NULL,
@@ -193,7 +369,8 @@ const SQL_CREATE_TABLES: &[&str] = &[
         encryption_key VARCHAR(1024),
         delete_count BIGINT,
         begin_snapshot BIGINT NOT NULL,
-        end_snapshot BIGINT
+        end_snapshot BIGINT,
+        partial_max BIGINT
     ) ENGINE = InnoDB"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
         data_file_id BIGINT NOT NULL,
@@ -280,6 +457,195 @@ impl MySqlMetadataWriter {
         writer.initialize_schema()?;
         Ok(writer)
     }
+
+    /// Expire snapshots and remove catalog rows no longer reachable from a
+    /// surviving snapshot. Physical files are queued for later cleanup.
+    pub fn expire_snapshots(&self, criteria: ExpireCriteria) -> Result<Vec<ExpiredSnapshot>> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let most_recent: Option<i64> =
+                sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+                    .fetch_one(&mut *tx)
+                    .await?;
+            let Some(most_recent) = most_recent else {
+                tx.commit().await?;
+                return Ok(Vec::new());
+            };
+            let rows = match criteria {
+                ExpireCriteria::Versions(versions) => {
+                    let versions = versions
+                        .into_iter()
+                        .filter(|snapshot| *snapshot != 0 && *snapshot != most_recent)
+                        .collect::<Vec<_>>();
+                    if versions.is_empty() {
+                        tx.commit().await?;
+                        return Ok(Vec::new());
+                    }
+                    sqlx::query(AssertSqlSafe(format!(
+                        "SELECT snapshot_id, CAST(snapshot_time AS CHAR)
+                         FROM ducklake_snapshot WHERE snapshot_id IN ({}) ORDER BY snapshot_id",
+                        id_list(&versions)
+                    )))
+                    .fetch_all(&mut *tx)
+                    .await?
+                },
+                ExpireCriteria::OlderThan(cutoff) => {
+                    sqlx::query(
+                        "SELECT snapshot_id, CAST(snapshot_time AS CHAR)
+                         FROM ducklake_snapshot
+                         WHERE snapshot_id != 0 AND snapshot_id != ? AND snapshot_time < ? ORDER BY snapshot_id",
+                    )
+                    .bind(most_recent)
+                    .bind(format_sql_timestamp(&cutoff))
+                    .fetch_all(&mut *tx)
+                    .await?
+                },
+            };
+            let candidates = rows
+                .into_iter()
+                .map(|row| {
+                    Ok(ExpiredSnapshot {
+                        snapshot_id: row.try_get(0)?,
+                        snapshot_time: row.try_get(1)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            if candidates.is_empty() {
+                tx.commit().await?;
+                return Ok(Vec::new());
+            }
+            let expire_ids = candidates
+                .iter()
+                .map(|snapshot| snapshot.snapshot_id)
+                .collect::<Vec<_>>();
+            sqlx::query(AssertSqlSafe(format!(
+                "DELETE FROM ducklake_snapshot WHERE snapshot_id IN ({})",
+                id_list(&expire_ids)
+            )))
+            .execute(&mut *tx)
+            .await?;
+            let dead_tables = sqlx::query(
+                "SELECT t.table_id FROM ducklake_table t
+                 WHERE t.end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= t.begin_snapshot AND snapshot_id < t.end_snapshot)
+                 AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_table t2
+                     WHERE t2.table_id = t.table_id
+                       AND (t2.end_snapshot IS NULL OR EXISTS (
+                           SELECT 1 FROM ducklake_snapshot
+                           WHERE snapshot_id >= t2.begin_snapshot
+                             AND snapshot_id < t2.end_snapshot)))",
+            )
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get::<i64, _>(0))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+            let dead_table_filter = if dead_tables.is_empty() {
+                "false".to_string()
+            } else {
+                format!("df.table_id IN ({})", id_list(&dead_tables))
+            };
+            let dead_data_files = sqlx::query(AssertSqlSafe(format!(
+                "SELECT df.data_file_id FROM ducklake_data_file df
+                 WHERE ({dead_table_filter}) OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
+            )))
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get::<i64, _>(0))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+            if !dead_data_files.is_empty() {
+                let ids = id_list(&dead_data_files);
+                sqlx::query(AssertSqlSafe(format!(
+                    "INSERT INTO ducklake_files_scheduled_for_deletion
+                         (data_file_id, path, path_is_relative)
+                     SELECT df.data_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                     FROM ducklake_data_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     WHERE df.data_file_id IN ({ids})"
+                )))
+                .execute(&mut *tx)
+                .await?;
+                sqlx::query(AssertSqlSafe(format!(
+                    "DELETE FROM ducklake_data_file WHERE data_file_id IN ({ids})"
+                )))
+                .execute(&mut *tx)
+                .await?;
+            }
+            let dead_data_filter = if dead_data_files.is_empty() {
+                "false".to_string()
+            } else {
+                format!("df.data_file_id IN ({})", id_list(&dead_data_files))
+            };
+            let dead_delete_table_filter = if dead_tables.is_empty() {
+                "false".to_string()
+            } else {
+                format!("df.table_id IN ({})", id_list(&dead_tables))
+            };
+            let dead_delete_files = sqlx::query(AssertSqlSafe(format!(
+                "SELECT df.delete_file_id FROM ducklake_delete_file df
+                 WHERE ({dead_data_filter}) OR ({dead_delete_table_filter})
+                    OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                        SELECT 1 FROM ducklake_snapshot
+                        WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
+            )))
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get::<i64, _>(0))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+            if !dead_delete_files.is_empty() {
+                let ids = id_list(&dead_delete_files);
+                sqlx::query(AssertSqlSafe(format!(
+                    "INSERT INTO ducklake_files_scheduled_for_deletion
+                         (data_file_id, path, path_is_relative)
+                     SELECT df.delete_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                     FROM ducklake_delete_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     WHERE df.delete_file_id IN ({ids})"
+                )))
+                .execute(&mut *tx)
+                .await?;
+                sqlx::query(AssertSqlSafe(format!(
+                    "DELETE FROM ducklake_delete_file WHERE delete_file_id IN ({ids})"
+                )))
+                .execute(&mut *tx)
+                .await?;
+            }
+            if !dead_tables.is_empty() {
+                let ids = id_list(&dead_tables);
+                for table in [
+                    "ducklake_table",
+                    "ducklake_table_stats",
+                    "ducklake_column",
+                    "ducklake_schema_versions",
+                ] {
+                    sqlx::query(AssertSqlSafe(format!(
+                        "DELETE FROM {table} WHERE table_id IN ({ids})"
+                    )))
+                    .execute(&mut *tx)
+                    .await?;
+                }
+            }
+            sqlx::query(
+                "DELETE FROM ducklake_schema
+                 WHERE end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= ducklake_schema.begin_snapshot
+                       AND snapshot_id < ducklake_schema.end_snapshot)",
+            )
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(candidates)
+        })
+    }
 }
 
 /// Atomically reserve `n` consecutive ids from a monotonic counter stored in
@@ -316,11 +682,27 @@ async fn reserve_ids(
     Ok(last)
 }
 
+async fn reserve_file_ids(tx: &mut sqlx::Transaction<'_, sqlx::MySql>, n: i64) -> Result<Vec<i64>> {
+    let last = reserve_ids(tx, "next_file_id", n).await?;
+    Ok(((last - n + 1)..=last).collect())
+}
+
+async fn reserve_delete_file_ids(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    n: i64,
+) -> Result<Vec<i64>> {
+    let last = reserve_ids(tx, "next_delete_file_id", n).await?;
+    Ok(((last - n + 1)..=last).collect())
+}
+
 /// Seed a monotonic id counter row if it does not already exist, starting from
 /// the current MAX of its backing column so a pre-existing catalog keeps
-/// allocating without reuse. Done as check-then-insert (two statements) rather
-/// than `INSERT … SELECT … WHERE NOT EXISTS`, because that self-referential
-/// `INSERT … SELECT` against `ducklake_metadata` is rejected by MySQL (1093).
+/// allocating without reuse; an existing counter is raised to that MAX if it
+/// fell behind (the file-id counters of a catalog written before the writer
+/// unified on explicit ids sit below the auto-increment-assigned MAX). Done as
+/// check-then-insert (two statements) rather than `INSERT … SELECT … WHERE NOT
+/// EXISTS`, because that self-referential `INSERT … SELECT` against
+/// `ducklake_metadata` is rejected by MySQL (1093).
 async fn seed_counter(pool: &MySqlPool, key: &str, max_sql: &'static str) -> Result<()> {
     let exists: i64 =
         sqlx::query("SELECT COUNT(*) FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL")
@@ -328,13 +710,23 @@ async fn seed_counter(pool: &MySqlPool, key: &str, max_sql: &'static str) -> Res
             .fetch_one(pool)
             .await?
             .try_get(0)?;
+    let start: i64 = sqlx::query(max_sql).fetch_one(pool).await?.try_get(0)?;
     if exists == 0 {
-        let start: i64 = sqlx::query(max_sql).fetch_one(pool).await?.try_get(0)?;
         sqlx::query("INSERT INTO ducklake_metadata (`key`, `value`, scope) VALUES (?, ?, NULL)")
             .bind(key)
             .bind(start.to_string())
             .execute(pool)
             .await?;
+    } else {
+        sqlx::query(
+            "UPDATE ducklake_metadata
+             SET `value` = CAST(GREATEST(CAST(`value` AS SIGNED), ?) AS CHAR)
+             WHERE `key` = ? AND scope IS NULL",
+        )
+        .bind(start)
+        .bind(key)
+        .execute(pool)
+        .await?;
     }
     Ok(())
 }
@@ -369,6 +761,30 @@ async fn detect_replace_conflict(
              snapshot {base_snapshot}; aborting (retry the write against the new generation)"
         )));
     }
+    let inlined_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inlined_tables {
+        let table_name: String = row.try_get(0)?;
+        let sql = format!(
+            "SELECT 1 FROM {} WHERE begin_snapshot > ? OR end_snapshot > ? LIMIT 1",
+            quote_ident(&table_name)
+        );
+        if sqlx::query(AssertSqlSafe(sql))
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut **tx)
+            .await?
+            .is_some()
+        {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "Replace on table {table_id} conflicts with inlined data committed since \
+                 snapshot {base_snapshot}; aborting"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -376,6 +792,57 @@ async fn detect_replace_conflict(
 /// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard spares
 /// files registered for *this* snapshot, so a multi-file write does not retire
 /// its own siblings. `next_row_id` is left untouched (rowids stay monotonic).
+async fn detect_new_inlined_deletes(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    base_snapshot: i64,
+    data_file_ids: &[i64],
+) -> Result<()> {
+    if data_file_ids.is_empty() {
+        return Ok(());
+    }
+
+    let table = crate::metadata_provider::inlined_delete_table_name(table_id)?;
+    let exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.tables
+         WHERE table_schema = DATABASE() AND table_name = ?",
+    )
+    .bind(&table)
+    .fetch_one(&mut **tx)
+    .await?;
+    if exists == 0 {
+        return Ok(());
+    }
+
+    let conflict: i64 = sqlx::query_scalar(AssertSqlSafe(format!(
+        "SELECT COUNT(*) FROM {} newer
+         WHERE newer.file_id IN ({})
+           AND (newer.begin_snapshot IS NULL OR (
+             newer.begin_snapshot > ?
+             AND (newer.row_id IS NULL OR NOT EXISTS (
+               SELECT 1 FROM {} prior
+               WHERE prior.file_id = newer.file_id
+                 AND prior.row_id = newer.row_id
+                 AND prior.begin_snapshot <= ?
+             ))
+           ))",
+        quote_ident(&table),
+        id_list(data_file_ids),
+        quote_ident(&table),
+    )))
+    .bind(base_snapshot)
+    .bind(base_snapshot)
+    .fetch_one(&mut **tx)
+    .await?;
+    if conflict > 0 {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "table {table_id} gained an inlined delete on a source file since snapshot \
+             {base_snapshot}; re-open the catalog and re-plan"
+        )));
+    }
+    Ok(())
+}
+
 async fn retire_prior_generation(
     tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
     table_id: i64,
@@ -390,6 +857,25 @@ async fn retire_prior_generation(
     .bind(snapshot_id)
     .execute(&mut **tx)
     .await?;
+
+    let inlined_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inlined_tables {
+        let table_name: String = row.try_get(0)?;
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? \
+             WHERE end_snapshot IS NULL AND begin_snapshot < ?",
+            quote_ident(&table_name)
+        );
+        sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
+    }
 
     sqlx::query(
         "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = ?",
@@ -471,6 +957,7 @@ async fn record_snapshot_changes(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn record_table_write_changes(
     tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
     snapshot_id: i64,
@@ -478,6 +965,7 @@ async fn record_table_write_changes(
     schema_name: &str,
     table_name: &str,
     mode: WriteMode,
+    has_deletes: bool,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
     let row = sqlx::query(
@@ -502,7 +990,7 @@ async fn record_table_write_changes(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
-    let replaced_existing_data: bool = sqlx::query_scalar(
+    let mut replaced_existing_data: bool = sqlx::query_scalar(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
             WHERE table_id = ? AND end_snapshot = ?
@@ -512,6 +1000,29 @@ async fn record_table_write_changes(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
+    if !replaced_existing_data {
+        // A Replace over inline-only prior data ends inline rows, not files.
+        let inlined_tables: Vec<String> = sqlx::query_scalar(
+            "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_all(&mut **tx)
+        .await?;
+        for inlined_table in inlined_tables {
+            let sql = format!(
+                "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot = ?)",
+                quote_ident(&inlined_table)
+            );
+            if sqlx::query_scalar(AssertSqlSafe(sql))
+                .bind(snapshot_id)
+                .fetch_one(&mut **tx)
+                .await?
+            {
+                replaced_existing_data = true;
+                break;
+            }
+        }
+    }
 
     let mut changes = Vec::new();
     if schema_begin_snapshot == snapshot_id {
@@ -531,7 +1042,7 @@ async fn record_table_write_changes(
     changes.push(table_write_changes(
         table_id,
         mode,
-        false,
+        has_deletes,
         replaced_existing_data,
     ));
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
@@ -653,6 +1164,176 @@ async fn insert_partition_metadata(
         .bind(value.clone())
         .execute(&mut **tx)
         .await?;
+    }
+    Ok(())
+}
+
+async fn live_columns_for_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+) -> Result<(Vec<ColumnDef>, Vec<i64>)> {
+    let rows = sqlx::query(
+        "SELECT column_id, column_name, column_type
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut columns = Vec::with_capacity(rows.len());
+    let mut column_ids = Vec::with_capacity(rows.len());
+    for row in rows {
+        column_ids.push(row.try_get(0)?);
+        columns.push(ColumnDef::new(
+            row.try_get::<String, _>(1)?,
+            row.try_get::<String, _>(2)?,
+            true,
+        )?);
+    }
+    Ok((columns, column_ids))
+}
+
+async fn apply_delete_entry(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    base_snapshot: i64,
+    snapshot_id: i64,
+    entry: &DeleteFileEntry,
+) -> Result<()> {
+    let target_live: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM ducklake_data_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(entry.data_file_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if target_live.is_none() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "UPDATE/DELETE on data file {} could not commit: the file is no longer live as of \
+             the catalog's current head (retired since snapshot {base_snapshot}); re-open the \
+             catalog at the latest snapshot and retry",
+            entry.data_file_id
+        )));
+    }
+    let current_delete: Option<i64> = sqlx::query_scalar(
+        "SELECT delete_file_id FROM ducklake_delete_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(entry.data_file_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if current_delete != entry.expected_prev_delete_file {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "UPDATE/DELETE on data file {} could not commit: its live delete file changed from \
+             {:?} to {current_delete:?} since snapshot {base_snapshot}; re-open the catalog at \
+             the latest snapshot and retry",
+            entry.data_file_id, entry.expected_prev_delete_file
+        )));
+    }
+    if let Some(delete_file_id) = entry.expected_prev_delete_file {
+        sqlx::query(
+            "UPDATE ducklake_delete_file SET end_snapshot = ?
+             WHERE delete_file_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(snapshot_id)
+        .bind(delete_file_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+    let delete_file_id = reserve_delete_file_ids(tx, 1).await?[0];
+    sqlx::query(
+        "INSERT INTO ducklake_delete_file
+             (delete_file_id, data_file_id, table_id, path, path_is_relative,
+              file_size_bytes, footer_size, delete_count, begin_snapshot)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(delete_file_id)
+    .bind(entry.data_file_id)
+    .bind(table_id)
+    .bind(&entry.delete.path)
+    .bind(entry.delete.path_is_relative)
+    .bind(entry.delete.file_size_bytes)
+    .bind(entry.delete.footer_size)
+    .bind(entry.delete.delete_count)
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// The physical `ducklake_inlined_data_*` tables registered for the table.
+/// Mirrors the SQLite writer's `inlined_table_names`.
+async fn inlined_table_names(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+) -> Result<Vec<String>> {
+    let rows =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    rows.into_iter().map(|row| Ok(row.try_get(0)?)).collect()
+}
+
+/// Count the table's still-visible inlined rows across its registered physical
+/// tables. Mirrors the SQLite writer's `live_inlined_row_count`.
+async fn live_inlined_row_count(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+) -> Result<i64> {
+    let mut total = 0;
+    for table_name in inlined_table_names(tx, table_id).await? {
+        let sql = format!(
+            "SELECT COUNT(*) FROM {} WHERE end_snapshot IS NULL",
+            quote_ident(&table_name)
+        );
+        total += sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
+            .fetch_one(&mut **tx)
+            .await?;
+    }
+    Ok(total)
+}
+
+/// End the referenced inlined rows at `snapshot_id`, fencing each against
+/// `base_snapshot`. Mirrors the SQLite writer's `apply_inlined_deletes`
+/// (used by the combined `commit_deletes` path).
+async fn apply_inlined_deletes(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    snapshot_id: i64,
+    base_snapshot: i64,
+    rows: &[InlinedRowRef],
+) -> Result<()> {
+    let registered = inlined_table_names(tx, table_id)
+        .await?
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    for row in rows {
+        if !registered.contains(&row.table_name) {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} belongs to an unregistered table '{}'",
+                row.row_id, row.table_name
+            )));
+        }
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? \
+             WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+            quote_ident(&row.table_name)
+        );
+        let affected = sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(row.row_id)
+            .bind(base_snapshot)
+            .execute(&mut **tx)
+            .await?
+            .rows_affected();
+        if affected != 1 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                row.row_id, row.table_name
+            )));
+        }
     }
     Ok(())
 }
@@ -926,6 +1607,9 @@ async fn finalize_snapshot(
 }
 
 impl MetadataWriter for MySqlMetadataWriter {
+    fn supports_update(&self) -> bool {
+        true
+    }
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;
@@ -1034,6 +1718,87 @@ impl MetadataWriter for MySqlMetadataWriter {
             .await?;
             tx.commit().await?;
             Ok((result.last_insert_id() as i64, true))
+        })
+    }
+
+    fn promote_column_type(
+        &self,
+        table_id: i64,
+        column_name: &str,
+        new_ducklake_type: &str,
+    ) -> Result<i64> {
+        crate::types::ducklake_to_arrow_type(new_ducklake_type)?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _carried) = insert_snapshot(&mut tx).await?;
+            let row = sqlx::query(
+                "SELECT column_id, column_type, column_order, nulls_allowed
+                 FROM ducklake_column
+                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .bind(column_name)
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or_else(|| {
+                crate::DuckLakeError::InvalidConfig(format!(
+                    "promote_column_type: no live column '{column_name}' in table {table_id}"
+                ))
+            })?;
+            let column_id: i64 = row.try_get("column_id")?;
+            let current_type: String = row.try_get("column_type")?;
+            let column_order: i64 = row.try_get("column_order")?;
+            let nulls_allowed = row
+                .try_get::<Option<bool>, _>("nulls_allowed")?
+                .unwrap_or(true);
+            if crate::types::types_equal_canonical(&current_type, new_ducklake_type) {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "promote_column_type: column '{column_name}' is already type '{current_type}' (no change)"
+                )));
+            }
+            if !crate::types::is_promotable(&current_type, new_ducklake_type) {
+                return Err(crate::DuckLakeError::UnsupportedTypeChange {
+                    operation: TypeChangeOperation::PromoteColumnType,
+                    column: column_name.to_string(),
+                    from: current_type,
+                    to: new_ducklake_type.to_string(),
+                });
+            }
+            let schema_version = bump_schema_version(&mut tx, snapshot_id).await?;
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = ?
+                 WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(column_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_column
+                     (column_id, begin_snapshot, end_snapshot, table_id, column_order,
+                      column_name, column_type, nulls_allowed)
+                 VALUES (?, ?, NULL, ?, ?, ?, ?, ?)",
+            )
+            .bind(column_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(column_order)
+            .bind(column_name)
+            .bind(new_ducklake_type)
+            .bind(nulls_allowed)
+            .execute(&mut *tx)
+            .await?;
+            record_schema_version(&mut tx, snapshot_id, schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
+            Ok(snapshot_id)
         })
     }
 
@@ -1203,12 +1968,17 @@ impl MetadataWriter for MySqlMetadataWriter {
                     .await?
                     .try_get(0)?;
 
-            let inserted = sqlx::query(
+            // The id comes from the shared next_file_id counter (never the
+            // auto-increment), so appends and the update/delete/compaction paths
+            // allocate from one id space and cannot collide on the PK.
+            let data_file_id = reserve_file_ids(&mut tx, 1).await?[0];
+            sqlx::query(
                 "INSERT INTO ducklake_data_file
-                     (table_id, path, path_is_relative, file_size_bytes,
+                     (data_file_id, table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
+            .bind(data_file_id)
             .bind(table_id)
             .bind(&file.path)
             .bind(file.path_is_relative)
@@ -1220,9 +1990,7 @@ impl MetadataWriter for MySqlMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            // MySQL has no RETURNING: the auto-increment PK is read via
-            // last_insert_id(). Persist the file's zone maps + refresh the roll-up.
-            let data_file_id = inserted.last_insert_id() as i64;
+            // Persist the file's zone maps + refresh the roll-up.
             insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
             insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
             recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
@@ -1250,6 +2018,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 schema_name,
                 table_name,
                 mode,
+                false,
                 commit_metadata,
             )
             .await?;
@@ -1356,13 +2125,22 @@ impl MetadataWriter for MySqlMetadataWriter {
                     .try_get(0)?;
             let mut total_records: i64 = 0;
             let mut total_bytes: i64 = 0;
-            for file in files {
-                let inserted = sqlx::query(
-                    "INSERT INTO ducklake_data_file
-                         (table_id, path, path_is_relative, file_size_bytes,
-                          footer_size, record_count, row_id_start, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            let file_count = i64::try_from(files.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "register_data_files file count exceeds i64".to_string(),
                 )
+            })?;
+            // Explicit ids from the shared next_file_id counter (never the
+            // auto-increment) keep every insert path in one id space.
+            let data_file_ids = reserve_file_ids(&mut tx, file_count).await?;
+            for (file, data_file_id) in files.iter().zip(data_file_ids) {
+                sqlx::query(
+                    "INSERT INTO ducklake_data_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, record_count, row_id_start, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(data_file_id)
                 .bind(table_id)
                 .bind(&file.path)
                 .bind(file.path_is_relative)
@@ -1373,7 +2151,6 @@ impl MetadataWriter for MySqlMetadataWriter {
                 .bind(snapshot_id)
                 .execute(&mut *tx)
                 .await?;
-                let data_file_id = inserted.last_insert_id() as i64;
                 insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats)
                     .await?;
                 insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
@@ -1402,6 +2179,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 schema_name,
                 table_name,
                 mode,
+                false,
                 commit_metadata,
             )
             .await?;
@@ -1411,6 +2189,952 @@ impl MetadataWriter for MySqlMetadataWriter {
                     .fetch_one(&mut *tx)
                     .await?
                     .try_get(0)?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn supports_data_inlining(&self, schema: &arrow::datatypes::Schema) -> bool {
+        schema
+            .fields()
+            .iter()
+            .all(|field| mysql_type_inlines(field.data_type()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_delete_file(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        data_file_id: i64,
+        expected_prev_delete_file: Option<i64>,
+        base_snapshot: i64,
+        delete: &DeleteFileInfo,
+    ) -> Result<CommitIds> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            apply_delete_entry(
+                &mut tx,
+                table_id,
+                base_snapshot,
+                snapshot_id,
+                &DeleteFileEntry {
+                    data_file_id,
+                    expected_prev_delete_file,
+                    delete: delete.clone(),
+                },
+            )
+            .await?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        validate_delete_entries(mode, deletes)?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+            let data_file_ids = deletes
+                .iter()
+                .map(|entry| entry.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &data_file_ids).await?;
+            let live_partition_id: Option<i64> = sqlx::query_scalar(
+                "SELECT partition_id FROM ducklake_partition_info
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+            sqlx::query(
+                "INSERT IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let row_id_start: i64 = sqlx::query_scalar(
+                "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let data_file_id = reserve_file_ids(&mut tx, 1).await?[0];
+            sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(data_file_id)
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(row_id_start)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id = next_row_id + ?, record_count = record_count + ?,
+                     file_size_bytes = file_size_bytes + ? WHERE table_id = ?",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            for entry in deletes {
+                apply_delete_entry(&mut tx, table_id, base_snapshot, snapshot_id, entry).await?;
+            }
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                !deletes.is_empty(),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_positional_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        deletes: &[DeleteFileEntry],
+    ) -> Result<CommitIds> {
+        if deletes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_positional_deletes requires at least one delete entry".to_string(),
+            ));
+        }
+        validate_delete_entries(WriteMode::Append, deletes)?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let data_file_ids = deletes
+                .iter()
+                .map(|entry| entry.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &data_file_ids).await?;
+            for entry in deletes {
+                apply_delete_entry(&mut tx, table_id, base_snapshot, snapshot_id, entry).await?;
+            }
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        base_snapshot: i64,
+        positional: &[DeleteFileEntry],
+        inlined: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        // Mixed positional + inlined DELETE in ONE snapshot/transaction,
+        // mirroring the SQLite writer's override (the trait default refuses the
+        // combination). Single-form deletes keep their dedicated paths.
+        if inlined.is_empty() {
+            return self.commit_positional_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                positional,
+            );
+        }
+        if positional.is_empty() {
+            return self.commit_inlined_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                inlined,
+            );
+        }
+        validate_delete_entries(WriteMode::Append, positional)?;
+        if inlined
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined.len()
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_deletes contains duplicate inlined rows".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let data_file_ids = positional
+                .iter()
+                .map(|entry| entry.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &data_file_ids).await?;
+            for entry in positional {
+                apply_delete_entry(&mut tx, table_id, base_snapshot, snapshot_id, entry).await?;
+            }
+            apply_inlined_deletes(&mut tx, table_id, snapshot_id, base_snapshot, inlined).await?;
+            let deleted = i64::try_from(inlined.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "commit_deletes row count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+            )
+            .bind(deleted)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_compaction(
+        &self,
+        table_id: i64,
+        base_snapshot: i64,
+        sources: &[CompactionSourceFile],
+        outputs: &[CompactionOutputFile],
+        retirement: SourceRetirement,
+    ) -> Result<CommitIds> {
+        if sources.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_compaction requires at least one source file".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let source_ids = sources
+                .iter()
+                .map(|source| source.data_file_id)
+                .collect::<Vec<_>>();
+            detect_new_inlined_deletes(&mut tx, table_id, base_snapshot, &source_ids).await?;
+            for source in sources {
+                let live: Option<i64> = sqlx::query_scalar(
+                    "SELECT 1 FROM ducklake_data_file
+                     WHERE data_file_id = ? AND table_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(source.data_file_id)
+                .bind(table_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if live.is_none() {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "compaction of table {table_id} could not commit: source data file {} is \
+                         no longer live since snapshot {base_snapshot}; re-open the catalog and \
+                         re-plan",
+                        source.data_file_id
+                    )));
+                }
+                let current_delete: Option<i64> = sqlx::query_scalar(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(source.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if current_delete != source.delete_file_id {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "compaction of table {table_id} could not commit: the live delete file \
+                         of source data file {} changed from {:?} to {current_delete:?} since \
+                         snapshot {base_snapshot}; re-open the catalog and re-plan",
+                        source.data_file_id, source.delete_file_id
+                    )));
+                }
+            }
+            let source_ids = sources
+                .iter()
+                .map(|source| source.data_file_id)
+                .collect::<Vec<_>>();
+            let source_ids = id_list(&source_ids);
+            match retirement {
+                SourceRetirement::Remove => {
+                    for query in [
+                        format!(
+                            "INSERT INTO ducklake_files_scheduled_for_deletion
+                                 (data_file_id, path, path_is_relative)
+                             SELECT df.data_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                             FROM ducklake_data_file df
+                             JOIN ducklake_table t ON t.table_id = df.table_id
+                             JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                             WHERE df.data_file_id IN ({source_ids})"
+                        ),
+                        format!(
+                            "INSERT INTO ducklake_files_scheduled_for_deletion
+                                 (data_file_id, path, path_is_relative)
+                             SELECT df.delete_file_id, {RESOLVED_PATH}, {REL_FLAG}
+                             FROM ducklake_delete_file df
+                             JOIN ducklake_table t ON t.table_id = df.table_id
+                             JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                             WHERE df.data_file_id IN ({source_ids})"
+                        ),
+                    ] {
+                        sqlx::query(AssertSqlSafe(query)).execute(&mut *tx).await?;
+                    }
+                    for table in [
+                        "ducklake_delete_file",
+                        "ducklake_data_file",
+                        "ducklake_file_column_stats",
+                        "ducklake_file_partition_value",
+                    ] {
+                        sqlx::query(AssertSqlSafe(format!(
+                            "DELETE FROM {table} WHERE data_file_id IN ({source_ids})"
+                        )))
+                        .execute(&mut *tx)
+                        .await?;
+                    }
+                },
+                SourceRetirement::Retire => {
+                    for table in ["ducklake_data_file", "ducklake_delete_file"] {
+                        sqlx::query(AssertSqlSafe(format!(
+                            "UPDATE {table} SET end_snapshot = ?
+                             WHERE data_file_id IN ({source_ids}) AND end_snapshot IS NULL"
+                        )))
+                        .bind(snapshot_id)
+                        .execute(&mut *tx)
+                        .await?;
+                    }
+                },
+            }
+            let output_count = i64::try_from(outputs.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "commit_compaction output count exceeds i64".to_string(),
+                )
+            })?;
+            let output_ids = reserve_file_ids(&mut tx, output_count).await?;
+            for (output, data_file_id) in outputs.iter().zip(output_ids) {
+                let begin_snapshot = output.begin_snapshot.unwrap_or(snapshot_id);
+                sqlx::query(
+                    "INSERT INTO ducklake_data_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, record_count, row_id_start, begin_snapshot, partial_max)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+                )
+                .bind(data_file_id)
+                .bind(table_id)
+                .bind(&output.file.path)
+                .bind(output.file.path_is_relative)
+                .bind(output.file.file_size_bytes)
+                .bind(output.file.footer_size)
+                .bind(output.file.record_count)
+                .bind(begin_snapshot)
+                .bind(output.partial_max)
+                .execute(&mut *tx)
+                .await?;
+                insert_file_column_stats(
+                    &mut tx,
+                    table_id,
+                    data_file_id,
+                    &output.file.column_stats,
+                )
+                .await?;
+                insert_partition_metadata(&mut tx, table_id, data_file_id, &output.file).await?;
+            }
+            sqlx::query(
+                "INSERT IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET
+                     record_count = (SELECT COALESCE(SUM(record_count), 0)
+                                     FROM ducklake_data_file
+                                     WHERE table_id = ? AND end_snapshot IS NULL),
+                     file_size_bytes = (SELECT COALESCE(SUM(file_size_bytes), 0)
+                                        FROM ducklake_data_file
+                                        WHERE table_id = ? AND end_snapshot IS NULL)
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .bind(table_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("compacted_table:{table_id}"),
+                &SnapshotCommitMetadata::new().with_message("datafusion compaction"),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn retire_appends_since(&self, table_id: i64, base_snapshot: i64) -> Result<Option<i64>> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let impure_delete: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_delete_file
+                 WHERE table_id = ? AND begin_snapshot > ? LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_ended: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND begin_snapshot <= ?
+                   AND end_snapshot IS NOT NULL AND end_snapshot > ? LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_column: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_column
+                 WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?) LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_partition: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_partition_info
+                 WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?) LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if impure_delete.is_some()
+                || impure_ended.is_some()
+                || impure_column.is_some()
+                || impure_partition.is_some()
+            {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "table {table_id}: changes since snapshot {base_snapshot} are not a pure \
+                     append (delete/replace/update or schema/partition change present); refusing \
+                     to retire"
+                )));
+            }
+            let has_appended: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot > ? LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if has_appended.is_none() {
+                return Ok(None);
+            }
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot > ?",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(base_snapshot)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET
+                     record_count = (SELECT COALESCE(SUM(record_count), 0)
+                                     FROM ducklake_data_file
+                                     WHERE table_id = ? AND end_snapshot IS NULL),
+                     file_size_bytes = (SELECT COALESCE(SUM(file_size_bytes), 0)
+                                        FROM ducklake_data_file
+                                        WHERE table_id = ? AND end_snapshot IS NULL)
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .bind(table_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let (columns, column_ids) = live_columns_for_stats(&mut tx, table_id).await?;
+            recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
+            Ok(Some(snapshot_id))
+        })
+    }
+
+    fn commit_truncate(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+    ) -> Result<u64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let has_live_data: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL LIMIT 1",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let live_inlined = live_inlined_row_count(&mut tx, table_id).await?;
+            if has_live_data.is_none() && live_inlined == 0 {
+                return Ok(0);
+            }
+            let gross: Option<i64> = sqlx::query_scalar(
+                "SELECT record_count FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let deleted: i64 = sqlx::query_scalar(
+                "SELECT CAST(COALESCE(SUM(delete_count), 0) AS SIGNED)
+                 FROM ducklake_delete_file
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let live_rows = (gross.unwrap_or(0) - deleted).max(0) as u64;
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            for table_name in inlined_table_names(&mut tx, table_id).await? {
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = ? WHERE end_snapshot IS NULL",
+                    quote_ident(&table_name)
+                );
+                sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
+            Ok(live_rows)
+        })
+    }
+
+    fn register_inlined_data(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        batches: &[RecordBatch],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        if record_count == 0 {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: batches must contain at least one row".to_string(),
+            ));
+        }
+        if batches
+            .iter()
+            .any(|batch| batch.num_columns() != columns.len())
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: batch schema does not match table columns".to_string(),
+            ));
+        }
+
+        block_on(async {
+            // MySQL DDL implicitly commits the surrounding transaction, so the
+            // physical inline table must exist BEFORE the write transaction
+            // opens (CREATE TABLE IF NOT EXISTS is idempotent, and an existing
+            // physical table without registry rows is inert). Its name embeds
+            // the schema version the commit will allocate, which is only known
+            // inside the transaction — predict it, and when the commit resolves
+            // a different version (a schema change in this write), roll back,
+            // create the table for the observed version, and retry once.
+            let mut create_for: Option<i64> = None;
+            let mut settled = None;
+            for _ in 0..3 {
+                let version_to_create = match create_for {
+                    Some(version) => version,
+                    None => {
+                        sqlx::query_scalar(
+                            "SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot",
+                        )
+                        .fetch_one(&self.pool)
+                        .await?
+                    },
+                };
+                let physical_name = format!("ducklake_inlined_data_{table_id}_{version_to_create}");
+                let mut ddl = format!(
+                    "CREATE TABLE IF NOT EXISTS {} (\
+                     row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+                    quote_ident(&physical_name)
+                );
+                for (column, field) in columns.iter().zip(batches[0].schema().fields()) {
+                    ddl.push_str(", ");
+                    ddl.push_str(&quote_ident(column.name()));
+                    ddl.push(' ');
+                    ddl.push_str(inlined_mysql_type(field.data_type()));
+                }
+                ddl.push_str(") ENGINE = InnoDB");
+                sqlx::query(AssertSqlSafe(ddl)).execute(&self.pool).await?;
+
+                let mut tx = self.pool.begin().await?;
+                let snapshot_id =
+                    finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                        .await?;
+                if mode != WriteMode::Replace
+                    && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+                {
+                    detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+                }
+                let schema_version: i64 = sqlx::query_scalar(
+                    "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+                )
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                if schema_version != version_to_create {
+                    tx.rollback().await?;
+                    create_for = Some(schema_version);
+                    continue;
+                }
+                settled = Some((tx, snapshot_id, schema_version, physical_name));
+                break;
+            }
+            let Some((mut tx, snapshot_id, schema_version, physical_name)) = settled else {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "register_inlined_data on table {table_id} could not settle on a schema \
+                     version for the inline table; retry the write"
+                )));
+            };
+            sqlx::query(
+                "INSERT INTO ducklake_inlined_data_tables
+                     (table_id, table_name, schema_version)
+                 SELECT ?, ?, ? FROM DUAL
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM ducklake_inlined_data_tables
+                     WHERE table_id = ? AND schema_version = ?)",
+            )
+            .bind(table_id)
+            .bind(&physical_name)
+            .bind(schema_version)
+            .bind(table_id)
+            .bind(schema_version)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let mut row_id: i64 = sqlx::query_scalar(
+                "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            let column_list = columns
+                .iter()
+                .map(|column| quote_ident(column.name()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            for batch in batches {
+                for batch_row in 0..batch.num_rows() {
+                    let mut query = QueryBuilder::<MySql>::new(format!(
+                        "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) VALUES (",
+                        quote_ident(&physical_name),
+                        column_list
+                    ));
+                    query.push_bind(row_id);
+                    query.push(", ").push_bind(snapshot_id);
+                    query.push(", NULL");
+                    for array in batch.columns() {
+                        query.push(", ");
+                        push_inlined_mysql_value(&mut query, array.as_ref(), batch_row)?;
+                    }
+                    query.push(')');
+                    query.build().execute(&mut *tx).await?;
+                    row_id += 1;
+                }
+            }
+
+            let record_count = i64::try_from(record_count).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "register_inlined_data: record count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id = next_row_id + ?, record_count = record_count + ?
+                 WHERE table_id = ?",
+            )
+            .bind(record_count)
+            .bind(record_count)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            // The same composed ledger recording the Parquet path uses: DDL
+            // entries plus the write change, appended rather than clobbered.
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                false,
+                commit_metadata,
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_inlined_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        rows: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        if rows.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes requires at least one row".to_string(),
+            ));
+        }
+        if rows.iter().collect::<std::collections::HashSet<_>>().len() != rows.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes contains duplicate rows".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let registered = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get(0))
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+            for row in rows {
+                if !registered.contains(&row.table_name) {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} belongs to an unregistered table '{}'",
+                        row.row_id, row.table_name
+                    )));
+                }
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = ? \
+                     WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+                    quote_ident(&row.table_name)
+                );
+                let affected = sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .bind(row.row_id)
+                    .bind(base_snapshot)
+                    .execute(&mut *tx)
+                    .await?
+                    .rows_affected();
+                if affected != 1 {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                        row.row_id, row.table_name
+                    )));
+                }
+            }
+            let deleted = i64::try_from(rows.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "commit_inlined_deletes row count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+            )
+            .bind(deleted)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
             tx.commit().await?;
             Ok(CommitIds {
                 snapshot_id,
@@ -1753,6 +3477,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 schema_name,
                 table_name,
                 mode,
+                false,
                 &SnapshotCommitMetadata::default(),
             )
             .await?;
@@ -1933,6 +3658,23 @@ impl MetadataWriter for MySqlMetadataWriter {
                     .execute(&self.pool)
                     .await?;
             }
+            for table in ["ducklake_data_file", "ducklake_delete_file"] {
+                let has_partial_max: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM information_schema.columns
+                     WHERE table_schema = DATABASE() AND table_name = ?
+                       AND column_name = 'partial_max'",
+                )
+                .bind(table)
+                .fetch_one(&self.pool)
+                .await?;
+                if has_partial_max == 0 {
+                    sqlx::query(AssertSqlSafe(format!(
+                        "ALTER TABLE {table} ADD COLUMN partial_max BIGINT"
+                    )))
+                    .execute(&self.pool)
+                    .await?;
+                }
+            }
             // Seed the monotonic id allocators. snapshot_id and column_id are
             // reserved inside a transaction and read back (no RETURNING and no
             // auto-increment for these), so they live in ducklake_metadata. Seeded
@@ -1948,6 +3690,18 @@ impl MetadataWriter for MySqlMetadataWriter {
                 &self.pool,
                 "next_snapshot_id",
                 "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+            )
+            .await?;
+            seed_counter(
+                &self.pool,
+                "next_file_id",
+                "SELECT COALESCE(MAX(data_file_id), 0) FROM ducklake_data_file",
+            )
+            .await?;
+            seed_counter(
+                &self.pool,
+                "next_delete_file_id",
+                "SELECT COALESCE(MAX(delete_file_id), 0) FROM ducklake_delete_file",
             )
             .await?;
             seed_counter(
@@ -2089,7 +3843,7 @@ impl MetadataWriter for MySqlMetadataWriter {
 
             // Data-write policy (§5): a data write — Replace OR Append — must NOT
             // change a column's type (that is schema evolution and must go through
-            // promote_column_type, which this backend does not support). The
+            // promote_column_type). The
             // comparison is canonical (`int64` ≡ `bigint`) so an alias-only
             // restatement is a no-op. Append additionally requires a genuinely new
             // column to be nullable.
@@ -2154,5 +3908,27 @@ impl MetadataWriter for MySqlMetadataWriter {
                 field_ids,
             })
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mysql_inlined_types_follow_sqlite_style_encodings() {
+        assert_eq!(inlined_mysql_type(&DataType::Int32), "BIGINT");
+        assert_eq!(inlined_mysql_type(&DataType::UInt64), "LONGTEXT");
+        assert_eq!(inlined_mysql_type(&DataType::Float64), "LONGTEXT");
+        assert_eq!(inlined_mysql_type(&DataType::Binary), "LONGBLOB");
+        assert_eq!(
+            inlined_mysql_type(&DataType::FixedSizeBinary(16)),
+            "LONGTEXT"
+        );
+        assert_eq!(
+            inlined_mysql_type(&DataType::FixedSizeBinary(32)),
+            "LONGBLOB"
+        );
+        assert_eq!(inlined_mysql_type(&DataType::Date32), "LONGTEXT");
     }
 }

--- a/tests/it/cdc_differential_tests.rs
+++ b/tests/it/cdc_differential_tests.rs
@@ -62,8 +62,7 @@ fn official_connection(path: &Path) -> DataFusionResult<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
-    conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
-        .map_err(box_err)?;
+    crate::common::attach_catalog_without_inlining(&conn, path, "c").map_err(box_err)?;
     Ok(conn)
 }
 

--- a/tests/it/cdc_rowid_tests.rs
+++ b/tests/it/cdc_rowid_tests.rs
@@ -27,8 +27,7 @@ fn write_catalog(path: &std::path::Path, statements: &[&str]) -> DataFusionResul
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
-    conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
-        .map_err(box_err)?;
+    crate::common::attach_catalog_without_inlining(&conn, path, "c").map_err(box_err)?;
     for s in statements {
         conn.execute(s, []).map_err(box_err)?;
     }

--- a/tests/it/column_defaults_tests.rs
+++ b/tests/it/column_defaults_tests.rs
@@ -28,6 +28,7 @@ fn create_official_default_catalog(path: &Path) -> Result<Vec<(i32, i32)>> {
         &format!("ATTACH 'ducklake:{}' AS official", path.display()),
         [],
     )?;
+    conn.execute("CALL official.set_option('data_inlining_row_limit', 0)", [])?;
     conn.execute("CREATE TABLE official.items (id INTEGER)", [])?;
     conn.execute("INSERT INTO official.items VALUES (1), (2)", [])?;
     conn.execute(

--- a/tests/it/common/mod.rs
+++ b/tests/it/common/mod.rs
@@ -49,6 +49,21 @@ pub fn ensure_ducklake_installed() {
     ensure_extension_installed("parquet");
 }
 
+pub fn attach_catalog_without_inlining(
+    connection: &duckdb::Connection,
+    path: &Path,
+    catalog: &str,
+) -> duckdb::Result<()> {
+    connection.execute(
+        &format!(
+            "ATTACH 'ducklake:{}' AS {catalog} (DATA_INLINING_ROW_LIMIT 0);",
+            path.display()
+        ),
+        [],
+    )?;
+    Ok(())
+}
+
 /// Creates a catalog with a simple table (no deletes)
 ///
 /// Table schema:
@@ -70,8 +85,7 @@ pub fn create_catalog_no_deletes(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.users (
@@ -110,8 +124,7 @@ pub fn create_catalog_with_deletes(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.products (
@@ -156,8 +169,7 @@ pub fn create_catalog_with_updates(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.inventory (
@@ -211,8 +223,7 @@ pub fn create_catalog_filter_pushdown(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.items (
@@ -249,8 +260,7 @@ pub fn create_catalog_empty_table(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.tbl (
@@ -279,8 +289,7 @@ pub fn create_catalog_basic_test(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     // Create first table: test(i INTEGER, j INTEGER)
     conn.execute(
@@ -331,8 +340,7 @@ pub fn create_catalog_complex_deletions(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     // Create table
     conn.execute(
@@ -377,8 +385,7 @@ pub fn create_catalog_multiple_snapshots(catalog_path: &Path) -> Result<()> {
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     // Snapshot 1: Create table and insert first batch
     conn.execute(

--- a/tests/it/compaction_duckdb_tests.rs
+++ b/tests/it/compaction_duckdb_tests.rs
@@ -1,0 +1,154 @@
+//! DuckDB file provenance and safe compaction.
+
+#![cfg(all(feature = "write-duckdb", feature = "metadata-duckdb"))]
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{Int32Array, Int64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, DuckdbMetadataProvider,
+    DuckdbMetadataWriter, MergeOptions, MetadataProvider, MetadataWriter,
+};
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn duckdb_compaction_retains_origin_metadata_and_rows() {
+    let temp = TempDir::new().unwrap();
+    let database = temp.path().join("catalog.ducklake");
+    let writer = Arc::new(DuckdbMetadataWriter::new_with_init(database.to_str().unwrap()).unwrap());
+    writer
+        .set_data_path(temp.path().join("data").to_str().unwrap())
+        .unwrap();
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let table_writer =
+        DuckLakeTableWriter::new(writer.clone(), Arc::new(LocalFileSystem::new())).unwrap();
+    let mut snapshots = Vec::new();
+    let mut table_id = 0;
+    for index in 0..3 {
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![index * 2, index * 2 + 1]))],
+        )
+        .unwrap();
+        let result = if index == 0 {
+            table_writer
+                .write_table("main", "events", &[batch])
+                .await
+                .unwrap()
+        } else {
+            table_writer
+                .append_table("main", "events", &[batch])
+                .await
+                .unwrap()
+        };
+        table_id = result.table_id;
+        snapshots.push(result.snapshot_id);
+    }
+    let provider = Arc::new(DuckdbMetadataProvider::new(database.to_string_lossy()).unwrap());
+    let files = provider
+        .get_table_files_for_select(table_id, *snapshots.last().unwrap())
+        .unwrap();
+    assert_eq!(
+        files
+            .iter()
+            .map(|file| file.begin_snapshot)
+            .collect::<Vec<_>>(),
+        snapshots.iter().copied().map(Some).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        files
+            .iter()
+            .map(|file| file.schema_version)
+            .collect::<Vec<_>>(),
+        vec![Some(1); 3]
+    );
+
+    let catalog = DuckLakeCatalog::with_writer(provider.clone(), writer).unwrap();
+    let context = SessionContext::new();
+    context.register_catalog("lake", Arc::new(catalog));
+    let table_provider = context
+        .catalog("lake")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table("events")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn Any)
+        .downcast_ref::<DuckLakeTable>()
+        .unwrap();
+    let options = MergeOptions {
+        target_file_size: 1 << 20,
+        ..Default::default()
+    };
+    let result = table
+        .merge_adjacent_files(&context.state(), options)
+        .await
+        .unwrap();
+    assert_eq!(
+        (
+            result.files_processed,
+            result.files_created,
+            result.rows_written
+        ),
+        (3, 1, 6)
+    );
+    let fresh = Arc::new(DuckdbMetadataProvider::new(database.to_string_lossy()).unwrap());
+    let current = fresh.get_current_snapshot().unwrap();
+    let files = fresh.get_table_files_for_select(table_id, current).unwrap();
+    assert_eq!(current, snapshots.last().unwrap() + 1);
+    assert_eq!(files.len(), 1);
+    assert_eq!(
+        (
+            files[0].begin_snapshot,
+            files[0].schema_version,
+            files[0].partial_max
+        ),
+        (Some(snapshots[0]), Some(1), snapshots.last().copied()),
+    );
+    assert_eq!(
+        read_rows(DuckLakeCatalog::with_snapshot(fresh.clone(), current).unwrap()).await,
+        vec![(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
+    );
+    assert_eq!(
+        read_rows(DuckLakeCatalog::with_snapshot(fresh.clone(), snapshots[0]).unwrap()).await,
+        vec![(0, 0), (1, 1)]
+    );
+    assert_eq!(
+        read_rows(DuckLakeCatalog::with_snapshot(fresh, snapshots[1]).unwrap()).await,
+        vec![(0, 0), (1, 1), (2, 2), (3, 3)]
+    );
+}
+
+async fn read_rows(catalog: DuckLakeCatalog) -> Vec<(i32, i64)> {
+    let context = SessionContext::new();
+    context.register_catalog("lake", Arc::new(catalog.with_row_lineage(true)));
+    let batches = context
+        .sql("SELECT id, rowid FROM lake.main.events ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let rowids = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        rows.extend((0..batch.num_rows()).map(|index| (ids.value(index), rowids.value(index))));
+    }
+    rows
+}

--- a/tests/it/hybrid_asyncdb.rs
+++ b/tests/it/hybrid_asyncdb.rs
@@ -75,7 +75,7 @@ impl HybridDuckLakeDB {
 
         let ducklake_path = format!("ducklake:{}", catalog_path.display());
         let attach_sql = format!(
-            "ATTACH '{}' AS ducklake (DATA_PATH '{}')",
+            "ATTACH '{}' AS ducklake (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 0)",
             ducklake_path,
             data_path.display()
         );

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -23,6 +23,7 @@ mod cdc_rowid_tests;
 mod column_defaults_tests;
 mod column_stats_tests;
 mod common;
+mod compaction_duckdb_tests;
 mod compaction_postgres_tests;
 mod compaction_sqlite_tests;
 mod concurrent_staged_upload_tests;

--- a/tests/it/mysql_metadata_writer_test.rs
+++ b/tests/it/mysql_metadata_writer_test.rs
@@ -9,15 +9,108 @@
 //! as `tests/it/mysql_metadata_provider_test.rs`: it is ignored under
 //! `skip-tests-with-docker` on macOS (Docker unavailable there).
 
-use arrow::datatypes::{DataType, Field};
+use arrow::array::Int32Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion_ducklake::maintenance::ExpireCriteria;
+use datafusion_ducklake::metadata_writer::InlinedRowRef;
 use datafusion_ducklake::{
-    ColumnDef, DataFileInfo, MetadataProvider, MetadataWriter, MySqlMetadataProvider,
-    MySqlMetadataWriter, SnapshotCommitMetadata, WriteMode,
+    ColumnDef, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
+    DeleteFileEntry, DeleteFileInfo, MetadataProvider, MetadataWriter, MySqlMetadataProvider,
+    MySqlMetadataWriter, SnapshotCommitMetadata, SourceRetirement, WriteMode, WriteSetupResult,
 };
-use sqlx::Row;
+use sqlx::{AssertSqlSafe, Row};
 use std::sync::Arc;
+use testcontainers::ContainerAsync;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mysql::Mysql;
+
+/// Start a throwaway MySQL and open an initialized writer against it. The
+/// container is returned so it stays alive for the test's duration.
+async fn start_writer() -> (ContainerAsync<Mysql>, MySqlMetadataWriter, sqlx::MySqlPool) {
+    let container = Mysql::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(3306).await.unwrap();
+    let conn_str = format!("mysql://root@127.0.0.1:{port}/test");
+    let writer = MySqlMetadataWriter::new_with_init(&conn_str).await.unwrap();
+    writer.set_data_path("file:///tmp/ducklake_data/").unwrap();
+    let pool = sqlx::MySqlPool::connect(&conn_str).await.unwrap();
+    (container, writer, pool)
+}
+
+fn int_column() -> Vec<ColumnDef> {
+    vec![ColumnDef::new("id", "int32", false).unwrap()]
+}
+
+fn append(writer: &MySqlMetadataWriter, path: &str, rows: i64) -> (WriteSetupResult, CommitIds) {
+    let columns = int_column();
+    let setup = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    let commit = writer
+        .register_data_file(
+            setup.table_id,
+            "main",
+            "t",
+            setup.snapshot_id,
+            &DataFileInfo::new(path, rows * 10, rows),
+            WriteMode::Append,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    (setup, commit)
+}
+
+fn append_inlined(writer: &MySqlMetadataWriter, values: &[i32]) -> (WriteSetupResult, CommitIds) {
+    let columns = int_column();
+    let setup = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values.to_vec()))]).unwrap();
+    let commit = writer
+        .register_inlined_data(
+            setup.table_id,
+            "main",
+            "t",
+            setup.snapshot_id,
+            &[batch],
+            WriteMode::Append,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+        .unwrap();
+    (setup, commit)
+}
+
+async fn file_id(pool: &sqlx::MySqlPool, path: &str) -> i64 {
+    sqlx::query_scalar("SELECT data_file_id FROM ducklake_data_file WHERE path = ?")
+        .bind(path)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn inlined_table(pool: &sqlx::MySqlPool, table_id: i64) -> String {
+    sqlx::query_scalar("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+        .bind(table_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn changes_made(pool: &sqlx::MySqlPool, snapshot_id: i64) -> Option<String> {
+    sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?")
+        .bind(snapshot_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
 
 /// Full write -> read round-trip through both a data-file commit
 /// (`register_data_file`) and a fileless CREATE-TABLE commit
@@ -283,5 +376,595 @@ async fn mysql_writer_roundtrip_write_then_read() {
                 Some(nested_setup.field_ids[1]),
             ),
         ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_writer_completion_matches_sqlite_contracts() {
+    let container = Mysql::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(3306).await.unwrap();
+    let conn_str = format!("mysql://root@127.0.0.1:{port}/test");
+    let writer = MySqlMetadataWriter::new_with_init(&conn_str).await.unwrap();
+    writer.set_data_path("file:///tmp/ducklake_data/").unwrap();
+    let pool = sqlx::MySqlPool::connect(&conn_str).await.unwrap();
+    let columns = vec![ColumnDef::new("id", "int32", false).unwrap()];
+
+    let first = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    let first_commit = writer
+        .register_data_file(
+            first.table_id,
+            "main",
+            "t",
+            first.snapshot_id,
+            &DataFileInfo::new("source.parquet", 40, 4),
+            WriteMode::Append,
+            first.base_snapshot_id,
+            &columns,
+            &first.column_ids,
+        )
+        .unwrap();
+    let source_id: i64 =
+        sqlx::query_scalar("SELECT data_file_id FROM ducklake_data_file WHERE path = ?")
+            .bind("source.parquet")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let delete_commit = writer
+        .set_delete_file(
+            first.table_id,
+            "main",
+            "t",
+            first_commit.snapshot_id + 1,
+            source_id,
+            None,
+            first_commit.snapshot_id,
+            &DeleteFileInfo::new("delete-1.parquet", 10, 1),
+        )
+        .unwrap();
+    let first_delete_id: i64 = sqlx::query_scalar(
+        "SELECT delete_file_id FROM ducklake_delete_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(source_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let update = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    let update_commit = writer
+        .register_data_file_with_deletes(
+            update.table_id,
+            "main",
+            "t",
+            update.snapshot_id,
+            &DataFileInfo::new("updated.parquet", 10, 1),
+            &[DeleteFileEntry {
+                data_file_id: source_id,
+                expected_prev_delete_file: Some(first_delete_id),
+                delete: DeleteFileInfo::new("delete-2.parquet", 20, 2),
+            }],
+            WriteMode::Append,
+            update.base_snapshot_id,
+            &columns,
+            &update.column_ids,
+        )
+        .unwrap();
+    assert!(writer.supports_update());
+    assert_eq!(update_commit.snapshot_id, delete_commit.snapshot_id + 1);
+    let update_state: (i64, Option<i64>, i64) = sqlx::query_as(
+        "SELECT
+            (SELECT begin_snapshot FROM ducklake_data_file WHERE path = 'updated.parquet'),
+            (SELECT end_snapshot FROM ducklake_delete_file WHERE delete_file_id = ?),
+            (SELECT begin_snapshot FROM ducklake_delete_file WHERE path = 'delete-2.parquet')",
+    )
+    .bind(first_delete_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        update_state,
+        (
+            update_commit.snapshot_id,
+            Some(update_commit.snapshot_id),
+            update_commit.snapshot_id,
+        )
+    );
+    assert_eq!(
+        writer
+            .commit_truncate(first.table_id, "main", "t", update_commit.snapshot_id,)
+            .unwrap(),
+        3
+    );
+
+    let compact_first = writer
+        .begin_write_transaction("main", "compact", &columns, WriteMode::Append)
+        .unwrap();
+    let compact_first_commit = writer
+        .register_data_file(
+            compact_first.table_id,
+            "main",
+            "compact",
+            compact_first.snapshot_id,
+            &DataFileInfo::new("compact-a.parquet", 20, 2),
+            WriteMode::Append,
+            compact_first.base_snapshot_id,
+            &columns,
+            &compact_first.column_ids,
+        )
+        .unwrap();
+    let compact_second = writer
+        .begin_write_transaction("main", "compact", &columns, WriteMode::Append)
+        .unwrap();
+    let compact_second_commit = writer
+        .register_data_file(
+            compact_second.table_id,
+            "main",
+            "compact",
+            compact_second.snapshot_id,
+            &DataFileInfo::new("compact-b.parquet", 30, 3),
+            WriteMode::Append,
+            compact_second.base_snapshot_id,
+            &columns,
+            &compact_second.column_ids,
+        )
+        .unwrap();
+    let compact_ids: Vec<i64> = sqlx::query_scalar(
+        "SELECT data_file_id FROM ducklake_data_file
+         WHERE table_id = ? AND end_snapshot IS NULL ORDER BY data_file_id",
+    )
+    .bind(compact_first.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let compact_commit = writer
+        .commit_compaction(
+            compact_first.table_id,
+            compact_second_commit.snapshot_id,
+            &compact_ids
+                .iter()
+                .map(|data_file_id| CompactionSourceFile {
+                    data_file_id: *data_file_id,
+                    delete_file_id: None,
+                })
+                .collect::<Vec<_>>(),
+            &[CompactionOutputFile {
+                file: DataFileInfo::new("merged.parquet", 45, 5),
+                begin_snapshot: Some(compact_first_commit.snapshot_id),
+                partial_max: Some(compact_second_commit.snapshot_id),
+            }],
+            SourceRetirement::Remove,
+        )
+        .unwrap();
+    let compact_state: (i64, i64, Option<i64>, String) = sqlx::query_as(
+        "SELECT
+            (SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = ?),
+            (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion),
+            (SELECT partial_max FROM ducklake_data_file WHERE path = 'merged.parquet'),
+            (SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?)",
+    )
+    .bind(compact_first.table_id)
+    .bind(compact_commit.snapshot_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        compact_state,
+        (
+            1,
+            2,
+            Some(compact_second_commit.snapshot_id),
+            format!("compacted_table:{}", compact_first.table_id),
+        )
+    );
+
+    let restore_base = writer
+        .begin_write_transaction("main", "restore", &columns, WriteMode::Append)
+        .unwrap();
+    let restore_base_commit = writer
+        .register_data_file(
+            restore_base.table_id,
+            "main",
+            "restore",
+            restore_base.snapshot_id,
+            &DataFileInfo::new("restore-base.parquet", 20, 2),
+            WriteMode::Append,
+            restore_base.base_snapshot_id,
+            &columns,
+            &restore_base.column_ids,
+        )
+        .unwrap();
+    let restore_append = writer
+        .begin_write_transaction("main", "restore", &columns, WriteMode::Append)
+        .unwrap();
+    writer
+        .register_data_file(
+            restore_append.table_id,
+            "main",
+            "restore",
+            restore_append.snapshot_id,
+            &DataFileInfo::new("restore-append.parquet", 30, 3),
+            WriteMode::Append,
+            restore_append.base_snapshot_id,
+            &columns,
+            &restore_append.column_ids,
+        )
+        .unwrap();
+    let restore_snapshot = writer
+        .retire_appends_since(restore_base.table_id, restore_base_commit.snapshot_id)
+        .unwrap()
+        .unwrap();
+    let restore_state: (Option<i64>, i64, i64) = sqlx::query_as(
+        "SELECT
+            (SELECT end_snapshot FROM ducklake_data_file WHERE path = 'restore-append.parquet'),
+            (SELECT record_count FROM ducklake_table_stats WHERE table_id = ?),
+            (SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?)",
+    )
+    .bind(restore_base.table_id)
+    .bind(restore_base.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(restore_state, (Some(restore_snapshot), 2, 5));
+
+    let promote = writer
+        .begin_write_transaction("main", "promote", &columns, WriteMode::Append)
+        .unwrap();
+    writer
+        .register_data_file(
+            promote.table_id,
+            "main",
+            "promote",
+            promote.snapshot_id,
+            &DataFileInfo::new("promote.parquet", 10, 1),
+            WriteMode::Append,
+            promote.base_snapshot_id,
+            &columns,
+            &promote.column_ids,
+        )
+        .unwrap();
+    let old_column_id: i64 = sqlx::query_scalar(
+        "SELECT column_id FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(promote.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let promote_snapshot = writer
+        .promote_column_type(promote.table_id, "id", "int64")
+        .unwrap();
+    let promoted: (i64, String, i64) = sqlx::query_as(
+        "SELECT column_id, column_type, begin_snapshot FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(promote.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        promoted,
+        (old_column_id, "int64".to_string(), promote_snapshot)
+    );
+
+    let expiry = writer
+        .begin_write_transaction("main", "expiry", &columns, WriteMode::Append)
+        .unwrap();
+    let expiry_commit = writer
+        .register_data_file(
+            expiry.table_id,
+            "main",
+            "expiry",
+            expiry.snapshot_id,
+            &DataFileInfo::new("expiry.parquet", 10, 1),
+            WriteMode::Append,
+            expiry.base_snapshot_id,
+            &columns,
+            &expiry.column_ids,
+        )
+        .unwrap();
+    writer
+        .commit_truncate(expiry.table_id, "main", "expiry", expiry_commit.snapshot_id)
+        .unwrap();
+    let expired = writer
+        .expire_snapshots(ExpireCriteria::Versions(vec![expiry_commit.snapshot_id]))
+        .unwrap();
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].snapshot_id, expiry_commit.snapshot_id);
+    let expiry_state: (i64, i64) = sqlx::query_as(
+        "SELECT
+            (SELECT COUNT(*) FROM ducklake_data_file WHERE path = 'expiry.parquet'),
+            (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion
+             WHERE path LIKE '%expiry.parquet')",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(expiry_state, (0, 1));
+}
+
+/// TRUNCATE of a table whose only live data is inlined rows must end those rows
+/// (not no-op on the "no live parquet files" guard) and count them.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_truncate_ends_inline_only_table() {
+    let (_container, writer, pool) = start_writer().await;
+    let (setup, commit) = append_inlined(&writer, &[1, 2]);
+    let removed = writer
+        .commit_truncate(setup.table_id, "main", "t", commit.snapshot_id)
+        .unwrap();
+    assert_eq!(removed, 2, "the two inline rows are the whole live table");
+    let truncate_snapshot = commit.snapshot_id + 1;
+    let physical = inlined_table(&pool, setup.table_id).await;
+    let state: (i64, i64, i64, i64) = sqlx::query_as(AssertSqlSafe(format!(
+        "SELECT
+            (SELECT MAX(snapshot_id) FROM ducklake_snapshot),
+            (SELECT COUNT(*) FROM `{physical}` WHERE end_snapshot IS NULL),
+            (SELECT COUNT(*) FROM `{physical}` WHERE end_snapshot = {truncate_snapshot}),
+            (SELECT record_count FROM ducklake_table_stats WHERE table_id = {})",
+        setup.table_id
+    )))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(state, (truncate_snapshot, 0, 2, 0));
+    assert_eq!(
+        changes_made(&pool, truncate_snapshot).await,
+        Some(format!("deleted_from_table:{}", setup.table_id))
+    );
+    // Nothing left to truncate: idempotent no-op with no new snapshot.
+    assert_eq!(
+        writer
+            .commit_truncate(setup.table_id, "main", "t", truncate_snapshot)
+            .unwrap(),
+        0
+    );
+}
+
+/// TRUNCATE of a mixed table retires the parquet files AND ends the inlined
+/// rows, counting both.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_truncate_retires_files_and_ends_inline_rows() {
+    let (_container, writer, pool) = start_writer().await;
+    let (setup, _) = append(&writer, "base.parquet", 3);
+    let (_, inline_commit) = append_inlined(&writer, &[10, 11]);
+    let removed = writer
+        .commit_truncate(setup.table_id, "main", "t", inline_commit.snapshot_id)
+        .unwrap();
+    assert_eq!(removed, 5, "3 parquet rows + 2 inline rows");
+    let truncate_snapshot = inline_commit.snapshot_id + 1;
+    let physical = inlined_table(&pool, setup.table_id).await;
+    let state: (Option<i64>, i64, i64, i64) = sqlx::query_as(AssertSqlSafe(format!(
+        "SELECT
+            (SELECT end_snapshot FROM ducklake_data_file WHERE path = 'base.parquet'),
+            (SELECT COUNT(*) FROM `{physical}` WHERE end_snapshot IS NULL),
+            (SELECT COUNT(*) FROM `{physical}` WHERE end_snapshot = {truncate_snapshot}),
+            (SELECT record_count FROM ducklake_table_stats WHERE table_id = {})",
+        setup.table_id
+    )))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(state, (Some(truncate_snapshot), 0, 2, 0));
+    assert_eq!(
+        changes_made(&pool, truncate_snapshot).await,
+        Some(format!("deleted_from_table:{}", setup.table_id))
+    );
+}
+
+/// A DELETE spanning parquet rows (positional delete file) and inlined rows
+/// commits in ONE snapshot via the commit_deletes override.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_commit_deletes_mixes_positional_and_inlined_in_one_snapshot() {
+    let (_container, writer, pool) = start_writer().await;
+    let (setup, _) = append(&writer, "base.parquet", 3);
+    let (_, inline_commit) = append_inlined(&writer, &[10, 11]);
+    let source_id = file_id(&pool, "base.parquet").await;
+    let physical = inlined_table(&pool, setup.table_id).await;
+    // Inline rows follow the parquet file's 3 rows: row_ids 3 and 4.
+    let commit = writer
+        .commit_deletes(
+            setup.table_id,
+            "main",
+            "t",
+            inline_commit.snapshot_id,
+            &[DeleteFileEntry {
+                data_file_id: source_id,
+                expected_prev_delete_file: None,
+                delete: DeleteFileInfo::new("delete-1.parquet", 10, 1),
+            }],
+            &[InlinedRowRef {
+                table_name: physical.clone(),
+                row_id: 3,
+            }],
+        )
+        .unwrap();
+    assert_eq!(commit.snapshot_id, inline_commit.snapshot_id + 1);
+    let state: (i64, Option<i64>, Option<i64>, i64) = sqlx::query_as(AssertSqlSafe(format!(
+        "SELECT
+            (SELECT begin_snapshot FROM ducklake_delete_file WHERE path = 'delete-1.parquet'),
+            (SELECT end_snapshot FROM `{physical}` WHERE row_id = 3),
+            (SELECT end_snapshot FROM `{physical}` WHERE row_id = 4),
+            (SELECT record_count FROM ducklake_table_stats WHERE table_id = {})",
+        setup.table_id
+    )))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        state,
+        (commit.snapshot_id, Some(commit.snapshot_id), None, 4),
+        "delete file begins at the commit, inline row 3 ends there, row 4 stays \
+         live, and only the inline delete adjusts the gross count"
+    );
+    assert_eq!(
+        changes_made(&pool, commit.snapshot_id).await,
+        Some(format!("deleted_from_table:{}", setup.table_id))
+    );
+}
+
+/// A pure positional-delete snapshot records `deleted_from_table` rather than
+/// leaving `changes_made` NULL.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_positional_delete_snapshot_records_changes_made() {
+    let (_container, writer, pool) = start_writer().await;
+    let (setup, base) = append(&writer, "a.parquet", 2);
+    let commit = writer
+        .commit_positional_deletes(
+            setup.table_id,
+            "main",
+            "t",
+            base.snapshot_id,
+            &[DeleteFileEntry {
+                data_file_id: file_id(&pool, "a.parquet").await,
+                expected_prev_delete_file: None,
+                delete: DeleteFileInfo::new("d.parquet", 10, 1),
+            }],
+        )
+        .unwrap();
+    assert_eq!(
+        changes_made(&pool, commit.snapshot_id).await,
+        Some(format!("deleted_from_table:{}", setup.table_id))
+    );
+}
+
+/// Staging a table (begin_write_transaction) and abandoning the write leaves a
+/// table row with zero live columns; the next write must create the columns at
+/// its commit instead of failing with a retryable-looking Conflict.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_first_write_commits_after_abandoned_staging() {
+    let (_container, writer, pool) = start_writer().await;
+    let columns = int_column();
+    // Stage the table but never write: it persists with zero live columns.
+    let staged = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    // The next write's commit creates the columns rather than conflicting.
+    let (setup, commit) = append(&writer, "a.parquet", 2);
+    assert_eq!(setup.table_id, staged.table_id);
+    assert_eq!(commit.snapshot_id, 1, "abandoned staging left no snapshot");
+    let live_columns: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(setup.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(live_columns, 1);
+}
+
+/// Every data/delete-file insert path draws from the explicit counters, so a
+/// sequence mixing appends (formerly AUTO_INCREMENT) with UPDATE-style and
+/// compaction registrations (always explicit) allocates distinct ids. Under the
+/// old split allocators the UPDATE's explicit id would have collided with the
+/// first append's auto-increment id on the primary key.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_unified_file_id_allocation_survives_mixed_paths() {
+    let (_container, writer, pool) = start_writer().await;
+    let columns = int_column();
+    let (setup, _) = append(&writer, "a.parquet", 2);
+    append(&writer, "b.parquet", 2);
+    let a_id = file_id(&pool, "a.parquet").await;
+    let b_id = file_id(&pool, "b.parquet").await;
+    assert_eq!((a_id, b_id), (1, 2), "appends allocate from the counter");
+
+    // UPDATE-style commit: register the rewritten file and swap a's delete file
+    // in one snapshot. Its explicit ids must not collide with the appends.
+    let update = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    let update_commit = writer
+        .register_data_file_with_deletes(
+            update.table_id,
+            "main",
+            "t",
+            update.snapshot_id,
+            &DataFileInfo::new("c.parquet", 20, 2),
+            &[DeleteFileEntry {
+                data_file_id: a_id,
+                expected_prev_delete_file: None,
+                delete: DeleteFileInfo::new("delete-a.parquet", 10, 2),
+            }],
+            WriteMode::Append,
+            update.base_snapshot_id,
+            &columns,
+            &update.column_ids,
+        )
+        .unwrap();
+    let c_id = file_id(&pool, "c.parquet").await;
+    let delete_id: i64 =
+        sqlx::query_scalar("SELECT delete_file_id FROM ducklake_delete_file WHERE path = ?")
+            .bind("delete-a.parquet")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        (c_id, delete_id),
+        (3, 1),
+        "the UPDATE's data file continues the shared space; delete files have \
+         their own counter"
+    );
+    assert_eq!(
+        changes_made(&pool, update_commit.snapshot_id).await,
+        Some(format!(
+            "deleted_from_table:{0},inserted_into_table:{0}",
+            setup.table_id
+        ))
+    );
+
+    // Compaction outputs draw from the same counter as the appends they retire.
+    let compact_commit = writer
+        .commit_compaction(
+            setup.table_id,
+            update_commit.snapshot_id,
+            &[
+                CompactionSourceFile {
+                    data_file_id: a_id,
+                    delete_file_id: Some(delete_id),
+                },
+                CompactionSourceFile {
+                    data_file_id: b_id,
+                    delete_file_id: None,
+                },
+                CompactionSourceFile {
+                    data_file_id: c_id,
+                    delete_file_id: None,
+                },
+            ],
+            &[CompactionOutputFile {
+                file: DataFileInfo::new("merged.parquet", 40, 4),
+                begin_snapshot: None,
+                partial_max: None,
+            }],
+            SourceRetirement::Retire,
+        )
+        .unwrap();
+    let merged_id = file_id(&pool, "merged.parquet").await;
+    assert_eq!(merged_id, 4, "compaction output continues the shared space");
+    let (rows, distinct_rows, live): (i64, i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), COUNT(DISTINCT data_file_id),
+                COUNT(CASE WHEN end_snapshot IS NULL THEN 1 END)
+         FROM ducklake_data_file",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        (rows, distinct_rows, live),
+        (4, 4, 1),
+        "four distinct file ids; only the compaction output is live"
+    );
+    assert_eq!(
+        changes_made(&pool, compact_commit.snapshot_id).await,
+        Some(format!("compacted_table:{}", setup.table_id))
     );
 }

--- a/tests/it/numeric_metadata_validation_tests.rs
+++ b/tests/it/numeric_metadata_validation_tests.rs
@@ -18,8 +18,7 @@ fn create_catalog_with_negative_file_size(catalog_path: &std::path::Path) -> any
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.items (id INT, name VARCHAR);",
@@ -46,8 +45,7 @@ fn create_catalog_with_negative_footer_size(catalog_path: &std::path::Path) -> a
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.items (id INT, name VARCHAR);",

--- a/tests/it/object_store_integration_test.rs
+++ b/tests/it/object_store_integration_test.rs
@@ -26,7 +26,10 @@ async fn create_local_test_catalog(catalog_path: &str) -> anyhow::Result<()> {
 
     // Create a test table with some data (local filesystem)
     conn.execute(
-        &format!("ATTACH 'ducklake:{}' AS test_catalog;", catalog_path),
+        &format!(
+            "ATTACH 'ducklake:{}' AS test_catalog (DATA_INLINING_ROW_LIMIT 0);",
+            catalog_path
+        ),
         [],
     )?;
 
@@ -145,7 +148,7 @@ async fn create_s3_test_catalog(
     eprintln!("Attaching catalog with DATA_PATH: {}", s3_data_path);
 
     let attach_sql = format!(
-        "ATTACH 'ducklake:{}' AS test_catalog (DATA_PATH '{}');",
+        "ATTACH 'ducklake:{}' AS test_catalog (DATA_PATH '{}', DATA_INLINING_ROW_LIMIT 0);",
         catalog_path, s3_data_path
     );
 
@@ -260,6 +263,10 @@ async fn test_minio_object_store_integration() -> anyhow::Result<()> {
         "ducklake-data/",
     )
     .await?;
+    assert_parquet_data_files(
+        &catalog_path_str,
+        &[("inventory", 1, 4), ("products", 1, 5)],
+    )?;
     eprintln!("Test data written to MinIO");
 
     // Configure S3 client for DataFusion
@@ -396,6 +403,7 @@ async fn test_local_filesystem_with_s3_style_paths() -> anyhow::Result<()> {
     // Generate test data locally
     eprintln!("Generating local test data...");
     create_local_test_catalog(&catalog_path_str).await?;
+    assert_parquet_data_files(&catalog_path_str, &[("products", 1, 5)])?;
 
     // Create session context
     let ctx = SessionContext::new();
@@ -421,5 +429,33 @@ async fn test_local_filesystem_with_s3_style_paths() -> anyhow::Result<()> {
 
     eprintln!("Local filesystem test passed");
 
+    Ok(())
+}
+
+fn assert_parquet_data_files(
+    catalog_path: &str,
+    expected: &[(&str, i64, i64)],
+) -> anyhow::Result<()> {
+    let connection = duckdb::Connection::open(catalog_path)?;
+    let mut statement = connection.prepare(
+        "SELECT t.table_name, COUNT(*), SUM(f.record_count)::BIGINT
+         FROM ducklake_data_file f JOIN ducklake_table t ON t.table_id = f.table_id
+         WHERE f.end_snapshot IS NULL AND t.end_snapshot IS NULL
+         GROUP BY t.table_name ORDER BY t.table_name",
+    )?;
+    let actual = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let expected = expected
+        .iter()
+        .map(|(name, files, rows)| (name.to_string(), *files, *rows))
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
     Ok(())
 }

--- a/tests/it/partition_tests.rs
+++ b/tests/it/partition_tests.rs
@@ -22,8 +22,7 @@ fn create_partitioned_catalog(catalog_path: &std::path::Path) -> anyhow::Result<
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     conn.execute(
         "CREATE TABLE test_catalog.events (id INTEGER, region VARCHAR, ts TIMESTAMP);",

--- a/tests/it/renamed_columns_tests.rs
+++ b/tests/it/renamed_columns_tests.rs
@@ -33,8 +33,7 @@ fn create_catalog_with_renamed_column(catalog_path: &Path) -> Result<()> {
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     // Create table with original column name
     conn.execute(
@@ -70,8 +69,7 @@ fn create_catalog_with_multiple_renames(catalog_path: &Path) -> Result<()> {
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
 
     // Create table with original column names
     conn.execute(
@@ -358,8 +356,7 @@ fn create_catalog_renamed_with_post_rename_file(catalog_path: &Path) -> Result<(
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
     conn.execute(
         "CREATE TABLE test_catalog.test_table (id INT, name VARCHAR);",
         [],
@@ -464,8 +461,7 @@ fn create_catalog_rename_then_delete(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
     conn.execute(
         "CREATE TABLE test_catalog.test_table (id INT, name VARCHAR);",
         [],
@@ -532,8 +528,7 @@ fn create_catalog_drop_readd(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
     conn.execute(
         "CREATE TABLE test_catalog.test_table (id INT, tag VARCHAR);",
         [],
@@ -567,8 +562,7 @@ async fn test_drop_readd_column_reads_null_for_pre_drop_rows() -> Result<()> {
         let conn = duckdb::Connection::open_in_memory()?;
         crate::common::ensure_ducklake_installed();
         conn.execute("LOAD ducklake;", [])?;
-        let ducklake_path = format!("ducklake:{}", catalog_path.display());
-        conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+        crate::common::attach_catalog_without_inlining(&conn, &catalog_path, "test_catalog")?;
         let mut stmt = conn.prepare("SELECT id, tag FROM test_catalog.test_table ORDER BY id")?;
         let mut rows = stmt.query([])?;
         let mut duck: Vec<(i32, Option<String>)> = Vec::new();
@@ -620,8 +614,7 @@ fn create_catalog_evolved_struct_child(catalog_path: &Path, rename: bool) -> Res
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "test_catalog")?;
     if rename {
         conn.execute(
             "CREATE TABLE test_catalog.t (id INT, s STRUCT(a INT, b INT));",

--- a/tests/it/row_id_tests.rs
+++ b/tests/it/row_id_tests.rs
@@ -26,8 +26,7 @@ fn create_catalog_rowid_two_files(catalog_path: &Path) -> Result<()> {
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "c")?;
 
     conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
     // First file: rows 0..3
@@ -45,8 +44,7 @@ fn create_catalog_rowid_with_deletes(catalog_path: &Path) -> Result<()> {
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "c")?;
 
     conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
     conn.execute("INSERT INTO c.t SELECT i FROM range(0, 3) t(i);", [])?;
@@ -77,8 +75,7 @@ fn create_catalog_rowid_with_update(catalog_path: &Path) -> Result<()> {
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
-    let ducklake_path = format!("ducklake:{}", catalog_path.display());
-    conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "c")?;
 
     conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
     conn.execute("INSERT INTO c.t SELECT i FROM range(0, 3) t(i);", [])?;

--- a/tests/it/rowid_physical_position_tests.rs
+++ b/tests/it/rowid_physical_position_tests.rs
@@ -33,10 +33,7 @@ fn open(catalog_path: &Path) -> anyhow::Result<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
-    conn.execute(
-        &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),
-        [],
-    )?;
+    crate::common::attach_catalog_without_inlining(&conn, catalog_path, "c")?;
     Ok(conn)
 }
 

--- a/tests/it/table_deletions_repartition_tests.rs
+++ b/tests/it/table_deletions_repartition_tests.rs
@@ -35,8 +35,7 @@ fn build_catalog(path: &Path, targets: &[i64]) -> DataFusionResult<()> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
-    conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
-        .map_err(box_err)?;
+    crate::common::attach_catalog_without_inlining(&conn, path, "c").map_err(box_err)?;
     conn.execute("CREATE TABLE c.t(id INTEGER);", [])
         .map_err(box_err)?;
     conn.execute(

--- a/tests/it/view_tests.rs
+++ b/tests/it/view_tests.rs
@@ -107,8 +107,11 @@ fn normalize_current_view_sql(catalog_path: &Path) -> anyhow::Result<()> {
     let connection = duckdb::Connection::open(catalog_path)?;
     connection.execute(
         "UPDATE ducklake_view
-         SET sql = replace(sql, 'lake.', '{DUCKLAKE_CATALOG}.')
-         WHERE view_name <> 'legacy_qualified'",
+         SET sql = CASE
+             WHEN view_name = 'legacy_qualified'
+                 THEN replace(sql, '{DUCKLAKE_CATALOG}.', 'lake.')
+             ELSE replace(sql, 'lake.', '{DUCKLAKE_CATALOG}.')
+         END",
         [],
     )?;
     Ok(())
@@ -187,7 +190,7 @@ async fn duckdb_views_are_listed_and_queryable() -> anyhow::Result<()> {
         &data_path,
         "SELECT CAST(rowid AS VARCHAR) AS rowid_text FROM lake.rowids ORDER BY rowid",
     )?;
-    assert!(stored_view_sql(&catalog_path, "filtered")?.contains("lake.users"));
+    assert!(stored_view_sql(&catalog_path, "filtered")?.contains("{DUCKLAKE_CATALOG}.users"));
     normalize_current_view_sql(&catalog_path)?;
     assert!(stored_view_sql(&catalog_path, "filtered")?.contains("{DUCKLAKE_CATALOG}.users"));
     assert!(stored_view_sql(&catalog_path, "legacy_qualified")?.contains("lake.users"));

--- a/tests/it/write_tests.rs
+++ b/tests/it/write_tests.rs
@@ -111,7 +111,7 @@ fn assert_duckdb_extension_reads_depths(catalog_path: &std::path::Path) {
          CREATE TABLE raw.ducklake_tag( \
              object_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR \
          ); \
-         CREATE TABLE raw.ducklake_inlined_data_tables( \
+             CREATE TABLE IF NOT EXISTS raw.ducklake_inlined_data_tables( \
              table_id BIGINT, table_name VARCHAR, schema_version BIGINT \
          ); \
          CREATE TABLE raw.ducklake_column_tag( \


### PR DESCRIPTION
### Summary

Bring the standard single‑catalog DuckDB and MySQL writers to the same metadata contract as the
SQLite writer. Both backends now commit positional deletes, mixed positional‑plus‑inline deletes,
atomic UPDATE metadata, inline‑aware truncate, compaction, append restoration, lossless type
promotion, and snapshot expiry, and every mutation flow records its
`ducklake_snapshot_changes.changes_made` entry. MySQL allocates every data‑file and delete‑file
id from the catalog counters, so appends and the update, delete, and compaction paths share one
id space.

Update the public backend matrix to report write support on DuckDB, SQLite, PostgreSQL, and MySQL
and to distinguish the three standard single-catalog layouts from the experimental PostgreSQL
multi-catalog layout.

This boundary also initializes and migrates the DuckDB catalog metadata columns and support tables
required by the DuckDB extension. It deliberately precedes write inlining: #272 consumes these
complete writer primitives and the extension-compatible catalog shape instead of repairing them in
a later PR.

DuckDB file reads retain each file's creation snapshot, schema version, and partial-file snapshot bounds.
Compaction can therefore select compatible files and preserve row lineage instead of skipping files whose
provenance is missing. Direct, paginated, filtered, and catalog-wide reads return the same metadata.
Catalogs without a per-table schema-version ledger continue to report an unknown version, so compaction retains its safety checks.

The Rust `duckdb` dependency uses `1.10505.0`, which bundles DuckDB 1.5.5, and CI installs the matching CLI.
DuckDB now uses Arrow 58 instead of Arrow 56; DataFusion retains its Arrow 59 dependency.
Parquet-backed integration fixtures explicitly disable default small-write inlining so they continue exercising
physical files. Catalogs with legacy global schema-version ledgers remain readable and report unknown per-file
schema versions; compaction retains its provenance checks.

### Commit flow

```mermaid
flowchart TB
    Operation["Delete, update, compact, restore, promote, or expire"] --> Writer["MetadataWriter contract"]
    Writer --> DuckDB["DuckDB transaction"]
    Writer --> MySQL["MySQL transaction"]
    DuckDB --> Snapshot["Allocate one commit snapshot"]
    MySQL --> Snapshot
    Snapshot --> Fence{"Source and delete state still live?"}
    Fence -->|no| Conflict["Abort with a conflict"]
    Fence -->|yes| Metadata["Version data, delete, column, stats, and change rows"]
    Metadata --> Commit["Commit one atomic metadata state"]
```

### Contract

- Use the standard single‑catalog DuckLake table layout for DuckDB and MySQL.
- Allocate and publish every mutating operation in one backend transaction and one snapshot.
- Allocate every MySQL `data_file_id` and `delete_file_id` from the catalog counters, never from
  auto‑increment, so all insert paths share one id space per catalog.
- Reject an UPDATE, DELETE, or compaction commit when its expected live source or delete file has
  changed, including a changed inlined‑delete row count on a compaction source
  (`CompactionSourceFile::inlined_delete_count`).
- Register a replacement data file and its delete files in the same transaction for UPDATE.
- Commit a DELETE spanning Parquet and inline rows through `commit_deletes` in one snapshot on
  DuckDB and MySQL, matching the SQLite and PostgreSQL behavior.
- Retire data and delete files together for truncate, end visible inline rows in the same
  snapshot, and return the exact live row count removed — inline rows included.
- Record `ducklake_snapshot_changes.changes_made` in every mutation flow: `set_delete_file`,
  positional deletes, retire, truncate, and promote.
- Commit the first write to a table that was staged but never written, seeding its stats row,
  instead of failing permanently with a retry‑suggesting `Conflict`.
- Preserve the original snapshot range and `partial_max` metadata for compaction outputs.
- Restore only pure appends after the selected base snapshot and retain monotonic row ID allocation.
- Promote only lossless type changes, preserve the stable `column_id`, and bump `schema_version`.
- Keep the newest snapshot during expiry, remove catalog rows no surviving snapshot can reach, and
  schedule their physical files for later cleanup.
- Keep multiple catalogs a PostgreSQL‑specific capability.

### Design decisions

- Port the SQLite transaction boundaries and compare‑and‑swap checks rather than introducing a
  backend‑neutral SQL builder. The SQL dialects differ enough in placeholder syntax, generated ID
  retrieval, path concatenation, aggregate result types, and multi‑statement execution that direct
  ports remain easier to audit.
- Add `partial_max` and `ducklake_snapshot_changes` through idempotent schema initialization. Existing
  DuckDB and MySQL catalogs therefore gain the columns without a destructive migration.
- Use `sqlx::AssertSqlSafe` only for SQL assembled from validated numeric IDs or fixed internal table
  names. User values continue through bound parameters.
- Cast MySQL's `SUM(BIGINT)` delete count back to `SIGNED`; MySQL returns that aggregate as `DECIMAL`,
  which otherwise fails exact `i64` decoding.
- Keep MySQL's `data_file_id` and `delete_file_id` `AUTO_INCREMENT` declarations for
  pre‑existing‑catalog compatibility, but pass an explicit counter‑allocated id on every insert.
  Mixing `last_insert_id()` appends with counter‑seeded explicit ids made primary‑key collisions
  arithmetically certain; one id space removes the second allocator.
- Route DuckDB and MySQL change recording through the shared `record_table_write_changes` helper,
  which also records a Replace over inline‑only prior data as delete plus insert.
- Split MySQL compaction statements because the driver executes one prepared statement per query.
- Keep focused backend tests beside the existing DuckDB module and live MySQL writer suite. They
  exercise the same contract families as the SQLite suites without hiding dialect failures behind a
  shared fixture.

### Verification

- The all-feature suite passes: 566 library tests, 452 integration tests, and 8 documentation tests; 238 tests are ignored in this feature combination.
- The exact single-catalog Docker CI feature combination passes: 544 library tests, 496 integration tests, and 8 documentation tests; 16 existing tests remain ignored.
- The legacy-ledger regression, formatting, and all-feature/all-target Clippy with warnings denied pass.

### Specification proof

| DuckLake rule                                                                                                                                                          | Implementation invariant                                                                                                                                                                                                                                          | Discriminating proof                                                                                                                                                                                                            |
| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [Every committed transaction is one snapshot](https://ducklake.select/docs/stable/duckdb/advanced_features/transactions)                                               | Each new DuckDB and MySQL writer operation opens one SQL transaction, allocates one snapshot, versions all affected rows, and commits once.                                                                                                                       | The delete and UPDATE tests assert exact consecutive snapshot IDs, and the compaction tests assert one change row at the returned snapshot.                                                                                     |
| [A DELETE writes and registers a positional delete file](https://ducklake.select/docs/stable/specification/queries#delete)                                             | `set_delete_file` and `commit_positional_deletes` retire the expected live delete version and register its replacement atomically; `commit_deletes` combines positional and inlined‑row deletes in one snapshot on both backends.                                 | Both backend tests assert the old delete file ends and the replacement begins at the exact returned snapshot; `mysql_commit_deletes_mixes_positional_and_inlined_in_one_snapshot` asserts one snapshot ends both storage forms. |
| [UPDATE is DELETE plus INSERT in the same transaction](https://ducklake.select/docs/stable/specification/queries#update)                                               | `register_data_file_with_deletes` commits the replacement data file and every source delete change under one snapshot.                                                                                                                                            | The tests assert the replacement data file and replacement delete file share the exact commit snapshot.                                                                                                                         |
| [Concurrent logical conflicts must abort](https://ducklake.select/docs/stable/duckdb/advanced_features/conflict_resolution)                                            | Delete, UPDATE, and compaction compare the expected live source and delete state before changing metadata.                                                                                                                                                        | Existing conflict tests compile against both completed writers, while focused tests prove the successful expected-state path and exact version transition.                                                                      |
| [Row IDs survive UPDATE and compaction](https://ducklake.select/docs/stable/duckdb/advanced_features/row_lineage)                                                      | Restore leaves `next_row_id` monotonic, and compaction accepts output lineage metadata instead of allocating replacement row IDs.                                                                                                                                 | DuckDB row‑ID and compaction tests plus the MySQL restore test assert the exact retained allocator and snapshot range.                                                                                                          |
| [Merged files may span snapshots through `partial_max`](https://ducklake.select/docs/stable/duckdb/maintenance/merge_adjacent_files)                                   | Both schemas carry `partial_max`; compaction records each output's original begin snapshot and maximum represented snapshot.                                                                                                                                      | The compaction tests assert the exact output `partial_max` and removal or retirement of every source.                                                                                                                           |
| [Only lossless type promotions are valid](https://ducklake.select/docs/stable/duckdb/usage/schema_evolution#type-promotion)                                            | Promotion validates the type pair, versions the column under the same `column_id`, and records a new schema version.                                                                                                                                              | Both backend tests promote `int32` to `int64` and assert stable identity, exact live type, and promotion snapshot.                                                                                                              |
| [Snapshots reconstruct historical table state](https://ducklake.select/docs/stable/duckdb/usage/time_travel)                                                           | Truncate ends data files, delete files, and visible inline rows at a new snapshot instead of erasing prior version ranges, and returns the exact live row count it removed — inline rows included.                                                                | DuckDB delete/truncate and restore tests plus `mysql_truncate_ends_inline_only_table` and `mysql_truncate_retires_files_and_ends_inline_rows` assert exact `end_snapshot` values, removed counts, and live stats.               |
| [Expiry removes only explicitly expired historical snapshots](https://ducklake.select/docs/stable/duckdb/maintenance/expire_snapshots)                                 | Expiry protects the newest snapshot, removes rows unreachable from survivors, and queues physical files instead of deleting them immediately.                                                                                                                     | DuckDB and MySQL expiry tests assert the selected historical snapshot is removed, the head survives, and its unreachable file is scheduled once.                                                                                |
| [`ducklake_snapshot_changes` summarizes all high‑level changes made by a snapshot](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot_changes) | Every DuckDB and MySQL mutation flow — `set_delete_file`, positional deletes, retire, truncate, and promote — records its `changes_made` entry through the shared `record_table_write_changes` helper, so no data‑modifying snapshot is hidden from spec readers. | `mysql_positional_delete_snapshot_records_changes_made` and the DuckDB contract tests assert the exact `changes_made` string at each mutation snapshot.                                                                         |

### Reference implementation

The writer ports follow the official extension's catalog transitions:

- [`GetCompactionChanges`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_transaction_state.cpp#L658-L764)
  preserves source `begin_snapshot`, merged `partial_max`, and row lineage on compacted outputs.
- [`WriteCompactions`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L5060-L5156)
  either removes merge-adjacent sources and schedules their objects or versions rewrite sources
  through `end_snapshot`, matching the two `SourceRetirement` modes.
- [`DeleteSnapshots`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L5180-L5265)
  deletes the requested snapshot rows, finds metadata with no surviving visibility interval, and
  schedules unreachable files before removing their catalog rows.
- [`TypePromotion`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_table_entry.cpp#L1027-L1050)
  rejects non-widening primitive changes, which both ports enforce before versioning the stable
  `column_id`.

The official extension has no MySQL metadata backend. The MySQL commit is therefore a dialect port
of these same row transitions, transaction fences, and error conditions rather than a separate
implementation-specific contract. Current extension source emits the newer `merge_adjacent` and
`rewrite_delete` change tokens. The published stable snapshot-changes table defines
`compacted_table:<table_id>`, so both ports deliberately retain that stable token.

### Review boundary

The shared writer trait and DuckDB/MySQL implementations expose explicit inline-write hooks in this boundary.
Normal table writes continue to use Parquet. Automatic small-write routing and complete inline type support land in #272.

This branch owns DuckDB and MySQL metadata writer completion, their schema migrations, DuckDB
extension metadata compatibility, focused contract tests, and the backend compatibility matrix. It
provides the writer foundation for #272 but does not enable table-level small-write inlining.
