### PR TITLE
Commit staged table writes in one DuckLake snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every live file (#293).
 - Scoped DuckLake settings resolve per key with table-over-schema-over-global precedence on
   every metadata backend; SQL writes and compaction honour the resolved values (#271).
-- Embedding APIs expose snapshot changes, opaque commit lookup, table-scoped
-  setting upserts, and backend commit coordination locks on SQLite and
-  PostgreSQL, with unsupported defaults elsewhere (#274).
-
-- `DuckLakeWriteTransaction` stages Parquet files, inlined rows, and deletes
-  across tables, then publishes them in one snapshot on DuckDB, SQLite,
-  PostgreSQL, or MySQL (#274).
+- Read nullable snapshot changes and find commits with live files on DuckDB,
+  SQLite, and PostgreSQL; MySQL reports unsupported APIs (#274).
+- Set table-scoped settings and coordinate commits on DuckDB, SQLite, and
+  multicatalog PostgreSQL; standard PostgreSQL and MySQL are unsupported (#274).
+- Commit staged writes across existing tables in one snapshot on DuckDB,
+  SQLite, MySQL, and multicatalog PostgreSQL (#274).
+- `DuckLakeWriteOptions::data_inlining_row_limit` reserves the automatic limit;
+  high-level writes still use Parquet (#274).
 
 - SQL `DELETE` can commit Parquet-resident and catalog-inlined rows in one
   snapshot on all four write backends; DuckDB and MySQL now implement combined
@@ -69,9 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offers no public constructor for one, so these two execs are effectively crate-internal now.
   `ROW_POS_COLUMN_NAME` is also only a *base* name: a scan whose file already has a column of
   that name uses a suffixed variant, so locating the column by name is no longer reliable (#130).
-- Failed multi-table commits remove staged objects only on definite pre-commit
-  rejection; ambiguous network commit failures leave them for guarded vacuum
-  rather than risking deletion of committed files (#274).
+- Opening SQLite and multicatalog PostgreSQL writers adds the inline registry
+  required by staged writes, replacements, and truncation (#274).
 
 - **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. Add
   `..Default::default()` to exhaustive struct literals; no catalog or data migration (#280).
@@ -108,11 +108,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delete file, with no `NanPruningBarrierExec` above it, silently dropping NaN rows (#130).
 - The internal physical-position column could bind to a catalog column of the same name in the
   CDC feeds, making them report the wrong rows (#130).
-- MySQL multi-table commits allocate the serializing snapshot before fence and
-  liveness reads, preventing stale read views and overlapping row IDs (#274).
-- Fresh multi-table creation records each `created_schema:` ledger entry exactly
-  once (#274).
-
 - MySQL allocates data and delete file IDs consistently from catalog counters,
   avoiding collisions across append, update, delete, and compaction paths (#273).
 - DuckDB and MySQL mutation flows now record `changes_made` entries for every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every live file (#293).
 - Scoped DuckLake settings resolve per key with table-over-schema-over-global precedence on
   every metadata backend; SQL writes and compaction honour the resolved values (#271).
+- Embedding APIs expose snapshot changes, opaque commit lookup, table-scoped
+  setting upserts, and backend commit coordination locks on SQLite and
+  PostgreSQL, with unsupported defaults elsewhere (#274).
+
+- `DuckLakeWriteTransaction` stages Parquet files, inlined rows, and deletes
+  across tables, then publishes them in one snapshot on DuckDB, SQLite,
+  PostgreSQL, or MySQL (#274).
+
 - SQL `DELETE` can commit Parquet-resident and catalog-inlined rows in one
   snapshot on all four write backends; DuckDB and MySQL now implement combined
   deletes and exact inline-aware truncate counts (#273).
@@ -61,6 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offers no public constructor for one, so these two execs are effectively crate-internal now.
   `ROW_POS_COLUMN_NAME` is also only a *base* name: a scan whose file already has a column of
   that name uses a suffixed variant, so locating the column by name is no longer reliable (#130).
+- Failed multi-table commits remove staged objects only on definite pre-commit
+  rejection; ambiguous network commit failures leave them for guarded vacuum
+  rather than risking deletion of committed files (#274).
+
 - **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. Add
   `..Default::default()` to exhaustive struct literals; no catalog or data migration (#280).
 - Rolling and partitioned writes upload up to 4 files at once, raising peak write memory
@@ -96,6 +108,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delete file, with no `NanPruningBarrierExec` above it, silently dropping NaN rows (#130).
 - The internal physical-position column could bind to a catalog column of the same name in the
   CDC feeds, making them report the wrong rows (#130).
+- MySQL multi-table commits allocate the serializing snapshot before fence and
+  liveness reads, preventing stale read views and overlapping row IDs (#274).
+- Fresh multi-table creation records each `created_schema:` ledger entry exactly
+  once (#274).
+
 - MySQL allocates data and delete file IDs consistently from catalog counters,
   avoiding collisions across append, update, delete, and compaction paths (#273).
 - DuckDB and MySQL mutation flows now record `changes_made` entries for every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scoped DuckLake settings resolve per key with table-over-schema-over-global precedence on
   every metadata backend; SQL writes and compaction honour the resolved values (#271).
 - Read nullable snapshot changes and find commits with live files on DuckDB,
-  SQLite, and PostgreSQL; MySQL reports unsupported APIs (#274).
-- Set table-scoped settings and coordinate commits on DuckDB, SQLite, and
-  multicatalog PostgreSQL; standard PostgreSQL and MySQL are unsupported (#274).
-- Commit staged writes across existing tables in one snapshot on DuckDB,
-  SQLite, MySQL, and multicatalog PostgreSQL (#274).
+  SQLite, PostgreSQL, and MySQL (#274).
+- Set supported table-scoped options and coordinate commits on DuckDB, SQLite,
+  MySQL, and both PostgreSQL layouts (#274).
+- Commit staged writes across new or existing tables in one snapshot on all
+  metadata backends; empty staging calls do not publish snapshots (#274).
 - `DuckLakeWriteOptions::data_inlining_row_limit` reserves the automatic limit;
-  high-level writes still use Parquet (#274).
+  high-level writes use Parquet and leave the stored limit unparsed (#274).
+- Validate snapshot-column staging before uploading files, and reject settings
+  for unknown options or dropped tables (#274).
 
 - SQL `DELETE` can commit Parquet-resident and catalog-inlined rows in one
   snapshot on all four write backends; DuckDB and MySQL now implement combined

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -204,6 +204,15 @@ observe another writer's uncommitted schema, a transient empty table, or a torn 
 On Postgres multi-catalog the begin step only *reserves* ids (via the IDENTITY sequence) and
 reads existing state; it writes nothing.
 
+`DuckLakeWriteTransaction` applies one optional table‑state precondition before it mutates any
+target, then commits every staged Parquet file, inlined row, positional delete, and inline delete
+in one snapshot. Use it after the target tables exist; table creation remains a normal writer
+commit. If the shared precondition or metadata commit is rejected before the commit point (a
+conflict, validation, or unsupported‑operation error), the metadata transaction rolls back and
+the writer removes all staged Parquet data and delete objects. An ambiguous failure — such as a
+lost COMMIT acknowledgement on a network backend — leaves the staged objects to the guarded
+vacuum, which reclaims only files no committed snapshot references.
+
 `WriteMode::Replace` (SQL `INSERT OVERWRITE`, and the first write of a table) is
 **abort-on-conflict** under concurrency, matching DuckLake's snapshot isolation:
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -196,45 +196,50 @@ settings, including `execution.time_zone`, are not inherited.
 
 ## Write concurrency
 
-All write backends use the same **commit-time** model: a write's snapshot id, all its
-metadata rows, and its publication are written in **one transaction**, with the snapshot id
-assigned at commit (so per-catalog id order == commit order) and nothing visible until that
-transaction commits. There are no "dormant" (committed-but-unpublished) rows, so reads never
-observe another writer's uncommitted schema, a transient empty table, or a torn generation.
-On Postgres multi-catalog the begin step only *reserves* ids (via the IDENTITY sequence) and
-reads existing state; it writes nothing.
+Write commits allocate a snapshot and publish their data and final metadata in
+one database transaction. Write setup retains each backend's existing schema
+and table reservation behavior; PostgreSQL layouts reserve identifiers without
+publishing schema or table rows.
 
-`DuckLakeWriteTransaction` applies one optional table‑state precondition before it mutates any
-target, then commits every staged Parquet file, inlined row, positional delete, and inline delete
-in one snapshot. Use it after the target tables exist; table creation remains a normal writer
-commit. If the shared precondition or metadata commit is rejected before the commit point (a
-conflict, validation, or unsupported‑operation error), the metadata transaction rolls back and
-the writer removes all staged Parquet data and delete objects. An ambiguous failure — such as a
-lost COMMIT acknowledgement on a network backend — leaves the staged objects to the guarded
-vacuum, which reclaims only files no committed snapshot references.
+`DuckLakeWriteTransaction` finalizes new or existing tables on DuckDB, SQLite,
+MySQL, and both PostgreSQL layouts. Every stage must retain its schema and field
+IDs. A conflict rejects the whole commit. Definite rejections remove staged
+objects; ambiguous database or transport failures retain them for guarded vacuum.
+Snapshot-column staging validates its inputs before uploading any objects.
 
-Staged commits are supported by DuckDB, SQLite, MySQL, and the experimental
-multicatalog PostgreSQL writer. The standard single-catalog PostgreSQL writer
-returns `Unsupported`. High-level row staging currently writes Parquet; explicit
-metadata-level inline writes and inline-row deletes use `inlined_insert` and
-`inlined_delete`, while flushes use `inline_flush`. Automatic small-write
-routing is separate from the staged transaction API.
+Ordinary append stages commute. Callers can explicitly require an unchanged
+base snapshot with `expected_base_snapshot_id`, including for append stages.
+That optional precondition is stronger than ordinary append isolation.
 
-Unlike DuckDB's no-op commits, empty transactions, zero-row stages, and empty
-delete sets return errors. Inline deletes require one live row visible at the
-stage's base snapshot; stale or missing row identities abort the transaction.
-Create and commit tables before staging on DuckDB and MySQL. SQLite and
-multicatalog PostgreSQL can also finalize reserved tables.
+Empty transactions, zero-row staging calls, and empty delete sets are no-ops.
+They add no result entry or snapshot. Staged inline deletes group row IDs by
+physical table, ignore missing identities, and exclude rows inserted in the
+same snapshot. Separate checks reject concurrent changes, including inline
+deletes and flushes. New inline-delete paths leave the gross metadata record
+count unchanged; query counts come from the visible rows.
 
-Opening a SQLite or multicatalog PostgreSQL writer creates the inline-table
-registry when it is absent, even without `initialize_schema()`. SQLite also
-migrates legacy non-null change ledgers. Snapshot-change readers preserve null
-changes and snapshots without ledger rows. The commit metadata lookup
-deliberately searches only snapshots with live Parquet files; it is not a
-general idempotency check for inline-only, delete-only, or retired commits.
-MySQL returns `Unsupported` for both snapshot-change APIs. Coordination locks
-cover the whole catalog file on SQLite and DuckDB, and the requested identity on
-multicatalog PostgreSQL; MySQL does not implement that API.
+MySQL resolves the inline schema version while holding the commit's counter
+lock. It creates physical inline tables through a separate connection so DDL
+cannot implicitly commit the metadata transaction. Zero-row inline stages are
+rejected before physical DDL. The new DuckDB staged inline DDL is nullable,
+matching SQLite and PostgreSQL; older native DDL remains unchanged.
+
+High-level row staging uses Parquet. Automatic small-write routing remains
+separate, and the stored `data_inlining_row_limit` is not parsed by this writer.
+Explicit inline inserts, deletes, and flushes use their storage-specific
+`inlined_insert`, `inlined_delete`, and `inline_flush` ledger tokens.
+
+Opening SQLite and multicatalog PostgreSQL writers creates a missing inline
+registry; standard PostgreSQL staged commits create it on demand. SQLite also
+migrates legacy non-null change ledgers. Snapshot-change readers on all backends
+preserve NULL changes and snapshots without ledger rows. Commit metadata lookup
+searches snapshots with live Parquet files; it is not general idempotency for
+inline-only, delete-only, or retired commits.
+
+Table settings require a supported option and a live table. Coordination locks
+cover the catalog file on SQLite and DuckDB, and the requested identity on
+PostgreSQL and MySQL. MySQL's pre-existing global-setting setter remains
+unsupported.
 
 `WriteMode::Replace` (SQL `INSERT OVERWRITE`, and the first write of a table) is
 **abort-on-conflict** under concurrency, matching DuckLake's snapshot isolation:

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -213,6 +213,29 @@ the writer removes all staged Parquet data and delete objects. An ambiguous fail
 lost COMMIT acknowledgement on a network backend — leaves the staged objects to the guarded
 vacuum, which reclaims only files no committed snapshot references.
 
+Staged commits are supported by DuckDB, SQLite, MySQL, and the experimental
+multicatalog PostgreSQL writer. The standard single-catalog PostgreSQL writer
+returns `Unsupported`. High-level row staging currently writes Parquet; explicit
+metadata-level inline writes and inline-row deletes use `inlined_insert` and
+`inlined_delete`, while flushes use `inline_flush`. Automatic small-write
+routing is separate from the staged transaction API.
+
+Unlike DuckDB's no-op commits, empty transactions, zero-row stages, and empty
+delete sets return errors. Inline deletes require one live row visible at the
+stage's base snapshot; stale or missing row identities abort the transaction.
+Create and commit tables before staging on DuckDB and MySQL. SQLite and
+multicatalog PostgreSQL can also finalize reserved tables.
+
+Opening a SQLite or multicatalog PostgreSQL writer creates the inline-table
+registry when it is absent, even without `initialize_schema()`. SQLite also
+migrates legacy non-null change ledgers. Snapshot-change readers preserve null
+changes and snapshots without ledger rows. The commit metadata lookup
+deliberately searches only snapshots with live Parquet files; it is not a
+general idempotency check for inline-only, delete-only, or retired commits.
+MySQL returns `Unsupported` for both snapshot-change APIs. Coordination locks
+cover the whole catalog file on SQLite and DuckDB, and the requested identity on
+multicatalog PostgreSQL; MySQL does not implement that API.
+
 `WriteMode::Replace` (SQL `INSERT OVERWRITE`, and the first write of a table) is
 **abort-on-conflict** under concurrency, matching DuckLake's snapshot isolation:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,9 @@ pub type Result<T> = std::result::Result<T, DuckLakeError>;
 // Re-export main types for convenience
 pub use catalog::DuckLakeCatalog;
 pub use error::{DuckLakeError, TypeChangeOperation, TypeChangeWriteMode};
-pub use metadata_provider::{DuckLakeFileData, DuckLakeTableFile, MetadataProvider};
+pub use metadata_provider::{
+    DuckLakeFileData, DuckLakeTableFile, MetadataProvider, SnapshotChangeMetadata,
+};
 pub use partition::{PartitionSpec, PartitionSpecColumn, PartitionTransform};
 pub use schema::DuckLakeSchema;
 pub use sort::{NullOrder, SortDirection, SortField, SortSpec};
@@ -137,8 +139,9 @@ pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
-    DeleteFileEntry, DeleteFileInfo, MetadataWriter, SnapshotCommitMetadata, SourceRetirement,
-    WriteMode, WriteResult, WriteSetupResult,
+    DeleteFileEntry, DeleteFileInfo, InlinedRowRef, MetadataWriter, MultiTableCommit,
+    SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite, WriteMode,
+    WriteResult, WriteSetupResult,
 };
 #[cfg(feature = "write-duckdb")]
 pub use metadata_writer_duckdb::DuckdbMetadataWriter;
@@ -158,7 +161,8 @@ pub use multicatalog_provider::MulticatalogProvider;
 pub use sql::execute_ducklake_sql;
 #[cfg(feature = "write")]
 pub use table_writer::{
-    DuckLakeTableWriter, DuckLakeWriteOptions, TableWriteOptions, TableWriteSession,
+    DuckLakeTableWriter, DuckLakeWriteOptions, DuckLakeWriteTransaction, TableWriteOptions,
+    TableWriteSession,
 };
 #[cfg(feature = "write")]
 pub use update_exec::DuckLakeUpdateExec;

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -1,5 +1,5 @@
-use crate::Result;
 use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
+use crate::{DuckLakeError, Result};
 use arrow::datatypes::{DataType, Field, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
@@ -413,7 +413,7 @@ pub struct SnapshotChangeMetadata {
     /// Timestamp when the snapshot was created.
     pub timestamp: Option<String>,
     /// Comma-separated DuckLake change tokens.
-    pub changes_made: String,
+    pub changes_made: Option<String>,
     /// Optional commit author.
     pub author: Option<String>,
     /// Optional commit message.
@@ -1447,7 +1447,9 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
 
     /// List snapshot change-ledger entries in snapshot order.
     fn list_snapshot_changes(&self) -> Result<Vec<SnapshotChangeMetadata>> {
-        Ok(Vec::new())
+        Err(DuckLakeError::Unsupported(
+            "snapshot change metadata is not supported by this backend".to_string(),
+        ))
     }
 
     /// Find the first snapshot with live data files whose `commit_extra_info`
@@ -1457,7 +1459,9 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
     /// and supplies the exact needle to match (including any delimiters its
     /// own convention uses to make substring matches unambiguous).
     fn find_snapshot_by_commit_extra_info(&self, _needle: &str) -> Result<Option<i64>> {
-        Ok(None)
+        Err(DuckLakeError::Unsupported(
+            "commit metadata lookup is not supported by this backend".to_string(),
+        ))
     }
 
     /// List schemas for a specific snapshot

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -405,6 +405,23 @@ pub struct SnapshotMetadata {
     pub timestamp: Option<String>,
 }
 
+/// Change ledger entry associated with a DuckLake snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotChangeMetadata {
+    /// Unique identifier for the snapshot.
+    pub snapshot_id: i64,
+    /// Timestamp when the snapshot was created.
+    pub timestamp: Option<String>,
+    /// Comma-separated DuckLake change tokens.
+    pub changes_made: String,
+    /// Optional commit author.
+    pub author: Option<String>,
+    /// Optional commit message.
+    pub commit_message: Option<String>,
+    /// Optional application-defined commit metadata.
+    pub commit_extra_info: Option<String>,
+}
+
 pub(crate) fn parse_snapshot_timestamp(raw: &str) -> Option<chrono::NaiveDateTime> {
     let mut timestamp = raw.trim();
     for suffix in ["Z", " UTC", "+00:00", "+00"] {
@@ -642,7 +659,9 @@ pub fn inlined_delete_table_name(table_id: i64) -> Result<String> {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum InlinedDataBackend {
+    #[cfg_attr(not(feature = "metadata-postgres"), allow(dead_code))]
     Postgres,
+    #[cfg_attr(not(feature = "metadata-mysql"), allow(dead_code))]
     MySql,
 }
 
@@ -828,6 +847,19 @@ pub struct DuckLakeNameMapping {
     pub table_id: i64,
     pub mapping_type: String,
     pub entries: Vec<DuckLakeNameMappingEntry>,
+}
+
+/// One physical inlined-data table's visible rows with their stable row ids.
+#[derive(Debug, Clone)]
+pub struct DuckLakeInlinedData {
+    /// Catalog physical table that owns the rows.
+    pub table_name: String,
+    /// Stable DuckLake row ids, aligned with `batch` rows.
+    pub row_ids: Vec<i64>,
+    /// Snapshot that introduced each row, aligned with `batch` rows.
+    pub begin_snapshots: Vec<i64>,
+    /// Physical table columns in catalog order.
+    pub batch: arrow::record_batch::RecordBatch,
 }
 
 impl DuckLakeTableColumn {
@@ -1413,6 +1445,21 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
     /// List all snapshots in the catalog
     fn list_snapshots(&self) -> Result<Vec<SnapshotMetadata>>;
 
+    /// List snapshot change-ledger entries in snapshot order.
+    fn list_snapshot_changes(&self) -> Result<Vec<SnapshotChangeMetadata>> {
+        Ok(Vec::new())
+    }
+
+    /// Find the first snapshot with live data files whose `commit_extra_info`
+    /// equals or contains `needle`.
+    ///
+    /// `commit_extra_info` is opaque to DuckLake; the caller owns its format
+    /// and supplies the exact needle to match (including any delimiters its
+    /// own convention uses to make substring matches unambiguous).
+    fn find_snapshot_by_commit_extra_info(&self, _needle: &str) -> Result<Option<i64>> {
+        Ok(None)
+    }
+
     /// List schemas for a specific snapshot
     fn list_schemas(&self, snapshot_id: i64) -> Result<Vec<SchemaMetadata>>;
 
@@ -1631,6 +1678,18 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         _table_id: i64,
         _snapshot_id: i64,
     ) -> Result<Vec<DuckLakeInlinedDelete>> {
+        Ok(Vec::new())
+    }
+
+    /// Read visible inlined rows together with their physical table and stable
+    /// row ids for mutation planning. Backends that only support read-only
+    /// inlined scans may keep the empty default.
+    fn get_inlined_data_with_row_ids(
+        &self,
+        _table_id: i64,
+        _snapshot_id: i64,
+        _columns: &[DuckLakeTableColumn],
+    ) -> Result<Vec<DuckLakeInlinedData>> {
         Ok(Vec::new())
     }
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -2,8 +2,8 @@ use crate::DuckLakeError;
 use crate::metadata_provider::SQL_FILE_SCHEMA_VERSION;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
-    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedData, DuckLakeInlinedDelete,
+    DuckLakeNameMapping, DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, INLINED_DATA_REMEDIATION, MetadataProvider, MetadataSetting, SQL_GET_DATA_FILES,
     SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS,
@@ -12,9 +12,10 @@ use crate::metadata_provider::{
     SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS, SQL_GET_TABLE_STATS, SQL_GET_VIEW_BY_NAME,
     SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES, SQL_LIST_ALL_VIEWS, SQL_LIST_SCHEMAS,
     SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_LIST_VIEWS, SQL_TABLE_EXISTS, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
-    build_inlined_batch, inlined_delete_table_name, inlined_missing_scalar, is_inlined_data_table,
-    reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
+    SnapshotChangeMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata,
+    ViewWithSchema, build_inlined_batch, inlined_delete_table_name, inlined_missing_scalar,
+    is_inlined_data_table, reconstruct_columns, reconstruct_columns_with_table,
+    resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -24,7 +25,7 @@ use arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
 use duckdb::AccessMode::ReadOnly;
 use duckdb::types::{TimeUnit as DuckdbTimeUnit, ValueRef};
-use duckdb::{Config, Connection, params};
+use duckdb::{Config, Connection, OptionalExt, params};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
@@ -459,7 +460,15 @@ fn duckdb_inlined_scalar(
                     "inlined data for column '{column}' has an out-of-range time value"
                 ))
             })?;
-            ScalarValue::Time64Microsecond(Some(value))
+            match to {
+                TimeUnit::Microsecond => ScalarValue::Time64Microsecond(Some(value)),
+                TimeUnit::Nanosecond => ScalarValue::Time64Nanosecond(Some(value)),
+                _ => {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "inlined data column '{column}' has unsupported time unit {to:?}"
+                    )));
+                },
+            }
         },
         (DataType::Timestamp(to, timezone), ValueRef::Timestamp(from, value)) => {
             let value = convert_time(value, from, *to).ok_or_else(|| {
@@ -507,7 +516,12 @@ fn duckdb_inlined_scalar(
                 crate::DuckLakeError::Unsupported(format!(
                     "inlined data for column '{column}' cannot decode '{value}' as fixed-size binary {size}"
                 ))
-            })?
+                })?
+        },
+        (DataType::FixedSizeBinary(size), ValueRef::Blob(value))
+            if value.len() == *size as usize =>
+        {
+            ScalarValue::FixedSizeBinary(*size, Some(value.to_vec()))
         },
         (data_type, value) => {
             return Err(crate::DuckLakeError::Unsupported(format!(
@@ -689,6 +703,17 @@ impl DuckdbMetadataProvider {
             catalog_path,
             schema_capabilities: Arc::new(OnceLock::new()),
         })
+    }
+
+    pub(crate) fn from_shared_connection(
+        conn: Arc<Mutex<Connection>>,
+        catalog_path: String,
+    ) -> Self {
+        Self {
+            conn,
+            catalog_path,
+            schema_capabilities: Arc::new(OnceLock::new()),
+        }
     }
 
     /// Get a reference to the shared connection
@@ -878,6 +903,58 @@ impl MetadataProvider for DuckdbMetadataProvider {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(snapshots)
+    }
+
+    fn list_snapshot_changes(&self) -> crate::Result<Vec<SnapshotChangeMetadata>> {
+        let conn = self.connection();
+        let mut statement = conn.prepare(
+            "SELECT snapshot.snapshot_id,
+                    CAST(snapshot.snapshot_time AS VARCHAR),
+                    changes.changes_made,
+                    changes.author,
+                    changes.commit_message,
+                    changes.commit_extra_info
+             FROM ducklake_snapshot AS snapshot
+             JOIN ducklake_snapshot_changes AS changes
+               ON changes.snapshot_id = snapshot.snapshot_id
+             ORDER BY snapshot.snapshot_id",
+        )?;
+        let changes = statement
+            .query_map([], |row| {
+                Ok(SnapshotChangeMetadata {
+                    snapshot_id: row.get(0)?,
+                    timestamp: row.get(1)?,
+                    changes_made: row.get(2)?,
+                    author: row.get(3)?,
+                    commit_message: row.get(4)?,
+                    commit_extra_info: row.get(5)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(changes)
+    }
+
+    fn find_snapshot_by_commit_extra_info(&self, needle: &str) -> crate::Result<Option<i64>> {
+        let conn = self.connection();
+        let snapshot_id = conn
+            .query_row(
+                "SELECT changes.snapshot_id
+                 FROM ducklake_snapshot_changes AS changes
+                 WHERE (changes.commit_extra_info = ?
+                        OR strpos(changes.commit_extra_info, ?) > 0)
+                   AND EXISTS (
+                       SELECT 1
+                       FROM ducklake_data_file AS files
+                       WHERE files.begin_snapshot = changes.snapshot_id
+                         AND files.end_snapshot IS NULL
+                   )
+                 ORDER BY changes.snapshot_id
+                 LIMIT 1",
+                params![needle, needle],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(snapshot_id)
     }
 
     fn list_schemas(&self, snapshot_id: i64) -> crate::Result<Vec<SchemaMetadata>> {
@@ -1624,6 +1701,101 @@ impl MetadataProvider for DuckdbMetadataProvider {
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    fn get_inlined_data_with_row_ids(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        columns: &[DuckLakeTableColumn],
+    ) -> crate::Result<Vec<DuckLakeInlinedData>> {
+        let conn = self.connection();
+        if !self.schema_capabilities(&conn)?.inlined_data_tables {
+            return Ok(Vec::new());
+        }
+
+        let mut registry =
+            conn.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+        let tables = registry
+            .query_map([table_id], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let schema: SchemaRef = Arc::new(crate::types::build_arrow_schema(columns)?);
+        let mut batches = Vec::new();
+        for table in tables {
+            if !is_inlined_data_table(&table) {
+                continue;
+            }
+
+            let info_sql = format!("SELECT name FROM pragma_table_info('{table}')");
+            let mut info = conn.prepare(&info_sql)?;
+            let present = info
+                .query_map([], |row| row.get::<_, String>(0))?
+                .collect::<std::result::Result<HashSet<_>, _>>()?;
+            let projected = columns
+                .iter()
+                .zip(schema.fields())
+                .map(|(column, field)| {
+                    if !present.contains(&column.column_name) {
+                        return "NULL".to_string();
+                    }
+                    let ident = quote_ident(&column.column_name);
+                    if matches!(
+                        field.data_type(),
+                        DataType::Utf8
+                            | DataType::LargeUtf8
+                            | DataType::Utf8View
+                            | DataType::FixedSizeBinary(_)
+                    ) {
+                        format!("CAST({ident} AS VARCHAR)")
+                    } else {
+                        ident
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT row_id, begin_snapshot, {projected} FROM {} \
+                 WHERE ? >= begin_snapshot AND (? < end_snapshot OR end_snapshot IS NULL) \
+                 ORDER BY begin_snapshot, row_id",
+                quote_ident(&table),
+            );
+            let mut statement = conn.prepare(&sql)?;
+            let mut query = statement.query(params![snapshot_id, snapshot_id])?;
+            let mut row_ids = Vec::new();
+            let mut begin_snapshots = Vec::new();
+            let mut rows = Vec::new();
+            while let Some(row) = query.next()? {
+                row_ids.push(row.get(0)?);
+                begin_snapshots.push(row.get(1)?);
+                rows.push(
+                    schema
+                        .fields()
+                        .iter()
+                        .enumerate()
+                        .map(|(index, field)| {
+                            if !present.contains(&columns[index].column_name) {
+                                return inlined_missing_scalar(&columns[index], field.data_type());
+                            }
+                            duckdb_inlined_scalar(
+                                row.get_ref(index + 2)?,
+                                field.data_type(),
+                                &columns[index].column_name,
+                            )
+                        })
+                        .collect::<crate::Result<Vec<_>>>()?,
+                );
+            }
+            if rows.is_empty() {
+                continue;
+            }
+            batches.push(DuckLakeInlinedData {
+                table_name: table,
+                row_ids,
+                begin_snapshots,
+                batch: build_inlined_batch(schema.clone(), columns, &rows)?,
+            });
+        }
+        Ok(batches)
     }
 
     fn get_schema_by_name(

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -915,7 +915,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     changes.commit_message,
                     changes.commit_extra_info
              FROM ducklake_snapshot AS snapshot
-             JOIN ducklake_snapshot_changes AS changes
+             LEFT JOIN ducklake_snapshot_changes AS changes
                ON changes.snapshot_id = snapshot.snapshot_id
              ORDER BY snapshot.snapshot_id",
         )?;

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -3,8 +3,8 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
-    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedData, DuckLakeInlinedDelete,
+    DuckLakeNameMapping, DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, InlinedDataBackend, MetadataProvider, MetadataSetting,
     SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
@@ -1490,6 +1490,104 @@ impl MetadataProvider for MySqlMetadataProvider {
                     rows,
                     Some(&present),
                 )?);
+            }
+            Ok(batches)
+        })
+    }
+
+    fn get_inlined_data_with_row_ids(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        columns: &[DuckLakeTableColumn],
+    ) -> Result<Vec<DuckLakeInlinedData>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.inlined_data_tables {
+                return Ok(Vec::new());
+            }
+            let entries = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let schema: SchemaRef = Arc::new(crate::types::build_strict_arrow_schema(columns)?);
+            let mut batches = Vec::new();
+
+            for entry in entries {
+                let table: String = entry.try_get("table_name")?;
+                if !is_inlined_data_table(&table) {
+                    continue;
+                }
+                let present = sqlx::query(
+                    "SELECT column_name FROM information_schema.columns
+                     WHERE table_schema = DATABASE() AND table_name = ?",
+                )
+                .bind(&table)
+                .fetch_all(&self.pool)
+                .await?
+                .into_iter()
+                .map(|row| row.try_get::<String, _>(0))
+                .collect::<std::result::Result<HashSet<_>, _>>()?;
+                let projected = columns
+                    .iter()
+                    .zip(schema.fields())
+                    .map(|(column, field)| {
+                        if !present.contains(&column.column_name) {
+                            "NULL".to_string()
+                        } else {
+                            let ident = quote_ident(&column.column_name);
+                            inlined_text_projection(
+                                InlinedDataBackend::MySql,
+                                column,
+                                field.data_type(),
+                                &ident,
+                            )
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let sql = format!(
+                    "SELECT row_id, begin_snapshot, {projected} FROM {}
+                     WHERE ? >= begin_snapshot AND (? < end_snapshot OR end_snapshot IS NULL)
+                     ORDER BY begin_snapshot, row_id",
+                    quote_ident(&table)
+                );
+                let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
+                    .bind(snapshot_id)
+                    .bind(snapshot_id)
+                    .fetch_all(&self.pool)
+                    .await?;
+                if rows.is_empty() {
+                    continue;
+                }
+                let row_ids = rows
+                    .iter()
+                    .map(|row| row.try_get("row_id"))
+                    .collect::<std::result::Result<Vec<i64>, _>>()?;
+                let begin_snapshots = rows
+                    .iter()
+                    .map(|row| row.try_get("begin_snapshot"))
+                    .collect::<std::result::Result<Vec<i64>, _>>()?;
+                let values = rows
+                    .iter()
+                    .map(|row| {
+                        (0..columns.len())
+                            .map(|index| row.try_get::<Option<String>, _>(index + 2))
+                            .collect::<std::result::Result<Vec<_>, _>>()
+                    })
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                batches.push(DuckLakeInlinedData {
+                    table_name: table,
+                    row_ids,
+                    begin_snapshots,
+                    batch: parse_inlined_rows_with_present(
+                        schema.clone(),
+                        columns,
+                        values,
+                        Some(&present),
+                    )?,
+                });
             }
             Ok(batches)
         })

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -8,10 +8,10 @@ use crate::metadata_provider::{
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, InlinedDataBackend, MetadataProvider, MetadataSetting,
     SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
-    SQL_GET_TABLE_COLUMNS, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
-    ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name, inlined_text_projection,
-    is_inlined_data_table, parse_inlined_rows_with_present, reconstruct_columns,
-    reconstruct_columns_with_table, resolve_metadata_settings,
+    SQL_GET_TABLE_COLUMNS, SchemaMetadata, SnapshotChangeMetadata, SnapshotMetadata, TableMetadata,
+    TableWithSchema, ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name,
+    inlined_text_projection, is_inlined_data_table, parse_inlined_rows_with_present,
+    reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -642,6 +642,62 @@ impl MetadataProvider for MySqlMetadataProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_snapshot_changes(&self) -> Result<Vec<SnapshotChangeMetadata>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT snapshot.snapshot_id,
+                        CAST(snapshot.snapshot_time AS CHAR) AS snapshot_time,
+                        changes.changes_made,
+                        changes.author,
+                        changes.commit_message,
+                        changes.commit_extra_info
+                 FROM ducklake_snapshot AS snapshot
+                 LEFT JOIN ducklake_snapshot_changes AS changes
+                   ON changes.snapshot_id = snapshot.snapshot_id
+                 ORDER BY snapshot.snapshot_id",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(SnapshotChangeMetadata {
+                        snapshot_id: row.try_get("snapshot_id")?,
+                        timestamp: row.try_get("snapshot_time")?,
+                        changes_made: row.try_get("changes_made")?,
+                        author: row.try_get("author")?,
+                        commit_message: row.try_get("commit_message")?,
+                        commit_extra_info: row.try_get("commit_extra_info")?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn find_snapshot_by_commit_extra_info(&self, needle: &str) -> Result<Option<i64>> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT changes.snapshot_id
+                 FROM ducklake_snapshot_changes AS changes
+                 WHERE (BINARY changes.commit_extra_info = BINARY ?
+                        OR instr(BINARY changes.commit_extra_info, BINARY ?) > 0)
+                   AND EXISTS (
+                       SELECT 1 FROM ducklake_data_file AS files
+                       WHERE files.begin_snapshot = changes.snapshot_id
+                         AND files.end_snapshot IS NULL
+                   )
+                 ORDER BY changes.snapshot_id
+                 LIMIT 1",
+            )
+            .bind(needle)
+            .bind(needle)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            Ok(row.map(|row| row.try_get("snapshot_id")).transpose()?)
         })
     }
 

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -3,14 +3,14 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
-    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedData, DuckLakeInlinedDelete,
+    DuckLakeNameMapping, DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, InlinedDataBackend, MetadataProvider, MetadataSetting, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
-    inlined_delete_table_name, inlined_text_projection, is_inlined_data_table,
-    parse_inlined_rows_with_present, reconstruct_columns, reconstruct_columns_with_table,
-    resolve_metadata_settings,
+    SnapshotChangeMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata,
+    ViewWithSchema, block_on, inlined_delete_table_name, inlined_text_projection,
+    is_inlined_data_table, parse_inlined_rows_with_present, reconstruct_columns,
+    reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -938,6 +938,62 @@ impl MetadataProvider for PostgresMetadataProvider {
         })
     }
 
+    fn list_snapshot_changes(&self) -> Result<Vec<SnapshotChangeMetadata>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT snapshot.snapshot_id,
+                        snapshot.snapshot_time::text AS snapshot_time,
+                        changes.changes_made,
+                        changes.author,
+                        changes.commit_message,
+                        changes.commit_extra_info
+                 FROM ducklake_snapshot AS snapshot
+                 JOIN ducklake_snapshot_changes AS changes
+                   ON changes.snapshot_id = snapshot.snapshot_id
+                 ORDER BY snapshot.snapshot_id",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(SnapshotChangeMetadata {
+                        snapshot_id: row.try_get("snapshot_id")?,
+                        timestamp: row.try_get("snapshot_time")?,
+                        changes_made: row.try_get("changes_made")?,
+                        author: row.try_get("author")?,
+                        commit_message: row.try_get("commit_message")?,
+                        commit_extra_info: row.try_get("commit_extra_info")?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn find_snapshot_by_commit_extra_info(&self, needle: &str) -> Result<Option<i64>> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT changes.snapshot_id
+                 FROM ducklake_snapshot_changes AS changes
+                 WHERE (changes.commit_extra_info = $1
+                        OR strpos(changes.commit_extra_info, $2) > 0)
+                   AND EXISTS (
+                       SELECT 1 FROM ducklake_data_file AS files
+                       WHERE files.begin_snapshot = changes.snapshot_id
+                         AND files.end_snapshot IS NULL
+                   )
+                 ORDER BY changes.snapshot_id
+                 LIMIT 1",
+            )
+            .bind(needle)
+            .bind(needle)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            Ok(row.map(|row| row.try_get("snapshot_id")).transpose()?)
+        })
+    }
+
     fn list_schemas(&self, snapshot_id: i64) -> Result<Vec<SchemaMetadata>> {
         block_on(async {
             let rows = sqlx::query(
@@ -1640,6 +1696,104 @@ impl MetadataProvider for PostgresMetadataProvider {
                     rows,
                     Some(&present),
                 )?);
+            }
+            Ok(batches)
+        })
+    }
+
+    fn get_inlined_data_with_row_ids(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        columns: &[DuckLakeTableColumn],
+    ) -> Result<Vec<DuckLakeInlinedData>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.inlined_data_tables {
+                return Ok(Vec::new());
+            }
+            let entries = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let schema: SchemaRef = Arc::new(crate::types::build_arrow_schema(columns)?);
+            let mut batches = Vec::new();
+
+            for entry in entries {
+                let table: String = entry.try_get("table_name")?;
+                if !is_inlined_data_table(&table) {
+                    continue;
+                }
+                let present = sqlx::query(
+                    "SELECT column_name FROM information_schema.columns
+                     WHERE table_schema = current_schema() AND table_name = $1",
+                )
+                .bind(&table)
+                .fetch_all(&self.pool)
+                .await?
+                .into_iter()
+                .map(|row| row.try_get::<String, _>(0))
+                .collect::<std::result::Result<HashSet<_>, _>>()?;
+                let projected = columns
+                    .iter()
+                    .zip(schema.fields())
+                    .map(|(column, field)| {
+                        if !present.contains(&column.column_name) {
+                            "NULL::text".to_string()
+                        } else {
+                            let ident = quote_ident(&column.column_name);
+                            inlined_text_projection(
+                                InlinedDataBackend::Postgres,
+                                column,
+                                field.data_type(),
+                                &ident,
+                            )
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let sql = format!(
+                    "SELECT row_id, begin_snapshot, {projected} FROM {}
+                     WHERE $1 >= begin_snapshot AND ($2 < end_snapshot OR end_snapshot IS NULL)
+                     ORDER BY begin_snapshot, row_id",
+                    quote_ident(&table)
+                );
+                let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
+                    .bind(snapshot_id)
+                    .bind(snapshot_id)
+                    .fetch_all(&self.pool)
+                    .await?;
+                if rows.is_empty() {
+                    continue;
+                }
+                let row_ids = rows
+                    .iter()
+                    .map(|row| row.try_get("row_id"))
+                    .collect::<std::result::Result<Vec<i64>, _>>()?;
+                let begin_snapshots = rows
+                    .iter()
+                    .map(|row| row.try_get("begin_snapshot"))
+                    .collect::<std::result::Result<Vec<i64>, _>>()?;
+                let decoded_rows = rows
+                    .into_iter()
+                    .map(|row| {
+                        (0..columns.len())
+                            .map(|index| row.try_get::<Option<String>, _>(index + 2))
+                            .collect::<std::result::Result<Vec<_>, _>>()
+                    })
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                batches.push(DuckLakeInlinedData {
+                    table_name: table,
+                    row_ids,
+                    begin_snapshots,
+                    batch: parse_inlined_rows_with_present(
+                        schema.clone(),
+                        columns,
+                        decoded_rows,
+                        Some(&present),
+                    )?,
+                });
             }
             Ok(batches)
         })

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -948,7 +948,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         changes.commit_message,
                         changes.commit_extra_info
                  FROM ducklake_snapshot AS snapshot
-                 JOIN ducklake_snapshot_changes AS changes
+                 LEFT JOIN ducklake_snapshot_changes AS changes
                    ON changes.snapshot_id = snapshot.snapshot_id
                  ORDER BY snapshot.snapshot_id",
             )

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -787,7 +787,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         changes.commit_message,
                         changes.commit_extra_info
                  FROM ducklake_snapshot AS snapshot
-                 JOIN ducklake_snapshot_changes AS changes
+                 LEFT JOIN ducklake_snapshot_changes AS changes
                    ON changes.snapshot_id = snapshot.snapshot_id
                  ORDER BY snapshot.snapshot_id",
             )

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -4,22 +4,23 @@ use crate::Result;
 use crate::metadata_provider::SQL_FILE_SCHEMA_VERSION;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedDelete, DuckLakeNameMapping,
-    DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedData, DuckLakeInlinedDelete,
+    DuckLakeNameMapping, DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
     FileWithTable, MetadataProvider, MetadataSetting, SQL_GET_FILE_PARTITION_VALUES,
     SQL_GET_NAME_MAPPING, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC, SQL_GET_TABLE_COLUMNS,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
-    block_on, inlined_delete_table_name, inlined_missing_scalar, reconstruct_columns,
-    reconstruct_columns_with_table, resolve_metadata_settings,
+    SchemaMetadata, SnapshotChangeMetadata, SnapshotMetadata, TableMetadata, TableWithSchema,
+    ViewMetadata, ViewWithSchema, block_on, inlined_delete_table_name, inlined_missing_scalar,
+    reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
 use crate::stats_encode::{is_canonical_date, is_canonical_timestamp, is_canonical_timestamptz};
 use crate::stats_filter::{StatsFilter, StatsLiteral, StatsSqlDialect};
 use arrow::array::{
-    ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array,
-    Int32Array, Int64Array, RecordBatch, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Float32Array, Float64Array, Int8Array,
+    Int16Array, Int32Array, Int64Array, LargeBinaryArray, RecordBatch, StringViewArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::{DataType, SchemaRef};
 use sqlx::AssertSqlSafe;
@@ -132,7 +133,23 @@ fn build_inlined_batch(
             DataType::UInt8 => ints!(UInt8Array, u8),
             DataType::UInt16 => ints!(UInt16Array, u16),
             DataType::UInt32 => ints!(UInt32Array, u32),
-            DataType::UInt64 => ints!(UInt64Array, u64),
+            DataType::UInt64 => {
+                let mut values = Vec::with_capacity(n);
+                for row in rows {
+                    let value = row.try_get::<Option<String>, _>(name)?;
+                    values.push(
+                        value
+                            .map(|value| value.parse::<u64>())
+                            .transpose()
+                            .map_err(|e| {
+                                crate::DuckLakeError::InvalidConfig(format!(
+                                    "invalid inlined UInt64 value for column '{name}': {e}"
+                                ))
+                            })?,
+                    );
+                }
+                Arc::new(UInt64Array::from(values)) as ArrayRef
+            },
             DataType::Float32 => {
                 let mut b = Vec::with_capacity(n);
                 for r in rows {
@@ -154,6 +171,13 @@ fn build_inlined_batch(
                 }
                 Arc::new(arrow::array::StringArray::from(b)) as ArrayRef
             },
+            DataType::Utf8View => {
+                let mut values: Vec<Option<String>> = Vec::with_capacity(n);
+                for row in rows {
+                    values.push(row.try_get::<Option<String>, _>(name)?);
+                }
+                Arc::new(values.into_iter().collect::<StringViewArray>()) as ArrayRef
+            },
             DataType::Boolean => {
                 let mut b = Vec::with_capacity(n);
                 for r in rows {
@@ -170,11 +194,64 @@ fn build_inlined_batch(
                     b.iter().map(|o| o.as_deref()).collect::<Vec<_>>(),
                 )) as ArrayRef
             },
+            DataType::LargeBinary => {
+                let mut values: Vec<Option<Vec<u8>>> = Vec::with_capacity(n);
+                for row in rows {
+                    values.push(row.try_get::<Option<Vec<u8>>, _>(name)?);
+                }
+                Arc::new(LargeBinaryArray::from(
+                    values
+                        .iter()
+                        .map(|value| value.as_deref())
+                        .collect::<Vec<_>>(),
+                )) as ArrayRef
+            },
+            DataType::BinaryView => {
+                let mut values: Vec<Option<Vec<u8>>> = Vec::with_capacity(n);
+                for row in rows {
+                    values.push(row.try_get::<Option<Vec<u8>>, _>(name)?);
+                }
+                Arc::new(values.into_iter().collect::<BinaryViewArray>()) as ArrayRef
+            },
+            DataType::FixedSizeBinary(size) if *size != 16 => {
+                let values = rows
+                    .iter()
+                    .map(|row| -> Result<datafusion::common::ScalarValue> {
+                        Ok(match row.try_get::<Option<Vec<u8>>, _>(name)? {
+                            Some(value) if value.len() == *size as usize => {
+                                datafusion::common::ScalarValue::FixedSizeBinary(*size, Some(value))
+                            },
+                            Some(value) => {
+                                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                                    "inlined data column '{name}' expected {size} bytes, was {}",
+                                    value.len(),
+                                )));
+                            },
+                            None => datafusion::common::ScalarValue::FixedSizeBinary(*size, None),
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                datafusion::common::ScalarValue::iter_to_array(values.into_iter())?
+            },
             other => {
-                return Err(crate::error::DuckLakeError::Unsupported(format!(
-                    "inlined data for column '{name}' of type {other:?} is not yet supported; \
-                     flush inlined data to Parquet (or disable data inlining at write time)"
-                )));
+                let values = rows
+                    .iter()
+                    .map(|row| -> Result<datafusion::common::ScalarValue> {
+                        let value = row.try_get::<Option<String>, _>(name)?;
+                        match value {
+                            Some(value) => crate::types::parse_ducklake_scalar(&value, other)
+                                .ok_or_else(|| {
+                                    crate::DuckLakeError::Unsupported(format!(
+                                        "inlined data column '{name}' type {other:?} cannot decode \
+                                 '{value}'; {}",
+                                        crate::metadata_provider::INLINED_DATA_REMEDIATION,
+                                    ))
+                                }),
+                            None => Ok(datafusion::common::ScalarValue::try_from(other)?),
+                        }
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                datafusion::common::ScalarValue::iter_to_array(values.into_iter())?
             },
         };
         arrays.push(array);
@@ -697,6 +774,62 @@ impl MetadataProvider for SqliteMetadataProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_snapshot_changes(&self) -> Result<Vec<SnapshotChangeMetadata>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT snapshot.snapshot_id,
+                        CAST(snapshot.snapshot_time AS TEXT) AS snapshot_time,
+                        changes.changes_made,
+                        changes.author,
+                        changes.commit_message,
+                        changes.commit_extra_info
+                 FROM ducklake_snapshot AS snapshot
+                 JOIN ducklake_snapshot_changes AS changes
+                   ON changes.snapshot_id = snapshot.snapshot_id
+                 ORDER BY snapshot.snapshot_id",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(SnapshotChangeMetadata {
+                        snapshot_id: row.try_get("snapshot_id")?,
+                        timestamp: row.try_get("snapshot_time")?,
+                        changes_made: row.try_get("changes_made")?,
+                        author: row.try_get("author")?,
+                        commit_message: row.try_get("commit_message")?,
+                        commit_extra_info: row.try_get("commit_extra_info")?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn find_snapshot_by_commit_extra_info(&self, needle: &str) -> Result<Option<i64>> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT changes.snapshot_id
+                 FROM ducklake_snapshot_changes AS changes
+                 WHERE (changes.commit_extra_info = ?
+                        OR instr(changes.commit_extra_info, ?) > 0)
+                   AND EXISTS (
+                       SELECT 1 FROM ducklake_data_file AS files
+                       WHERE files.begin_snapshot = changes.snapshot_id
+                         AND files.end_snapshot IS NULL
+                   )
+                 ORDER BY changes.snapshot_id
+                 LIMIT 1",
+            )
+            .bind(needle)
+            .bind(needle)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            Ok(row.map(|row| row.try_get("snapshot_id")).transpose()?)
         })
     }
 
@@ -1660,6 +1793,86 @@ impl MetadataProvider for SqliteMetadataProvider {
                 Err(error) if is_missing_statistics_table(&error) => Ok(Vec::new()),
                 Err(error) => Err(error.into()),
             }
+        })
+    }
+
+    fn get_inlined_data_with_row_ids(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        columns: &[DuckLakeTableColumn],
+    ) -> Result<Vec<DuckLakeInlinedData>> {
+        block_on(async {
+            if !self.schema_capabilities().await?.inlined_data_tables {
+                return Ok(Vec::new());
+            }
+            let regs = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let schema: SchemaRef = Arc::new(crate::types::build_arrow_schema(columns)?);
+            let mut batches = Vec::new();
+            for reg in regs {
+                let physical_name: String = reg.try_get("table_name")?;
+                if !physical_name.starts_with("ducklake_inlined_data_")
+                    || !physical_name
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+                {
+                    continue;
+                }
+                let info = sqlx::query(AssertSqlSafe(format!(
+                    "SELECT name FROM pragma_table_info({})",
+                    format_args!("'{}'", physical_name.replace('\'', "''"))
+                )))
+                .fetch_all(&self.pool)
+                .await?;
+                let present: HashSet<String> = info
+                    .iter()
+                    .filter_map(|row| row.try_get::<String, _>("name").ok())
+                    .collect();
+                let projected = columns
+                    .iter()
+                    .filter(|column| present.contains(column.column_name.as_str()))
+                    .map(|column| quote_ident(&column.column_name))
+                    .collect::<Vec<_>>();
+                let select_list = if projected.is_empty() {
+                    "row_id, begin_snapshot".to_string()
+                } else {
+                    format!("row_id, begin_snapshot, {}", projected.join(", "))
+                };
+                let sql = format!(
+                    "SELECT {select_list} FROM {} \
+                     WHERE ? >= begin_snapshot AND (? < end_snapshot OR end_snapshot IS NULL) \
+                 ORDER BY begin_snapshot, row_id",
+                    quote_ident(&physical_name)
+                );
+                let rows = sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .bind(snapshot_id)
+                    .fetch_all(&self.pool)
+                    .await?;
+                if rows.is_empty() {
+                    continue;
+                }
+                let row_ids = rows
+                    .iter()
+                    .map(|row| row.try_get("row_id"))
+                    .collect::<std::result::Result<Vec<i64>, _>>()?;
+                let begin_snapshots = rows
+                    .iter()
+                    .map(|row| row.try_get("begin_snapshot"))
+                    .collect::<std::result::Result<Vec<i64>, _>>()?;
+                batches.push(DuckLakeInlinedData {
+                    table_name: physical_name,
+                    row_ids,
+                    begin_snapshots,
+                    batch: build_inlined_batch(&schema, columns, &present, &rows)?,
+                });
+            }
+            Ok(batches)
         })
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -1042,6 +1042,104 @@ pub struct InlinedRowRef {
     pub row_id: i64,
 }
 
+/// Row storage staged for one table in a multi-table write.
+#[derive(Debug, Clone)]
+pub enum StagedTableData {
+    /// Parquet data files already uploaded to object storage.
+    Files(Vec<DataFileInfo>),
+    /// Record batches to store in DuckLake's metadata catalog.
+    Inlined(Vec<RecordBatch>),
+    /// No inserted rows; the stage contains only deletes.
+    None,
+}
+
+/// One table's staged changes in a multi-table write.
+#[derive(Debug, Clone)]
+pub struct StagedTableWrite {
+    pub(crate) table_id: i64,
+    pub(crate) schema_name: String,
+    pub(crate) table_name: String,
+    pub(crate) base_snapshot_id: i64,
+    pub(crate) mode: WriteMode,
+    pub(crate) columns: Vec<ColumnDef>,
+    pub(crate) column_ids: Vec<i64>,
+    pub(crate) data: StagedTableData,
+    pub(crate) snapshot_id_columns: Vec<String>,
+    pub(crate) positional_deletes: Vec<DeleteFileEntry>,
+    pub(crate) inlined_deletes: Vec<InlinedRowRef>,
+}
+
+impl StagedTableWrite {
+    /// Returns the target table id reserved during write setup.
+    #[must_use]
+    pub const fn table_id(&self) -> i64 {
+        self.table_id
+    }
+
+    /// Returns the target schema name.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    /// Returns the target table name.
+    #[must_use]
+    pub fn table_name(&self) -> &str {
+        &self.table_name
+    }
+
+    /// Returns the table snapshot observed during write setup.
+    #[must_use]
+    pub const fn base_snapshot_id(&self) -> i64 {
+        self.base_snapshot_id
+    }
+
+    /// Returns the staged write mode.
+    #[must_use]
+    pub const fn mode(&self) -> WriteMode {
+        self.mode
+    }
+
+    /// Returns the staged catalog columns.
+    #[must_use]
+    pub fn columns(&self) -> &[ColumnDef] {
+        &self.columns
+    }
+
+    /// Returns the catalog column ids paired with the staged columns.
+    #[must_use]
+    pub fn column_ids(&self) -> &[i64] {
+        &self.column_ids
+    }
+
+    /// Returns the staged row storage.
+    #[must_use]
+    pub const fn data(&self) -> &StagedTableData {
+        &self.data
+    }
+
+    /// Returns the staged positional deletes.
+    #[must_use]
+    pub fn positional_deletes(&self) -> &[DeleteFileEntry] {
+        &self.positional_deletes
+    }
+
+    /// Returns the staged inlined-row deletes.
+    #[must_use]
+    pub fn inlined_deletes(&self) -> &[InlinedRowRef] {
+        &self.inlined_deletes
+    }
+}
+
+/// Result of one atomic multi-table write.
+#[derive(Debug, Clone)]
+pub struct MultiTableCommit {
+    /// Snapshot shared by every committed table change.
+    pub snapshot_id: i64,
+    /// Authoritative schema and table ids for each staged table.
+    pub tables: Vec<CommitIds>,
+}
+
 /// Result of a transactional write setup operation.
 #[derive(Debug)]
 pub struct WriteSetupResult {
@@ -1078,6 +1176,38 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     fn set_global_setting(&self, _key: &str, _value: &str) -> Result<()> {
         Err(DuckLakeError::Unsupported(
             "global-scoped settings are not supported by this metadata backend".to_string(),
+        ))
+    }
+
+    /// Replace a table-scoped catalog setting.
+    fn set_table_setting(&self, _table_id: i64, _key: &str, _value: &str) -> Result<()> {
+        Err(DuckLakeError::Unsupported(
+            "table-scoped settings are not supported by this metadata backend".to_string(),
+        ))
+    }
+
+    /// Run an operation while holding a backend-appropriate commit lock.
+    ///
+    /// A coordination utility for callers that want to serialize a multi-step
+    /// commit workflow (e.g. read staged state, dedup, commit) under one
+    /// `identity` across processes. Correctness does not depend on it: the
+    /// optimistic `expected_base_snapshot_id` fence remains the conflict
+    /// mechanism, and this lock only avoids duplicate concurrent work.
+    ///
+    /// Contract: the lock is held for the duration of `operation` and released
+    /// on both success and error before this returns; an `operation` error
+    /// propagates and takes precedence over a release error. A crashed holder
+    /// must not leave the lock held (backends use self-releasing mechanisms:
+    /// an advisory transaction lock, a file lock released on close). Keep
+    /// critical sections short — implementations may pin a connection while
+    /// the lock is held.
+    fn with_commit_lock(
+        &self,
+        _identity: &str,
+        _operation: Box<dyn FnOnce() -> Result<()> + '_>,
+    ) -> Result<()> {
+        Err(DuckLakeError::Unsupported(
+            "commit locking is not supported by this metadata backend".to_string(),
         ))
     }
 
@@ -1463,6 +1593,22 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     ) -> Result<CommitIds> {
         Err(DuckLakeError::InvalidConfig(
             "data inlining is not supported by this metadata writer".to_string(),
+        ))
+    }
+
+    /// Commit staged changes for multiple tables in one metadata transaction.
+    ///
+    /// Implementations allocate one snapshot, evaluate the optional table-state
+    /// fence once for the complete write, and make every table change visible
+    /// together. A returned error must leave no staged metadata visible.
+    fn commit_multi_table(
+        &self,
+        _writes: &[StagedTableWrite],
+        _commit_metadata: &SnapshotCommitMetadata,
+        _expected_base_snapshot_id: Option<i64>,
+    ) -> Result<MultiTableCommit> {
+        Err(DuckLakeError::InvalidConfig(
+            "multi-table writes are not supported by this metadata writer".to_string(),
         ))
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -8,7 +8,7 @@ use crate::{DuckLakeError, Result};
 use arrow::array::{Array, FixedSizeBinaryArray};
 use arrow::datatypes::{DataType, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// Maximum allowed length for catalog entity names (schemas, tables, columns).
 pub const MAX_NAME_LENGTH: usize = 1024;
@@ -47,6 +47,26 @@ pub enum WriteMode {
     Replace,
     /// Keep existing data and append new records
     Append,
+}
+
+pub(crate) fn validate_table_setting(key: &str) -> Result<String> {
+    let key = key.to_ascii_lowercase();
+    match key.as_str() {
+        "parquet_compression"
+        | "parquet_compression_level"
+        | "parquet_version"
+        | "parquet_row_group_size"
+        | "parquet_row_group_size_bytes"
+        | "target_file_size"
+        | "data_inlining_row_limit"
+        | "sort_on_insert"
+        | "hive_file_pattern"
+        | "auto_compact"
+        | "rewrite_delete_threshold" => Ok(key),
+        _ => Err(DuckLakeError::Unsupported(format!(
+            "unsupported table setting '{key}'"
+        ))),
+    }
 }
 
 pub(crate) fn table_write_changes(
@@ -103,6 +123,50 @@ pub(crate) fn table_storage_changes(
         None => {},
     }
     changes.join(",")
+}
+
+pub(crate) fn snapshot_has_change(changes: &str, expected: &str) -> bool {
+    snapshot_change_tokens(changes).any(|change| change == expected)
+}
+
+pub(crate) fn inlined_delete_conflicts(changes: &str, table_id: i64) -> bool {
+    snapshot_change_tokens(changes).any(|change| {
+        let Some((kind, id)) = change.split_once(':') else {
+            return false;
+        };
+        id.parse::<i64>().ok() == Some(table_id)
+            && [
+                "dropped_table",
+                "altered_table",
+                "inlined_delete",
+                "inline_flush",
+                "inserted_into_table",
+                "inlined_insert",
+            ]
+            .iter()
+            .any(|candidate| kind.eq_ignore_ascii_case(candidate))
+    })
+}
+
+fn snapshot_change_tokens(changes: &str) -> impl Iterator<Item = &str> {
+    let mut quoted = false;
+    changes.split(move |character| {
+        if character == '"' {
+            quoted = !quoted;
+        }
+        character == ',' && !quoted
+    })
+}
+
+pub(crate) fn inlined_delete_groups(rows: &[InlinedRowRef]) -> BTreeMap<&str, BTreeSet<i64>> {
+    let mut groups = BTreeMap::new();
+    for row in rows {
+        groups
+            .entry(row.table_name.as_str())
+            .or_insert_with(BTreeSet::new)
+            .insert(row.row_id);
+    }
+    groups
 }
 
 pub(crate) fn quote_snapshot_name(name: &str) -> String {
@@ -1227,7 +1291,7 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         ))
     }
 
-    /// Replace a table-scoped catalog setting.
+    /// Replace a supported write option on a live table.
     fn set_table_setting(&self, _table_id: i64, _key: &str, _value: &str) -> Result<()> {
         Err(DuckLakeError::Unsupported(
             "table-scoped settings are not supported by this metadata backend".to_string(),
@@ -1238,9 +1302,9 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     ///
     /// A coordination utility for callers that want to serialize a multi-step
     /// commit workflow (e.g. read staged state, dedup, commit) under one
-    /// `identity` across processes. Multicatalog PostgreSQL scopes the lock by identity;
+    /// `identity` across processes. PostgreSQL and MySQL scope the lock by identity;
     /// SQLite and DuckDB serialize all identities in the same catalog file.
-    /// MySQL does not support this coordination API. Correctness does not depend on it: the
+    /// Correctness does not depend on it: the
     /// optimistic `expected_base_snapshot_id` fence remains the conflict
     /// mechanism, and this lock only avoids duplicate concurrent work.
     ///

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -53,16 +53,56 @@ pub(crate) fn table_write_changes(
     table_id: i64,
     mode: WriteMode,
     has_deletes: bool,
-    replaced_existing_data: bool,
+    replaced_storage: (bool, bool),
 ) -> String {
-    match (mode, has_deletes, replaced_existing_data) {
-        (WriteMode::Append, false, _) | (WriteMode::Replace, false, false) => {
-            format!("inserted_into_table:{table_id}")
-        },
-        (WriteMode::Append | WriteMode::Replace, true, _) | (WriteMode::Replace, false, true) => {
-            format!("deleted_from_table:{table_id},inserted_into_table:{table_id}")
-        },
+    table_storage_changes(
+        table_id,
+        Some(false),
+        has_deletes || (mode == WriteMode::Replace && replaced_storage.0),
+        mode == WriteMode::Replace && replaced_storage.1,
+    )
+}
+
+pub(crate) fn staged_table_write_changes(
+    write: &StagedTableWrite,
+    had_files: bool,
+    had_inlined_rows: bool,
+) -> String {
+    if write.inlined_flush {
+        return format!("inline_flush:{}", write.table_id);
     }
+    let insert = match &write.data {
+        StagedTableData::Files(_) => Some(false),
+        StagedTableData::Inlined(_) => Some(true),
+        StagedTableData::None => None,
+    };
+    table_storage_changes(
+        write.table_id,
+        insert,
+        !write.positional_deletes.is_empty() || (write.mode == WriteMode::Replace && had_files),
+        !write.inlined_deletes.is_empty() || (write.mode == WriteMode::Replace && had_inlined_rows),
+    )
+}
+
+pub(crate) fn table_storage_changes(
+    table_id: i64,
+    inlined_insert: Option<bool>,
+    deleted_files: bool,
+    deleted_inlined: bool,
+) -> String {
+    let mut changes = Vec::new();
+    if deleted_files {
+        changes.push(format!("deleted_from_table:{table_id}"));
+    }
+    if deleted_inlined {
+        changes.push(format!("inlined_delete:{table_id}"));
+    }
+    match inlined_insert {
+        Some(false) => changes.push(format!("inserted_into_table:{table_id}")),
+        Some(true) => changes.push(format!("inlined_insert:{table_id}")),
+        None => {},
+    }
+    changes.join(",")
 }
 
 pub(crate) fn quote_snapshot_name(name: &str) -> String {
@@ -1044,6 +1084,7 @@ pub struct InlinedRowRef {
 
 /// Row storage staged for one table in a multi-table write.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum StagedTableData {
     /// Parquet data files already uploaded to object storage.
     Files(Vec<DataFileInfo>),
@@ -1067,6 +1108,7 @@ pub struct StagedTableWrite {
     pub(crate) snapshot_id_columns: Vec<String>,
     pub(crate) positional_deletes: Vec<DeleteFileEntry>,
     pub(crate) inlined_deletes: Vec<InlinedRowRef>,
+    pub(crate) inlined_flush: bool,
 }
 
 impl StagedTableWrite {
@@ -1129,6 +1171,12 @@ impl StagedTableWrite {
     pub fn inlined_deletes(&self) -> &[InlinedRowRef] {
         &self.inlined_deletes
     }
+
+    /// Returns whether this stage moves inlined rows into Parquet without changing logical rows.
+    #[must_use]
+    pub const fn inlined_flush(&self) -> bool {
+        self.inlined_flush
+    }
 }
 
 /// Result of one atomic multi-table write.
@@ -1190,7 +1238,9 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     ///
     /// A coordination utility for callers that want to serialize a multi-step
     /// commit workflow (e.g. read staged state, dedup, commit) under one
-    /// `identity` across processes. Correctness does not depend on it: the
+    /// `identity` across processes. Multicatalog PostgreSQL scopes the lock by identity;
+    /// SQLite and DuckDB serialize all identities in the same catalog file.
+    /// MySQL does not support this coordination API. Correctness does not depend on it: the
     /// optimistic `expected_base_snapshot_id` fence remains the conflict
     /// mechanism, and this lock only avoids duplicate concurrent work.
     ///

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -43,10 +43,11 @@ use crate::maintenance::{
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
     DeleteFileEntry, DeleteFileInfo, ExistingCatalogColumn, InlinedRowRef, MetadataWriter,
-    SnapshotCommitMetadata, SourceRetirement, WriteMode, WriteSetupResult, assign_column_ids,
-    catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
-    catalog_columns_differ, quote_snapshot_name, quote_snapshot_table, table_write_changes,
-    top_level_column_ids, validate_delete_entries, validate_name,
+    MultiTableCommit, SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite,
+    WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
+    catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
+    quote_snapshot_table, table_write_changes, top_level_column_ids, validate_delete_entries,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -61,6 +62,7 @@ use arrow::datatypes::{DataType, TimeUnit as ArrowTimeUnit};
 use arrow::record_batch::RecordBatch;
 use duckdb::types::{TimeUnit as DuckdbTimeUnit, Value};
 use duckdb::{Connection, OptionalExt, Transaction, params, params_from_iter};
+use std::fs::OpenOptions;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 fn quote_ident(name: &str) -> String {
@@ -585,9 +587,8 @@ CREATE TABLE IF NOT EXISTS ducklake_sort_expression (
 #[derive(Debug, Clone)]
 pub struct DuckdbMetadataWriter {
     conn: Arc<Mutex<Connection>>,
-    /// Path to the catalog database, retained for logging/debugging.
-    #[allow(dead_code)]
     catalog_path: String,
+    commit_lock: Arc<Mutex<()>>,
 }
 
 impl DuckdbMetadataWriter {
@@ -598,6 +599,7 @@ impl DuckdbMetadataWriter {
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
             catalog_path,
+            commit_lock: Arc::new(Mutex::new(())),
         })
     }
 
@@ -606,6 +608,19 @@ impl DuckdbMetadataWriter {
         let writer = Self::new(path)?;
         writer.initialize_schema()?;
         Ok(writer)
+    }
+
+    /// Return a metadata provider sharing this writer's DuckDB connection.
+    ///
+    /// DuckDB permits one process-level client for a writable catalog file, so
+    /// embedded catalogs retain provider and writer views over the same
+    /// synchronized connection.
+    #[must_use]
+    pub fn metadata_provider(&self) -> crate::DuckdbMetadataProvider {
+        crate::metadata_provider_duckdb::DuckdbMetadataProvider::from_shared_connection(
+            Arc::clone(&self.conn),
+            self.catalog_path.clone(),
+        )
     }
 
     /// Lock the shared connection. Panics only if a previous holder panicked
@@ -1615,6 +1630,327 @@ fn finalize_snapshot(
     Ok(snapshot_id)
 }
 
+fn validate_staged_table(tx: &Transaction<'_>, write: &StagedTableWrite) -> Result<i64> {
+    let schema_id: i64 = tx
+        .query_row(
+            "SELECT schema_id FROM ducklake_table
+             WHERE table_id = ? AND end_snapshot IS NULL",
+            params![write.table_id],
+            |row| row.get(0),
+        )
+        .optional()?
+        .ok_or_else(|| {
+            crate::DuckLakeError::Conflict(format!(
+                "multi-table write target {}.{} is no longer live",
+                write.schema_name, write.table_name
+            ))
+        })?;
+    let proposed = catalog_column_defs(&write.columns)?;
+    let mut statement = tx.prepare(
+        "SELECT column_id, column_type, nulls_allowed, parent_column
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )?;
+    let current = statement
+        .query_map(params![write.table_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<bool>>(2)?.unwrap_or(true),
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(statement);
+    if current.len() != proposed.len() || proposed.len() != write.column_ids.len() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "multi-table write target {}.{} changed schema after staging",
+            write.schema_name, write.table_name
+        )));
+    }
+    for (index, ((column_id, column_type, nullable, parent_id), proposed)) in
+        current.iter().zip(&proposed).enumerate()
+    {
+        let proposed_parent = proposed.parent_index.map(|parent| write.column_ids[parent]);
+        if *column_id != write.column_ids[index]
+            || !catalog_column_type_equal(column_type, proposed)
+            || *nullable != proposed.is_nullable
+            || *parent_id != proposed_parent
+        {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "multi-table write target {}.{} changed schema after staging",
+                write.schema_name, write.table_name
+            )));
+        }
+    }
+    Ok(schema_id)
+}
+
+fn has_live_data(tx: &Transaction<'_>, table_id: i64) -> Result<bool> {
+    let has_files: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM ducklake_data_file
+             WHERE table_id = ? AND end_snapshot IS NULL
+         )",
+        params![table_id],
+        |row| row.get(0),
+    )?;
+    if has_files {
+        return Ok(true);
+    }
+    let mut statement =
+        tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+    let table_names = statement
+        .query_map(params![table_id], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(statement);
+    for table_name in table_names {
+        let has_rows: bool = tx.query_row(
+            &format!(
+                "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot IS NULL)",
+                quote_ident(&table_name)
+            ),
+            [],
+            |row| row.get(0),
+        )?;
+        if has_rows {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn commit_staged_files(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    files: &[DataFileInfo],
+) -> Result<()> {
+    if files.is_empty() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table file stage requires at least one file".to_string(),
+        ));
+    }
+    let live_partition_id: Option<i64> = tx.query_row(
+        "SELECT (SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = ? AND end_snapshot IS NULL LIMIT 1)",
+        params![write.table_id],
+        |row| row.get(0),
+    )?;
+    for file in files {
+        crate::metadata_writer::enforce_partition_fence(write.table_id, live_partition_id, file)?;
+    }
+    seed_stats_if_missing(tx, write.table_id)?;
+    let mut next_row_id: i64 = tx.query_row(
+        "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+        params![write.table_id],
+        |row| row.get(0),
+    )?;
+    let mut total_records = 0i64;
+    let mut total_bytes = 0i64;
+    for file in files {
+        let data_file_id: i64 = tx.query_row(
+            "INSERT INTO ducklake_data_file
+                 (table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, record_count, row_id_start, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING data_file_id",
+            params![
+                write.table_id,
+                file.path.as_str(),
+                file.path_is_relative,
+                file.file_size_bytes,
+                file.footer_size,
+                file.record_count,
+                next_row_id,
+                snapshot_id
+            ],
+            |row| row.get(0),
+        )?;
+        insert_file_column_stats(tx, write.table_id, data_file_id, &file.column_stats)?;
+        insert_partition_metadata(tx, write.table_id, data_file_id, file)?;
+        next_row_id += file.record_count;
+        total_records += file.record_count;
+        total_bytes += file.file_size_bytes;
+    }
+    recompute_table_column_stats(tx, write.table_id, &write.columns, &write.column_ids)?;
+    tx.execute(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + ?,
+             record_count = record_count + ?,
+             file_size_bytes = file_size_bytes + ?
+         WHERE table_id = ?",
+        params![total_records, total_records, total_bytes, write.table_id],
+    )?;
+    Ok(())
+}
+
+fn commit_staged_inline(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    batches: &[RecordBatch],
+) -> Result<()> {
+    let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    if record_count == 0 {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table inline stage requires at least one row".to_string(),
+        ));
+    }
+    let schema_version: i64 = tx.query_row(
+        "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+        params![snapshot_id],
+        |row| row.get(0),
+    )?;
+    let physical_name = format!(
+        "ducklake_inlined_data_{}_{}",
+        write.table_id, schema_version
+    );
+    let mut ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {} (\
+         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+        quote_ident(&physical_name)
+    );
+    let schema = batches[0].schema();
+    for (column, field) in write.columns.iter().zip(schema.fields()) {
+        ddl.push_str(", ");
+        ddl.push_str(&quote_ident(column.name()));
+        ddl.push(' ');
+        ddl.push_str(&inlined_duckdb_type(
+            field.data_type(),
+            column.ducklake_type(),
+        ));
+    }
+    ddl.push(')');
+    tx.execute(&ddl, [])?;
+    tx.execute(
+        "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version)
+         SELECT ?, ?, ? WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_inlined_data_tables
+             WHERE table_id = ? AND schema_version = ?
+         )",
+        params![
+            write.table_id,
+            physical_name.as_str(),
+            schema_version,
+            write.table_id,
+            schema_version
+        ],
+    )?;
+    seed_stats_if_missing(tx, write.table_id)?;
+    let mut row_id: i64 = tx.query_row(
+        "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+        params![write.table_id],
+        |row| row.get(0),
+    )?;
+    let column_list = write
+        .columns
+        .iter()
+        .map(|column| quote_ident(column.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let value_list = write
+        .columns
+        .iter()
+        .zip(schema.fields())
+        .map(|(column, field)| {
+            format!(
+                "CAST(? AS {})",
+                inlined_duckdb_type(field.data_type(), column.ducklake_type()),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let insert_sql = format!(
+        "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) \
+         VALUES (?, ?, ?, {})",
+        quote_ident(&physical_name),
+        column_list,
+        value_list
+    );
+    for batch in batches {
+        for batch_row in 0..batch.num_rows() {
+            let mut values = Vec::with_capacity(write.columns.len() + 3);
+            values.push(Value::BigInt(row_id));
+            values.push(Value::BigInt(snapshot_id));
+            values.push(Value::Null);
+            for (array, column) in batch.columns().iter().zip(&write.columns) {
+                if write
+                    .snapshot_id_columns
+                    .iter()
+                    .any(|name| name == column.name())
+                    && array.is_null(batch_row)
+                {
+                    values.push(Value::BigInt(snapshot_id));
+                } else {
+                    values.push(inlined_duckdb_value(array.as_ref(), batch_row)?);
+                }
+            }
+            tx.execute(&insert_sql, params_from_iter(values))?;
+            row_id += 1;
+        }
+    }
+    let record_count = i64::try_from(record_count).map_err(|_| {
+        crate::DuckLakeError::InvalidConfig("multi-table inline row count exceeds i64".to_string())
+    })?;
+    tx.execute(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + ?, record_count = record_count + ?
+         WHERE table_id = ?",
+        params![record_count, record_count, write.table_id],
+    )?;
+    Ok(())
+}
+
+fn apply_staged_inlined_deletes(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+) -> Result<()> {
+    if write.inlined_deletes.is_empty() {
+        return Ok(());
+    }
+    let mut statement =
+        tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
+    let registered = statement
+        .query_map(params![write.table_id], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
+    drop(statement);
+    for row in &write.inlined_deletes {
+        if !registered.contains(&row.table_name) {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} belongs to an unregistered table '{}'",
+                row.row_id, row.table_name
+            )));
+        }
+        let affected = tx.execute(
+            &format!(
+                "UPDATE {} SET end_snapshot = ? \
+                 WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+                quote_ident(&row.table_name)
+            ),
+            params![snapshot_id, row.row_id, write.base_snapshot_id],
+        )?;
+        if affected != 1 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} in '{}' is no longer live at snapshot {}",
+                row.row_id, row.table_name, write.base_snapshot_id
+            )));
+        }
+    }
+    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
+        crate::DuckLakeError::InvalidConfig(
+            "multi-table inline delete count exceeds i64".to_string(),
+        )
+    })?;
+    tx.execute(
+        "UPDATE ducklake_table_stats
+         SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+        params![deleted, write.table_id],
+    )?;
+    Ok(())
+}
+
 impl DuckdbMetadataWriter {
     pub(crate) fn list_scheduled_for_deletion(
         &self,
@@ -1718,6 +2054,58 @@ impl MetadataWriter for DuckdbMetadataWriter {
         )?;
         tx.commit()?;
         Ok(())
+    }
+
+    fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let exists: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM ducklake_table WHERE table_id = ?)",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            return Err(crate::DuckLakeError::TableNotFound(table_id.to_string()));
+        }
+        tx.execute(
+            "DELETE FROM ducklake_metadata WHERE key = ? AND scope = 'table' AND scope_id = ?",
+            params![key, table_id],
+        )?;
+        tx.execute(
+            "INSERT INTO ducklake_metadata (key, value, scope, scope_id) VALUES (?, ?, 'table', ?)",
+            params![key, value, table_id],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn with_commit_lock(
+        &self,
+        _identity: &str,
+        operation: Box<dyn FnOnce() -> Result<()> + '_>,
+    ) -> Result<()> {
+        if self.catalog_path == ":memory:" {
+            let _guard = self.commit_lock.lock().map_err(|_| {
+                crate::DuckLakeError::Internal("DuckDB commit lock is poisoned".to_string())
+            })?;
+            return operation();
+        }
+
+        let lock_path = format!("{}.commit.lock", self.catalog_path);
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .truncate(false)
+            .write(true)
+            .open(lock_path)?;
+        lock_file.lock()?;
+        let result = operation();
+        let unlock = lock_file.unlock();
+        match (result, unlock) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Ok(()), Err(e)) => Err(e.into()),
+            (Err(e), _) => Err(e),
+        }
     }
 
     fn get_or_create_schema(
@@ -2373,6 +2761,93 @@ impl MetadataWriter for DuckdbMetadataWriter {
             snapshot_id,
             schema_id,
             table_id,
+        })
+    }
+
+    fn commit_multi_table(
+        &self,
+        writes: &[StagedTableWrite],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<MultiTableCommit> {
+        if writes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires at least one table stage".to_string(),
+            ));
+        }
+        let table_ids = writes
+            .iter()
+            .map(|write| write.table_id)
+            .collect::<std::collections::HashSet<_>>();
+        if table_ids.len() != writes.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires one stage per table".to_string(),
+            ));
+        }
+
+        let mut connection = self.connection();
+        let tx = connection.transaction()?;
+        if let Some(expected) = expected_base_snapshot_id {
+            for write in writes {
+                detect_replace_conflict(&tx, write.table_id, expected)?;
+            }
+        }
+        let had_live_data = writes
+            .iter()
+            .map(|write| has_live_data(&tx, write.table_id))
+            .collect::<Result<Vec<_>>>()?;
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        let mut tables = Vec::with_capacity(writes.len());
+        for write in writes {
+            let schema_id = validate_staged_table(&tx, write)?;
+            if write.mode == WriteMode::Replace {
+                detect_replace_conflict(&tx, write.table_id, write.base_snapshot_id)?;
+                retire_prior_generation(&tx, write.table_id, snapshot_id)?;
+            }
+            tables.push(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id: write.table_id,
+            });
+        }
+        for (write, replaced_existing_data) in writes.iter().zip(had_live_data) {
+            match &write.data {
+                StagedTableData::Files(files) => {
+                    commit_staged_files(&tx, snapshot_id, write, files)?;
+                },
+                StagedTableData::Inlined(batches) => {
+                    commit_staged_inline(&tx, snapshot_id, write, batches)?;
+                },
+                StagedTableData::None => {},
+            }
+            for entry in &write.positional_deletes {
+                apply_delete_entry(
+                    &tx,
+                    write.table_id,
+                    write.base_snapshot_id,
+                    snapshot_id,
+                    entry,
+                )?;
+            }
+            apply_staged_inlined_deletes(&tx, snapshot_id, write)?;
+            let has_deletes =
+                !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
+            let changes_made = if matches!(&write.data, StagedTableData::None) {
+                format!("deleted_from_table:{}", write.table_id)
+            } else {
+                table_write_changes(
+                    write.table_id,
+                    write.mode,
+                    has_deletes,
+                    replaced_existing_data,
+                )
+            };
+            record_snapshot_changes(&tx, snapshot_id, &changes_made, commit_metadata)?;
+        }
+        tx.commit()?;
+        Ok(MultiTableCommit {
+            snapshot_id,
+            tables,
         })
     }
 

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -45,9 +45,10 @@ use crate::metadata_writer::{
     DeleteFileEntry, DeleteFileInfo, ExistingCatalogColumn, InlinedRowRef, MetadataWriter,
     MultiTableCommit, SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite,
     WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
-    catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
-    quote_snapshot_table, staged_table_write_changes, table_storage_changes, top_level_column_ids,
-    validate_delete_entries, validate_name,
+    catalog_column_type_requires_migration, catalog_columns_differ, inlined_delete_conflicts,
+    inlined_delete_groups, quote_snapshot_name, quote_snapshot_table, snapshot_has_change,
+    staged_table_write_changes, table_storage_changes, top_level_column_ids,
+    validate_delete_entries, validate_name, validate_table_setting,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -908,22 +909,6 @@ fn record_table_write_changes(
     inlined: bool,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
-    let (schema_begin_snapshot, table_begin_snapshot): (i64, i64) = tx.query_row(
-        "SELECT s.begin_snapshot, t.begin_snapshot
-         FROM ducklake_table t
-         JOIN ducklake_schema s ON s.schema_id = t.schema_id
-         WHERE t.table_id = ?",
-        params![table_id],
-        |row| Ok((row.get(0)?, row.get(1)?)),
-    )?;
-    let altered: bool = tx.query_row(
-        "SELECT EXISTS(
-            SELECT 1 FROM ducklake_schema_versions
-            WHERE table_id = ? AND begin_snapshot = ?
-         )",
-        params![table_id, snapshot_id],
-        |row| row.get(0),
-    )?;
     let replaced_existing_data: bool = tx.query_row(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
@@ -955,12 +940,62 @@ fn record_table_write_changes(
         }
     }
 
+    let write_changes = table_storage_changes(
+        table_id,
+        Some(inlined),
+        has_deletes || (mode == WriteMode::Replace && replaced_existing_data),
+        replaced_inlined,
+    );
+    record_table_changes(
+        tx,
+        snapshot_id,
+        table_id,
+        schema_name,
+        table_name,
+        &write_changes,
+        commit_metadata,
+    )
+}
+
+fn record_table_changes(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    write_changes: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let (schema_begin_snapshot, table_begin_snapshot): (i64, i64) = tx.query_row(
+        "SELECT s.begin_snapshot, t.begin_snapshot
+         FROM ducklake_table t
+         JOIN ducklake_schema s ON s.schema_id = t.schema_id
+         WHERE t.table_id = ?",
+        params![table_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    let altered: bool = tx.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_schema_versions
+            WHERE table_id = ? AND begin_snapshot = ?
+         )",
+        params![table_id, snapshot_id],
+        |row| row.get(0),
+    )?;
     let mut changes = Vec::new();
     if schema_begin_snapshot == snapshot_id {
-        changes.push(format!(
-            "created_schema:{}",
-            quote_snapshot_name(schema_name)
-        ));
+        let entry = format!("created_schema:{}", quote_snapshot_name(schema_name));
+        let recorded: Option<String> = tx
+            .query_row(
+                "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+                params![snapshot_id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .flatten();
+        if !snapshot_has_change(recorded.as_deref().unwrap_or_default(), &entry) {
+            changes.push(entry);
+        }
     }
     if table_begin_snapshot == snapshot_id {
         changes.push(format!(
@@ -970,12 +1005,7 @@ fn record_table_write_changes(
     } else if altered {
         changes.push(format!("altered_table:{table_id}"));
     }
-    changes.push(table_storage_changes(
-        table_id,
-        Some(inlined),
-        has_deletes || (mode == WriteMode::Replace && replaced_existing_data),
-        replaced_inlined,
-    ));
+    changes.push(write_changes.to_string());
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata)
 }
 
@@ -1426,36 +1456,85 @@ fn apply_inlined_deletes(
     base_snapshot: i64,
     rows: &[InlinedRowRef],
 ) -> Result<()> {
-    let registered = inlined_table_names(tx, table_id)?
-        .into_iter()
-        .collect::<std::collections::HashSet<_>>();
-    for row in rows {
-        if !registered.contains(&row.table_name) {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} belongs to an unregistered table '{}'",
-                row.row_id, row.table_name
-            )));
-        }
-        let affected = tx.execute(
-            &format!(
-                "UPDATE {} SET end_snapshot = ? \
-                 WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
-                quote_ident(&row.table_name)
-            ),
-            params![snapshot_id, row.row_id, base_snapshot],
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let registered = inlined_table_names(tx, table_id)?;
+    let changes: Vec<Option<String>> = {
+        let mut statement = tx.prepare("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id > ? AND snapshot_id < ?")?;
+        statement
+            .query_map(params![base_snapshot, snapshot_id], |row| row.get(0))?
+            .collect::<std::result::Result<_, _>>()?
+    };
+    if changes
+        .iter()
+        .flatten()
+        .any(|changes| inlined_delete_conflicts(changes, table_id))
+    {
+        return Err(crate::DuckLakeError::Conflict(
+            "table changed since the inlined delete snapshot".to_string(),
+        ));
+    }
+    for name in &registered {
+        let sql = format!(
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE (begin_snapshot > ? AND begin_snapshot < ?) OR (end_snapshot > ? AND end_snapshot < ?))",
+            quote_ident(name)
+        );
+        let changed: bool = tx.query_row(
+            &sql,
+            params![base_snapshot, snapshot_id, base_snapshot, snapshot_id],
+            |row| row.get(0),
         )?;
-        if affected != 1 {
+        if changed {
+            return Err(crate::DuckLakeError::Conflict(
+                "inlined rows changed since the delete snapshot".to_string(),
+            ));
+        }
+    }
+    for (name, row_ids) in inlined_delete_groups(rows) {
+        if !registered.iter().any(|table| table == name) {
             return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                row.row_id, row.table_name
+                "inlined deletes reference unregistered table '{name}'"
             )));
         }
+        let ids = row_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? WHERE row_id IN ({ids}) AND end_snapshot IS NULL AND begin_snapshot <> ?",
+            quote_ident(name)
+        );
+        tx.execute(&sql, params![snapshot_id, snapshot_id])?;
     }
     Ok(())
 }
 
 fn finalize_snapshot(
     tx: &Transaction<'_>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<i64> {
+    let (snapshot_id, _) = insert_snapshot(tx)?;
+    finalize_table_snapshot(
+        tx,
+        snapshot_id,
+        table_id,
+        columns,
+        column_ids,
+        mode,
+        base_snapshot,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finalize_table_snapshot(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
     table_id: i64,
     columns: &[ColumnDef],
     column_ids: &[i64],
@@ -1474,7 +1553,11 @@ fn finalize_snapshot(
 
     // Allocate the snapshot FIRST (carrying schema_version forward); corrected to
     // a DDL bump below once the commit is classified.
-    let (snapshot_id, mut schema_version) = insert_snapshot(tx)?;
+    let mut schema_version: i64 = tx.query_row(
+        "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+        params![snapshot_id],
+        |row| row.get(0),
+    )?;
 
     // The table's live columns ordered by column_order. Collected into an owned
     // Vec so the prepared statement is dropped before we mutate the same
@@ -1522,6 +1605,13 @@ fn finalize_snapshot(
         ));
     }
 
+    if current.is_empty() {
+        tx.execute("UPDATE ducklake_schema SET begin_snapshot = ? WHERE schema_id = (SELECT schema_id FROM ducklake_table WHERE table_id = ?) AND begin_snapshot = (SELECT begin_snapshot FROM ducklake_table WHERE table_id = ?)", params![snapshot_id, table_id, table_id])?;
+        tx.execute(
+            "UPDATE ducklake_table SET begin_snapshot = ? WHERE table_id = ?",
+            params![snapshot_id, table_id],
+        )?;
+    }
     let is_ddl = current.is_empty()
         || catalog_columns_differ(
             &existing_catalog_columns,
@@ -1665,6 +1755,9 @@ fn validate_staged_table(tx: &Transaction<'_>, write: &StagedTableWrite) -> Resu
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
     drop(statement);
+    if current.is_empty() && proposed.len() == write.column_ids.len() {
+        return Ok(schema_id);
+    }
     if current.len() != proposed.len() || proposed.len() != write.column_ids.len() {
         return Err(crate::DuckLakeError::Conflict(format!(
             "multi-table write target {}.{} changed schema after staging",
@@ -1807,7 +1900,7 @@ fn commit_staged_inline(
     );
     let mut ddl = format!(
         "CREATE TABLE IF NOT EXISTS {} (\
-         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+         row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT",
         quote_ident(&physical_name)
     );
     let schema = batches[0].schema();
@@ -1906,48 +1999,13 @@ fn apply_staged_inlined_deletes(
     snapshot_id: i64,
     write: &StagedTableWrite,
 ) -> Result<()> {
-    if write.inlined_deletes.is_empty() {
-        return Ok(());
-    }
-    let mut statement =
-        tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
-    let registered = statement
-        .query_map(params![write.table_id], |row| row.get::<_, String>(0))?
-        .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
-    drop(statement);
-    for row in &write.inlined_deletes {
-        if !registered.contains(&row.table_name) {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} belongs to an unregistered table '{}'",
-                row.row_id, row.table_name
-            )));
-        }
-        let affected = tx.execute(
-            &format!(
-                "UPDATE {} SET end_snapshot = ? \
-                 WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
-                quote_ident(&row.table_name)
-            ),
-            params![snapshot_id, row.row_id, write.base_snapshot_id],
-        )?;
-        if affected != 1 {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} in '{}' is no longer live at snapshot {}",
-                row.row_id, row.table_name, write.base_snapshot_id
-            )));
-        }
-    }
-    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
-        crate::DuckLakeError::InvalidConfig(
-            "multi-table inline delete count exceeds i64".to_string(),
-        )
-    })?;
-    tx.execute(
-        "UPDATE ducklake_table_stats
-         SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
-        params![deleted, write.table_id],
-    )?;
-    Ok(())
+    apply_inlined_deletes(
+        tx,
+        write.table_id,
+        snapshot_id,
+        write.base_snapshot_id,
+        &write.inlined_deletes,
+    )
 }
 
 impl DuckdbMetadataWriter {
@@ -2056,10 +2114,11 @@ impl MetadataWriter for DuckdbMetadataWriter {
     }
 
     fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        let key = validate_table_setting(key)?;
         let mut conn = self.connection();
         let tx = conn.transaction()?;
         let exists: bool = tx.query_row(
-            "SELECT EXISTS(SELECT 1 FROM ducklake_table WHERE table_id = ?)",
+            "SELECT EXISTS(SELECT 1 FROM ducklake_table WHERE table_id = ? AND end_snapshot IS NULL)",
             params![table_id],
             |row| row.get(0),
         )?;
@@ -2802,10 +2861,15 @@ impl MetadataWriter for DuckdbMetadataWriter {
         let mut tables = Vec::with_capacity(writes.len());
         for write in writes {
             let schema_id = validate_staged_table(&tx, write)?;
-            if write.mode == WriteMode::Replace {
-                detect_replace_conflict(&tx, write.table_id, write.base_snapshot_id)?;
-                retire_prior_generation(&tx, write.table_id, snapshot_id)?;
-            }
+            finalize_table_snapshot(
+                &tx,
+                snapshot_id,
+                write.table_id,
+                &write.columns,
+                &write.column_ids,
+                write.mode,
+                write.base_snapshot_id,
+            )?;
             tables.push(CommitIds {
                 snapshot_id,
                 schema_id,
@@ -2833,7 +2897,15 @@ impl MetadataWriter for DuckdbMetadataWriter {
             }
             apply_staged_inlined_deletes(&tx, snapshot_id, write)?;
             let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
-            record_snapshot_changes(&tx, snapshot_id, &changes_made, commit_metadata)?;
+            record_table_changes(
+                &tx,
+                snapshot_id,
+                write.table_id,
+                &write.schema_name,
+                &write.table_name,
+                &changes_made,
+                commit_metadata,
+            )?;
         }
         tx.commit()?;
         Ok(MultiTableCommit {

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -46,8 +46,8 @@ use crate::metadata_writer::{
     MultiTableCommit, SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite,
     WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
     catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
-    quote_snapshot_table, table_write_changes, top_level_column_ids, validate_delete_entries,
-    validate_name,
+    quote_snapshot_table, staged_table_write_changes, table_storage_changes, top_level_column_ids,
+    validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -905,6 +905,7 @@ fn record_table_write_changes(
     table_name: &str,
     mode: WriteMode,
     has_deletes: bool,
+    inlined: bool,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
     let (schema_begin_snapshot, table_begin_snapshot): (i64, i64) = tx.query_row(
@@ -923,7 +924,7 @@ fn record_table_write_changes(
         params![table_id, snapshot_id],
         |row| row.get(0),
     )?;
-    let mut replaced_existing_data: bool = tx.query_row(
+    let replaced_existing_data: bool = tx.query_row(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
             WHERE table_id = ? AND end_snapshot = ?
@@ -931,7 +932,8 @@ fn record_table_write_changes(
         params![table_id, snapshot_id],
         |row| row.get(0),
     )?;
-    if !replaced_existing_data {
+    let mut replaced_inlined = false;
+    if mode == WriteMode::Replace {
         // A Replace over inline-only prior data ends inline rows, not files.
         let inlined_tables: Vec<String> = {
             let mut statement = tx.prepare(
@@ -947,7 +949,7 @@ fn record_table_write_changes(
                 quote_ident(&inlined_table)
             );
             if tx.query_row(&sql, params![snapshot_id], |row| row.get(0))? {
-                replaced_existing_data = true;
+                replaced_inlined = true;
                 break;
             }
         }
@@ -968,11 +970,11 @@ fn record_table_write_changes(
     } else if altered {
         changes.push(format!("altered_table:{table_id}"));
     }
-    changes.push(table_write_changes(
+    changes.push(table_storage_changes(
         table_id,
-        mode,
-        has_deletes,
-        replaced_existing_data,
+        Some(inlined),
+        has_deletes || (mode == WriteMode::Replace && replaced_existing_data),
+        replaced_inlined,
     ));
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata)
 }
@@ -1687,7 +1689,7 @@ fn validate_staged_table(tx: &Transaction<'_>, write: &StagedTableWrite) -> Resu
     Ok(schema_id)
 }
 
-fn has_live_data(tx: &Transaction<'_>, table_id: i64) -> Result<bool> {
+fn has_live_data(tx: &Transaction<'_>, table_id: i64) -> Result<(bool, bool)> {
     let has_files: bool = tx.query_row(
         "SELECT EXISTS(
              SELECT 1 FROM ducklake_data_file
@@ -1696,9 +1698,6 @@ fn has_live_data(tx: &Transaction<'_>, table_id: i64) -> Result<bool> {
         params![table_id],
         |row| row.get(0),
     )?;
-    if has_files {
-        return Ok(true);
-    }
     let mut statement =
         tx.prepare("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")?;
     let table_names = statement
@@ -1715,10 +1714,10 @@ fn has_live_data(tx: &Transaction<'_>, table_id: i64) -> Result<bool> {
             |row| row.get(0),
         )?;
         if has_rows {
-            return Ok(true);
+            return Ok((has_files, true));
         }
     }
-    Ok(false)
+    Ok((has_files, false))
 }
 
 fn commit_staged_files(
@@ -2458,6 +2457,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             table_name,
             mode,
             false,
+            false,
             commit_metadata,
         )?;
         let schema_id: i64 = tx.query_row(
@@ -2593,6 +2593,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             schema_name,
             table_name,
             mode,
+            false,
             false,
             commit_metadata,
         )?;
@@ -2749,6 +2750,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             table_name,
             mode,
             false,
+            true,
             commit_metadata,
         )?;
         let schema_id: i64 = tx.query_row(
@@ -2810,7 +2812,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
                 table_id: write.table_id,
             });
         }
-        for (write, replaced_existing_data) in writes.iter().zip(had_live_data) {
+        for (write, (had_files, had_inlined_rows)) in writes.iter().zip(had_live_data) {
             match &write.data {
                 StagedTableData::Files(files) => {
                     commit_staged_files(&tx, snapshot_id, write, files)?;
@@ -2830,18 +2832,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
                 )?;
             }
             apply_staged_inlined_deletes(&tx, snapshot_id, write)?;
-            let has_deletes =
-                !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
-            let changes_made = if matches!(&write.data, StagedTableData::None) {
-                format!("deleted_from_table:{}", write.table_id)
-            } else {
-                table_write_changes(
-                    write.table_id,
-                    write.mode,
-                    has_deletes,
-                    replaced_existing_data,
-                )
-            };
+            let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
             record_snapshot_changes(&tx, snapshot_id, &changes_made, commit_metadata)?;
         }
         tx.commit()?;
@@ -3051,6 +3042,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             table_name,
             mode,
             !deletes.is_empty(),
+            false,
             &SnapshotCommitMetadata::default(),
         )?;
         let schema_id = tx.query_row(
@@ -3807,6 +3799,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             schema_name,
             table_name,
             mode,
+            false,
             false,
             &SnapshotCommitMetadata::default(),
         )?;

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -38,10 +38,11 @@ use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
     DeleteFileEntry, DeleteFileInfo, ExistingCatalogColumn, InlinedRowRef, MetadataWriter,
-    SnapshotCommitMetadata, SourceRetirement, WriteMode, WriteSetupResult, assign_column_ids,
-    catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
-    catalog_columns_differ, quote_snapshot_name, quote_snapshot_table, table_write_changes,
-    top_level_column_ids, validate_delete_entries, validate_name,
+    MultiTableCommit, SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite,
+    WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
+    catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
+    quote_snapshot_table, table_write_changes, top_level_column_ids, validate_delete_entries,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -1606,6 +1607,366 @@ async fn finalize_snapshot(
     Ok(snapshot_id)
 }
 
+async fn validate_staged_table(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    write: &StagedTableWrite,
+) -> Result<i64> {
+    let schema_id: i64 = sqlx::query_scalar(
+        "SELECT schema_id FROM ducklake_table
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(write.table_id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .ok_or_else(|| {
+        crate::DuckLakeError::Conflict(format!(
+            "multi-table write target {}.{} is no longer live",
+            write.schema_name, write.table_name
+        ))
+    })?;
+    let proposed = catalog_column_defs(&write.columns)?;
+    let current = sqlx::query(
+        "SELECT column_id, column_type, nulls_allowed, parent_column
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(write.table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    if current.len() != proposed.len() || proposed.len() != write.column_ids.len() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "multi-table write target {}.{} changed schema after staging",
+            write.schema_name, write.table_name
+        )));
+    }
+    for (index, (row, proposed)) in current.iter().zip(&proposed).enumerate() {
+        let column_id: i64 = row.try_get(0)?;
+        let column_type: String = row.try_get(1)?;
+        let nullable = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+        let parent_id: Option<i64> = row.try_get(3)?;
+        let proposed_parent = proposed.parent_index.map(|parent| write.column_ids[parent]);
+        if column_id != write.column_ids[index]
+            || !catalog_column_type_equal(&column_type, proposed)
+            || nullable != proposed.is_nullable
+            || parent_id != proposed_parent
+        {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "multi-table write target {}.{} changed schema after staging",
+                write.schema_name, write.table_name
+            )));
+        }
+    }
+    Ok(schema_id)
+}
+
+async fn has_live_data(tx: &mut sqlx::Transaction<'_, sqlx::MySql>, table_id: i64) -> Result<bool> {
+    let has_files: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+             SELECT 1 FROM ducklake_data_file
+             WHERE table_id = ? AND end_snapshot IS NULL
+         )",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    if has_files {
+        return Ok(true);
+    }
+    let inline_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inline_tables {
+        let table_name: String = row.try_get(0)?;
+        let has_rows: bool = sqlx::query_scalar(AssertSqlSafe(format!(
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot IS NULL)",
+            quote_ident(&table_name)
+        )))
+        .fetch_one(&mut **tx)
+        .await?;
+        if has_rows {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn commit_staged_files(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    files: &[DataFileInfo],
+) -> Result<()> {
+    if files.is_empty() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table file stage requires at least one file".to_string(),
+        ));
+    }
+    let live_partition_id: Option<i64> = sqlx::query_scalar(
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(write.table_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    for file in files {
+        crate::metadata_writer::enforce_partition_fence(write.table_id, live_partition_id, file)?;
+    }
+    sqlx::query(
+        "INSERT IGNORE INTO ducklake_table_stats
+             (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES (?, 0, 0, 0)",
+    )
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut next_row_id: i64 =
+        sqlx::query_scalar("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+            .bind(write.table_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let data_file_ids = reserve_file_ids(tx, files.len() as i64).await?;
+    let mut total_records = 0i64;
+    let mut total_bytes = 0i64;
+    for (file, data_file_id) in files.iter().zip(data_file_ids) {
+        sqlx::query(
+            "INSERT INTO ducklake_data_file
+                 (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, record_count, row_id_start, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(data_file_id)
+        .bind(write.table_id)
+        .bind(&file.path)
+        .bind(file.path_is_relative)
+        .bind(file.file_size_bytes)
+        .bind(file.footer_size)
+        .bind(file.record_count)
+        .bind(next_row_id)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+        insert_file_column_stats(tx, write.table_id, data_file_id, &file.column_stats).await?;
+        insert_partition_metadata(tx, write.table_id, data_file_id, file).await?;
+        next_row_id += file.record_count;
+        total_records += file.record_count;
+        total_bytes += file.file_size_bytes;
+    }
+    recompute_table_column_stats(tx, write.table_id, &write.columns, &write.column_ids).await?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + ?,
+             record_count = record_count + ?,
+             file_size_bytes = file_size_bytes + ?
+         WHERE table_id = ?",
+    )
+    .bind(total_records)
+    .bind(total_records)
+    .bind(total_bytes)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Build the DDL for a physical inline table. MySQL DDL implicitly commits the
+/// surrounding transaction, so callers MUST execute this on the pool BEFORE the
+/// write transaction opens (CREATE TABLE IF NOT EXISTS is idempotent, and an
+/// existing physical table without registry rows is inert).
+fn inlined_mysql_table_ddl(
+    physical_name: &str,
+    fields: &arrow::datatypes::Fields,
+    columns: &[ColumnDef],
+) -> String {
+    let mut ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {} (\
+         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+        quote_ident(physical_name)
+    );
+    for (field, column) in fields.iter().zip(columns) {
+        ddl.push_str(", ");
+        ddl.push_str(&quote_ident(column.name()));
+        ddl.push(' ');
+        ddl.push_str(inlined_mysql_type(field.data_type()));
+    }
+    ddl.push_str(") ENGINE = InnoDB");
+    ddl
+}
+
+async fn commit_staged_inline(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    batches: &[RecordBatch],
+) -> Result<()> {
+    let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    if record_count == 0 {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table inline stage requires at least one row".to_string(),
+        ));
+    }
+    let schema_version: i64 =
+        sqlx::query_scalar("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?")
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let physical_name = format!(
+        "ducklake_inlined_data_{}_{}",
+        write.table_id, schema_version
+    );
+    // The physical table was created before this transaction opened (MySQL DDL
+    // would implicitly commit it). A missing table means the schema version
+    // moved between pre-creation and this commit; abort so the caller retries.
+    let physical_exists: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0 FROM information_schema.tables
+         WHERE table_schema = DATABASE() AND table_name = ?",
+    )
+    .bind(&physical_name)
+    .fetch_one(&mut **tx)
+    .await?;
+    if !physical_exists {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "multi-table inline stage for table {} resolved schema version {schema_version}, \
+             whose inline table does not exist yet; retry the commit",
+            write.table_id
+        )));
+    }
+    sqlx::query(
+        "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version)
+         SELECT ?, ?, ? FROM DUAL WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_inlined_data_tables
+             WHERE table_id = ? AND schema_version = ?
+         )",
+    )
+    .bind(write.table_id)
+    .bind(&physical_name)
+    .bind(schema_version)
+    .bind(write.table_id)
+    .bind(schema_version)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "INSERT IGNORE INTO ducklake_table_stats
+             (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES (?, 0, 0, 0)",
+    )
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut row_id: i64 =
+        sqlx::query_scalar("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+            .bind(write.table_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let column_list = write
+        .columns
+        .iter()
+        .map(|column| quote_ident(column.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    for batch in batches {
+        for batch_row in 0..batch.num_rows() {
+            let mut query = QueryBuilder::<MySql>::new(format!(
+                "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) VALUES (",
+                quote_ident(&physical_name),
+                column_list
+            ));
+            query.push_bind(row_id);
+            query.push(", ").push_bind(snapshot_id);
+            query.push(", NULL");
+            for (array, column) in batch.columns().iter().zip(&write.columns) {
+                query.push(", ");
+                if write
+                    .snapshot_id_columns
+                    .iter()
+                    .any(|name| name == column.name())
+                    && array.is_null(batch_row)
+                {
+                    query.push_bind(snapshot_id);
+                } else {
+                    push_inlined_mysql_value(&mut query, array.as_ref(), batch_row)?;
+                }
+            }
+            query.push(')');
+            query.build().execute(&mut **tx).await?;
+            row_id += 1;
+        }
+    }
+    let record_count = i64::try_from(record_count).map_err(|_| {
+        crate::DuckLakeError::InvalidConfig("multi-table inline row count exceeds i64".to_string())
+    })?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + ?, record_count = record_count + ?
+         WHERE table_id = ?",
+    )
+    .bind(record_count)
+    .bind(record_count)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn apply_staged_inlined_deletes(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+) -> Result<()> {
+    if write.inlined_deletes.is_empty() {
+        return Ok(());
+    }
+    let registered =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(write.table_id)
+            .fetch_all(&mut **tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get(0))
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+    for row in &write.inlined_deletes {
+        if !registered.contains(&row.table_name) {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} belongs to an unregistered table '{}'",
+                row.row_id, row.table_name
+            )));
+        }
+        let affected = sqlx::query(AssertSqlSafe(format!(
+            "UPDATE {} SET end_snapshot = ? \
+             WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+            quote_ident(&row.table_name)
+        )))
+        .bind(snapshot_id)
+        .bind(row.row_id)
+        .bind(write.base_snapshot_id)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
+        if affected != 1 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} in '{}' is no longer live at snapshot {}",
+                row.row_id, row.table_name, write.base_snapshot_id
+            )));
+        }
+    }
+    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
+        crate::DuckLakeError::InvalidConfig(
+            "multi-table inline delete count exceeds i64".to_string(),
+        )
+    })?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+    )
+    .bind(deleted)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 impl MetadataWriter for MySqlMetadataWriter {
     fn supports_update(&self) -> bool {
         true
@@ -2913,18 +3274,8 @@ impl MetadataWriter for MySqlMetadataWriter {
                     },
                 };
                 let physical_name = format!("ducklake_inlined_data_{table_id}_{version_to_create}");
-                let mut ddl = format!(
-                    "CREATE TABLE IF NOT EXISTS {} (\
-                     row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
-                    quote_ident(&physical_name)
-                );
-                for (column, field) in columns.iter().zip(batches[0].schema().fields()) {
-                    ddl.push_str(", ");
-                    ddl.push_str(&quote_ident(column.name()));
-                    ddl.push(' ');
-                    ddl.push_str(inlined_mysql_type(field.data_type()));
-                }
-                ddl.push_str(") ENGINE = InnoDB");
+                let ddl =
+                    inlined_mysql_table_ddl(&physical_name, batches[0].schema().fields(), columns);
                 sqlx::query(AssertSqlSafe(ddl)).execute(&self.pool).await?;
 
                 let mut tx = self.pool.begin().await?;
@@ -3049,6 +3400,129 @@ impl MetadataWriter for MySqlMetadataWriter {
                 snapshot_id,
                 schema_id,
                 table_id,
+            })
+        })
+    }
+
+    fn commit_multi_table(
+        &self,
+        writes: &[StagedTableWrite],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<MultiTableCommit> {
+        if writes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires at least one table stage".to_string(),
+            ));
+        }
+        let table_ids = writes
+            .iter()
+            .map(|write| write.table_id)
+            .collect::<std::collections::HashSet<_>>();
+        if table_ids.len() != writes.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires one stage per table".to_string(),
+            ));
+        }
+
+        block_on(async {
+            // MySQL DDL implicitly commits, so physical inline tables must exist
+            // before the write transaction opens. Predict the schema version the
+            // commit will resolve; commit_staged_inline aborts with Conflict if
+            // it moved, and the caller's retry recreates for the new version.
+            let predicted_version: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            for write in writes {
+                if let StagedTableData::Inlined(batches) = &write.data {
+                    if batches.is_empty() {
+                        continue;
+                    }
+                    let physical_name = format!(
+                        "ducklake_inlined_data_{}_{predicted_version}",
+                        write.table_id
+                    );
+                    let ddl = inlined_mysql_table_ddl(
+                        &physical_name,
+                        batches[0].schema().fields(),
+                        &write.columns,
+                    );
+                    sqlx::query(AssertSqlSafe(ddl)).execute(&self.pool).await?;
+                }
+            }
+
+            let mut tx = self.pool.begin().await?;
+            // Allocate the snapshot FIRST: its counter update takes the
+            // serializing row lock before any plain SELECT establishes this
+            // transaction's InnoDB read view, so every fence and stats read
+            // below sees all commits serialized before ours. Reading first
+            // would freeze a pre-lock view and silently bypass the fences.
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            if let Some(expected) = expected_base_snapshot_id {
+                for write in writes {
+                    detect_replace_conflict(&mut tx, write.table_id, expected).await?;
+                }
+            }
+            let mut had_live_data = Vec::with_capacity(writes.len());
+            for write in writes {
+                had_live_data.push(has_live_data(&mut tx, write.table_id).await?);
+            }
+            let mut tables = Vec::with_capacity(writes.len());
+            for write in writes {
+                let schema_id = validate_staged_table(&mut tx, write).await?;
+                if write.mode == WriteMode::Replace {
+                    detect_replace_conflict(&mut tx, write.table_id, write.base_snapshot_id)
+                        .await?;
+                    retire_prior_generation(&mut tx, write.table_id, snapshot_id).await?;
+                }
+                tables.push(CommitIds {
+                    snapshot_id,
+                    schema_id,
+                    table_id: write.table_id,
+                });
+            }
+            for (write, replaced_existing_data) in writes.iter().zip(had_live_data) {
+                match &write.data {
+                    StagedTableData::Files(files) => {
+                        commit_staged_files(&mut tx, snapshot_id, write, files).await?;
+                    },
+                    StagedTableData::Inlined(batches) => {
+                        commit_staged_inline(&mut tx, snapshot_id, write, batches).await?;
+                    },
+                    StagedTableData::None => {},
+                }
+                for entry in &write.positional_deletes {
+                    apply_delete_entry(
+                        &mut tx,
+                        write.table_id,
+                        write.base_snapshot_id,
+                        snapshot_id,
+                        entry,
+                    )
+                    .await?;
+                }
+                apply_staged_inlined_deletes(&mut tx, snapshot_id, write).await?;
+                let has_deletes =
+                    !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
+                let changes_made = if matches!(&write.data, StagedTableData::None) {
+                    format!("deleted_from_table:{}", write.table_id)
+                } else {
+                    table_write_changes(
+                        write.table_id,
+                        write.mode,
+                        has_deletes,
+                        replaced_existing_data,
+                    )
+                };
+                record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
+                    .await?;
+            }
+            tx.commit().await?;
+            Ok(MultiTableCommit {
+                snapshot_id,
+                tables,
             })
         })
     }

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -41,8 +41,8 @@ use crate::metadata_writer::{
     MultiTableCommit, SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite,
     WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
     catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
-    quote_snapshot_table, table_write_changes, top_level_column_ids, validate_delete_entries,
-    validate_name,
+    quote_snapshot_table, staged_table_write_changes, table_storage_changes, top_level_column_ids,
+    validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -967,6 +967,7 @@ async fn record_table_write_changes(
     table_name: &str,
     mode: WriteMode,
     has_deletes: bool,
+    inlined: bool,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
     let row = sqlx::query(
@@ -991,7 +992,7 @@ async fn record_table_write_changes(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
-    let mut replaced_existing_data: bool = sqlx::query_scalar(
+    let replaced_existing_data: bool = sqlx::query_scalar(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
             WHERE table_id = ? AND end_snapshot = ?
@@ -1001,7 +1002,8 @@ async fn record_table_write_changes(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
-    if !replaced_existing_data {
+    let mut replaced_inlined = false;
+    if mode == WriteMode::Replace {
         // A Replace over inline-only prior data ends inline rows, not files.
         let inlined_tables: Vec<String> = sqlx::query_scalar(
             "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
@@ -1019,7 +1021,7 @@ async fn record_table_write_changes(
                 .fetch_one(&mut **tx)
                 .await?
             {
-                replaced_existing_data = true;
+                replaced_inlined = true;
                 break;
             }
         }
@@ -1040,11 +1042,11 @@ async fn record_table_write_changes(
     } else if altered {
         changes.push(format!("altered_table:{table_id}"));
     }
-    changes.push(table_write_changes(
+    changes.push(table_storage_changes(
         table_id,
-        mode,
-        has_deletes,
-        replaced_existing_data,
+        Some(inlined),
+        has_deletes || (mode == WriteMode::Replace && replaced_existing_data),
+        replaced_inlined,
     ));
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
 }
@@ -1660,7 +1662,10 @@ async fn validate_staged_table(
     Ok(schema_id)
 }
 
-async fn has_live_data(tx: &mut sqlx::Transaction<'_, sqlx::MySql>, table_id: i64) -> Result<bool> {
+async fn has_live_data(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+) -> Result<(bool, bool)> {
     let has_files: bool = sqlx::query_scalar(
         "SELECT EXISTS(
              SELECT 1 FROM ducklake_data_file
@@ -1670,9 +1675,6 @@ async fn has_live_data(tx: &mut sqlx::Transaction<'_, sqlx::MySql>, table_id: i6
     .bind(table_id)
     .fetch_one(&mut **tx)
     .await?;
-    if has_files {
-        return Ok(true);
-    }
     let inline_tables =
         sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
             .bind(table_id)
@@ -1687,10 +1689,10 @@ async fn has_live_data(tx: &mut sqlx::Transaction<'_, sqlx::MySql>, table_id: i6
         .fetch_one(&mut **tx)
         .await?;
         if has_rows {
-            return Ok(true);
+            return Ok((has_files, true));
         }
     }
-    Ok(false)
+    Ok((has_files, false))
 }
 
 async fn commit_staged_files(
@@ -2380,6 +2382,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 table_name,
                 mode,
                 false,
+                false,
                 commit_metadata,
             )
             .await?;
@@ -2540,6 +2543,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 schema_name,
                 table_name,
                 mode,
+                false,
                 false,
                 commit_metadata,
             )
@@ -2705,6 +2709,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 table_name,
                 mode,
                 !deletes.is_empty(),
+                false,
                 &SnapshotCommitMetadata::default(),
             )
             .await?;
@@ -3387,6 +3392,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 table_name,
                 mode,
                 false,
+                true,
                 commit_metadata,
             )
             .await?;
@@ -3483,7 +3489,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                     table_id: write.table_id,
                 });
             }
-            for (write, replaced_existing_data) in writes.iter().zip(had_live_data) {
+            for (write, (had_files, had_inlined_rows)) in writes.iter().zip(had_live_data) {
                 match &write.data {
                     StagedTableData::Files(files) => {
                         commit_staged_files(&mut tx, snapshot_id, write, files).await?;
@@ -3504,18 +3510,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                     .await?;
                 }
                 apply_staged_inlined_deletes(&mut tx, snapshot_id, write).await?;
-                let has_deletes =
-                    !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
-                let changes_made = if matches!(&write.data, StagedTableData::None) {
-                    format!("deleted_from_table:{}", write.table_id)
-                } else {
-                    table_write_changes(
-                        write.table_id,
-                        write.mode,
-                        has_deletes,
-                        replaced_existing_data,
-                    )
-                };
+                let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
                 record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
                     .await?;
             }
@@ -3951,6 +3946,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 schema_name,
                 table_name,
                 mode,
+                false,
                 false,
                 &SnapshotCommitMetadata::default(),
             )

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -40,9 +40,10 @@ use crate::metadata_writer::{
     DeleteFileEntry, DeleteFileInfo, ExistingCatalogColumn, InlinedRowRef, MetadataWriter,
     MultiTableCommit, SnapshotCommitMetadata, SourceRetirement, StagedTableData, StagedTableWrite,
     WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
-    catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
-    quote_snapshot_table, staged_table_write_changes, table_storage_changes, top_level_column_ids,
-    validate_delete_entries, validate_name,
+    catalog_column_type_requires_migration, catalog_columns_differ, inlined_delete_conflicts,
+    inlined_delete_groups, quote_snapshot_name, quote_snapshot_table, snapshot_has_change,
+    staged_table_write_changes, table_storage_changes, top_level_column_ids,
+    validate_delete_entries, validate_name, validate_table_setting,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -53,8 +54,8 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use sqlx::Row;
-use sqlx::mysql::{MySql, MySqlPool, MySqlPoolOptions};
-use sqlx::{AssertSqlSafe, QueryBuilder};
+use sqlx::mysql::{MySql, MySqlConnection, MySqlPool, MySqlPoolOptions};
+use sqlx::{AssertSqlSafe, Connection, QueryBuilder};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
@@ -970,28 +971,6 @@ async fn record_table_write_changes(
     inlined: bool,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
-    let row = sqlx::query(
-        "SELECT s.begin_snapshot AS schema_begin_snapshot,
-                t.begin_snapshot AS table_begin_snapshot
-         FROM ducklake_table t
-         JOIN ducklake_schema s ON s.schema_id = t.schema_id
-         WHERE t.table_id = ?",
-    )
-    .bind(table_id)
-    .fetch_one(&mut **tx)
-    .await?;
-    let schema_begin_snapshot: i64 = row.try_get("schema_begin_snapshot")?;
-    let table_begin_snapshot: i64 = row.try_get("table_begin_snapshot")?;
-    let altered: bool = sqlx::query_scalar(
-        "SELECT EXISTS(
-            SELECT 1 FROM ducklake_schema_versions
-            WHERE table_id = ? AND begin_snapshot = ?
-         )",
-    )
-    .bind(table_id)
-    .bind(snapshot_id)
-    .fetch_one(&mut **tx)
-    .await?;
     let replaced_existing_data: bool = sqlx::query_scalar(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
@@ -1027,12 +1006,68 @@ async fn record_table_write_changes(
         }
     }
 
+    let write_changes = table_storage_changes(
+        table_id,
+        Some(inlined),
+        has_deletes || (mode == WriteMode::Replace && replaced_existing_data),
+        replaced_inlined,
+    );
+    record_table_changes(
+        tx,
+        snapshot_id,
+        table_id,
+        schema_name,
+        table_name,
+        &write_changes,
+        commit_metadata,
+    )
+    .await
+}
+
+async fn record_table_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    write_changes: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT s.begin_snapshot AS schema_begin_snapshot,
+                t.begin_snapshot AS table_begin_snapshot
+         FROM ducklake_table t
+         JOIN ducklake_schema s ON s.schema_id = t.schema_id
+         WHERE t.table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let schema_begin_snapshot: i64 = row.try_get("schema_begin_snapshot")?;
+    let table_begin_snapshot: i64 = row.try_get("table_begin_snapshot")?;
+    let altered: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_schema_versions
+            WHERE table_id = ? AND begin_snapshot = ?
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
     let mut changes = Vec::new();
     if schema_begin_snapshot == snapshot_id {
-        changes.push(format!(
-            "created_schema:{}",
-            quote_snapshot_name(schema_name)
-        ));
+        let entry = format!("created_schema:{}", quote_snapshot_name(schema_name));
+        let recorded: Option<String> = sqlx::query_scalar(
+            "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+        )
+        .bind(snapshot_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .flatten();
+        if !snapshot_has_change(recorded.as_deref().unwrap_or_default(), &entry) {
+            changes.push(entry);
+        }
     }
     if table_begin_snapshot == snapshot_id {
         changes.push(format!(
@@ -1042,12 +1077,7 @@ async fn record_table_write_changes(
     } else if altered {
         changes.push(format!("altered_table:{table_id}"));
     }
-    changes.push(table_storage_changes(
-        table_id,
-        Some(inlined),
-        has_deletes || (mode == WriteMode::Replace && replaced_existing_data),
-        replaced_inlined,
-    ));
+    changes.push(write_changes.to_string());
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
 }
 
@@ -1308,35 +1338,63 @@ async fn apply_inlined_deletes(
     base_snapshot: i64,
     rows: &[InlinedRowRef],
 ) -> Result<()> {
-    let registered = inlined_table_names(tx, table_id)
-        .await?
-        .into_iter()
-        .collect::<std::collections::HashSet<_>>();
-    for row in rows {
-        if !registered.contains(&row.table_name) {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} belongs to an unregistered table '{}'",
-                row.row_id, row.table_name
-            )));
-        }
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let registered: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let changes: Vec<Option<String>> = sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id > ? AND snapshot_id < ?").bind(base_snapshot).bind(snapshot_id).fetch_all(&mut **tx).await?;
+    if changes
+        .iter()
+        .flatten()
+        .any(|changes| inlined_delete_conflicts(changes, table_id))
+    {
+        return Err(crate::DuckLakeError::Conflict(
+            "table changed since the inlined delete snapshot".to_string(),
+        ));
+    }
+    for name in &registered {
         let sql = format!(
-            "UPDATE {} SET end_snapshot = ? \
-             WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
-            quote_ident(&row.table_name)
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE (begin_snapshot > ? AND begin_snapshot < ?) OR (end_snapshot > ? AND end_snapshot < ?))",
+            quote_ident(name)
         );
-        let affected = sqlx::query(AssertSqlSafe(sql))
-            .bind(snapshot_id)
-            .bind(row.row_id)
+        let changed: bool = sqlx::query_scalar(AssertSqlSafe(sql))
             .bind(base_snapshot)
-            .execute(&mut **tx)
-            .await?
-            .rows_affected();
-        if affected != 1 {
+            .bind(snapshot_id)
+            .bind(base_snapshot)
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
+        if changed {
+            return Err(crate::DuckLakeError::Conflict(
+                "inlined rows changed since the delete snapshot".to_string(),
+            ));
+        }
+    }
+    for (name, row_ids) in inlined_delete_groups(rows) {
+        if !registered.iter().any(|table| table == name) {
             return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                row.row_id, row.table_name
+                "inlined deletes reference unregistered table '{name}'"
             )));
         }
+        let ids = row_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? WHERE row_id IN ({ids}) AND end_snapshot IS NULL AND begin_snapshot <> ?",
+            quote_ident(name)
+        );
+        sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
     }
     Ok(())
 }
@@ -1419,10 +1477,37 @@ async fn finalize_snapshot(
     mode: WriteMode,
     base_snapshot: i64,
 ) -> Result<i64> {
+    let (snapshot_id, _) = insert_snapshot(tx).await?;
+    finalize_table_snapshot(
+        tx,
+        snapshot_id,
+        table_id,
+        columns,
+        column_ids,
+        mode,
+        base_snapshot,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_table_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<i64> {
     // Allocate the snapshot FIRST (carrying schema_version forward): this takes
     // the counter lock up front, serializing concurrent commits. schema_version is
     // corrected to a DDL bump below once we've classified the commit.
-    let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
+    let mut schema_version: i64 =
+        sqlx::query_scalar("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?")
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
 
     // Classify this commit as DDL vs pure data write. `current` is the table's
     // live columns ordered by `column_order`; an empty set means a brand-new table
@@ -1472,6 +1557,14 @@ async fn finalize_snapshot(
             "table columns were created concurrently with different field ids; retry the write"
                 .to_string(),
         ));
+    }
+    if current.is_empty() {
+        sqlx::query("UPDATE ducklake_schema AS s JOIN ducklake_table AS t ON t.schema_id = s.schema_id SET s.begin_snapshot = ? WHERE t.table_id = ? AND s.begin_snapshot = t.begin_snapshot").bind(snapshot_id).bind(table_id).execute(&mut **tx).await?;
+        sqlx::query("UPDATE ducklake_table SET begin_snapshot = ? WHERE table_id = ?")
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut **tx)
+            .await?;
     }
     let is_ddl = current.is_empty()
         || catalog_columns_differ(
@@ -1636,6 +1729,9 @@ async fn validate_staged_table(
     .bind(write.table_id)
     .fetch_all(&mut **tx)
     .await?;
+    if current.is_empty() && proposed.len() == write.column_ids.len() {
+        return Ok(schema_id);
+    }
     if current.len() != proposed.len() || proposed.len() != write.column_ids.len() {
         return Err(crate::DuckLakeError::Conflict(format!(
             "multi-table write target {}.{} changed schema after staging",
@@ -1818,23 +1914,6 @@ async fn commit_staged_inline(
         "ducklake_inlined_data_{}_{}",
         write.table_id, schema_version
     );
-    // The physical table was created before this transaction opened (MySQL DDL
-    // would implicitly commit it). A missing table means the schema version
-    // moved between pre-creation and this commit; abort so the caller retries.
-    let physical_exists: bool = sqlx::query_scalar(
-        "SELECT COUNT(*) > 0 FROM information_schema.tables
-         WHERE table_schema = DATABASE() AND table_name = ?",
-    )
-    .bind(&physical_name)
-    .fetch_one(&mut **tx)
-    .await?;
-    if !physical_exists {
-        return Err(crate::DuckLakeError::Conflict(format!(
-            "multi-table inline stage for table {} resolved schema version {schema_version}, \
-             whose inline table does not exist yet; retry the commit",
-            write.table_id
-        )));
-    }
     sqlx::query(
         "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version)
          SELECT ?, ?, ? FROM DUAL WHERE NOT EXISTS (
@@ -1917,62 +1996,72 @@ async fn apply_staged_inlined_deletes(
     snapshot_id: i64,
     write: &StagedTableWrite,
 ) -> Result<()> {
-    if write.inlined_deletes.is_empty() {
-        return Ok(());
-    }
-    let registered =
-        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
-            .bind(write.table_id)
-            .fetch_all(&mut **tx)
-            .await?
-            .into_iter()
-            .map(|row| row.try_get(0))
-            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
-    for row in &write.inlined_deletes {
-        if !registered.contains(&row.table_name) {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} belongs to an unregistered table '{}'",
-                row.row_id, row.table_name
-            )));
-        }
-        let affected = sqlx::query(AssertSqlSafe(format!(
-            "UPDATE {} SET end_snapshot = ? \
-             WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
-            quote_ident(&row.table_name)
-        )))
-        .bind(snapshot_id)
-        .bind(row.row_id)
-        .bind(write.base_snapshot_id)
-        .execute(&mut **tx)
-        .await?
-        .rows_affected();
-        if affected != 1 {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} in '{}' is no longer live at snapshot {}",
-                row.row_id, row.table_name, write.base_snapshot_id
-            )));
-        }
-    }
-    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
-        crate::DuckLakeError::InvalidConfig(
-            "multi-table inline delete count exceeds i64".to_string(),
-        )
-    })?;
-    sqlx::query(
-        "UPDATE ducklake_table_stats
-         SET record_count = GREATEST(record_count - ?, 0) WHERE table_id = ?",
+    apply_inlined_deletes(
+        tx,
+        write.table_id,
+        snapshot_id,
+        write.base_snapshot_id,
+        &write.inlined_deletes,
     )
-    .bind(deleted)
-    .bind(write.table_id)
-    .execute(&mut **tx)
-    .await?;
-    Ok(())
+    .await
 }
 
 impl MetadataWriter for MySqlMetadataWriter {
     fn supports_update(&self) -> bool {
         true
     }
+    fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        let key = validate_table_setting(key)?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let live: Option<i64> = sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE table_id = ? AND end_snapshot IS NULL FOR UPDATE").bind(table_id).fetch_optional(&mut *tx).await?;
+            if live.is_none() {
+                return Err(crate::DuckLakeError::TableNotFound(table_id.to_string()));
+            }
+            sqlx::query("DELETE FROM ducklake_metadata WHERE `key` = ? AND scope = 'table' AND scope_id = ?").bind(&key).bind(table_id).execute(&mut *tx).await?;
+            sqlx::query("INSERT INTO ducklake_metadata (`key`, value, scope, scope_id) VALUES (?, ?, 'table', ?)").bind(&key).bind(value).bind(table_id).execute(&mut *tx).await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn with_commit_lock(
+        &self,
+        identity: &str,
+        operation: Box<dyn FnOnce() -> Result<()> + '_>,
+    ) -> Result<()> {
+        block_on(async {
+            let mut connection = self.pool.acquire().await?;
+            // Named locks outlive transactions; close also releases the lock after a panic or failed unlock.
+            connection.close_on_drop();
+            let acquired: Option<i64> =
+                sqlx::query_scalar("SELECT GET_LOCK(SHA2(CONCAT(DATABASE(), ':', ?), 256), 30)")
+                    .bind(identity)
+                    .fetch_one(&mut *connection)
+                    .await?;
+            if acquired != Some(1) {
+                return Err(crate::DuckLakeError::Conflict(
+                    "commit coordination lock was not acquired".to_string(),
+                ));
+            }
+            let result = operation();
+            let unlock = sqlx::query_scalar::<_, Option<i64>>(
+                "SELECT RELEASE_LOCK(SHA2(CONCAT(DATABASE(), ':', ?), 256))",
+            )
+            .bind(identity)
+            .fetch_one(&mut *connection)
+            .await;
+            match (result, unlock) {
+                (Err(e), _) => Err(e),
+                (Ok(()), Ok(Some(1))) => Ok(()),
+                (Ok(()), Ok(_)) => Err(crate::DuckLakeError::Internal(
+                    "commit coordination lock was not released".to_string(),
+                )),
+                (Ok(()), Err(e)) => Err(e.into()),
+            }
+        })
+    }
+
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;
@@ -3432,33 +3521,15 @@ impl MetadataWriter for MySqlMetadataWriter {
         }
 
         block_on(async {
-            // MySQL DDL implicitly commits, so physical inline tables must exist
-            // before the write transaction opens. Predict the schema version the
-            // commit will resolve; commit_staged_inline aborts with Conflict if
-            // it moved, and the caller's retry recreates for the new version.
-            let predicted_version: i64 = sqlx::query_scalar(
-                "SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot",
-            )
-            .fetch_one(&self.pool)
-            .await?;
             for write in writes {
-                if let StagedTableData::Inlined(batches) = &write.data {
-                    if batches.is_empty() {
-                        continue;
-                    }
-                    let physical_name = format!(
-                        "ducklake_inlined_data_{}_{predicted_version}",
-                        write.table_id
-                    );
-                    let ddl = inlined_mysql_table_ddl(
-                        &physical_name,
-                        batches[0].schema().fields(),
-                        &write.columns,
-                    );
-                    sqlx::query(AssertSqlSafe(ddl)).execute(&self.pool).await?;
+                if let StagedTableData::Inlined(batches) = &write.data
+                    && batches.iter().all(|batch| batch.num_rows() == 0)
+                {
+                    return Err(crate::DuckLakeError::InvalidConfig(
+                        "multi-table inline stage requires at least one row".to_string(),
+                    ));
                 }
             }
-
             let mut tx = self.pool.begin().await?;
             // Allocate the snapshot FIRST: its counter update takes the
             // serializing row lock before any plain SELECT establishes this
@@ -3478,16 +3549,49 @@ impl MetadataWriter for MySqlMetadataWriter {
             let mut tables = Vec::with_capacity(writes.len());
             for write in writes {
                 let schema_id = validate_staged_table(&mut tx, write).await?;
-                if write.mode == WriteMode::Replace {
-                    detect_replace_conflict(&mut tx, write.table_id, write.base_snapshot_id)
-                        .await?;
-                    retire_prior_generation(&mut tx, write.table_id, snapshot_id).await?;
-                }
+                finalize_table_snapshot(
+                    &mut tx,
+                    snapshot_id,
+                    write.table_id,
+                    &write.columns,
+                    &write.column_ids,
+                    write.mode,
+                    write.base_snapshot_id,
+                )
+                .await?;
                 tables.push(CommitIds {
                     snapshot_id,
                     schema_id,
                     table_id: write.table_id,
                 });
+            }
+            if writes
+                .iter()
+                .any(|write| matches!(write.data, StagedTableData::Inlined(_)))
+            {
+                let schema_version: i64 = sqlx::query_scalar(
+                    "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+                )
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                // The counter lock keeps the version stable. A separate connection prevents DDL from committing metadata.
+                let mut ddl_connection =
+                    MySqlConnection::connect_with(&self.pool.connect_options()).await?;
+                for write in writes {
+                    if let StagedTableData::Inlined(batches) = &write.data {
+                        let physical_name =
+                            format!("ducklake_inlined_data_{}_{schema_version}", write.table_id);
+                        let ddl = inlined_mysql_table_ddl(
+                            &physical_name,
+                            batches[0].schema().fields(),
+                            &write.columns,
+                        );
+                        sqlx::query(AssertSqlSafe(ddl))
+                            .execute(&mut ddl_connection)
+                            .await?;
+                    }
+                }
             }
             for (write, (had_files, had_inlined_rows)) in writes.iter().zip(had_live_data) {
                 match &write.data {
@@ -3511,8 +3615,16 @@ impl MetadataWriter for MySqlMetadataWriter {
                 }
                 apply_staged_inlined_deletes(&mut tx, snapshot_id, write).await?;
                 let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
-                record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
-                    .await?;
+                record_table_changes(
+                    &mut tx,
+                    snapshot_id,
+                    write.table_id,
+                    &write.schema_name,
+                    &write.table_name,
+                    &changes_made,
+                    commit_metadata,
+                )
+                .await?;
             }
             tx.commit().await?;
             Ok(MultiTableCommit {
@@ -4384,6 +4496,92 @@ impl MetadataWriter for MySqlMetadataWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Int64Array;
+    use std::sync::Arc;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::mysql::Mysql;
+
+    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+    async fn mysql_staged_inline_uses_the_locked_schema_version() {
+        let container = Mysql::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(3306).await.unwrap();
+        let url = format!("mysql://root@127.0.0.1:{port}/test");
+        let writer = MySqlMetadataWriter::with_max_connections(&url, 1)
+            .await
+            .unwrap();
+        writer.initialize_schema().unwrap();
+        let columns = vec![ColumnDef::new("value", "BIGINT", false).unwrap()];
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![7, 11])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let setup = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Append)
+            .unwrap();
+        let write = StagedTableWrite {
+            table_id: setup.table_id,
+            schema_name: "main".to_string(),
+            table_name: "events".to_string(),
+            base_snapshot_id: setup.base_snapshot_id,
+            mode: WriteMode::Append,
+            columns,
+            column_ids: setup.column_ids,
+            data: StagedTableData::Inlined(vec![batch]),
+            snapshot_id_columns: Vec::new(),
+            positional_deletes: Vec::new(),
+            inlined_deletes: Vec::new(),
+            inlined_flush: false,
+        };
+        let committed = writer
+            .commit_multi_table(
+                std::slice::from_ref(&write),
+                &SnapshotCommitMetadata::default(),
+                None,
+            )
+            .unwrap();
+        let schema_version: i64 = sqlx::query_scalar(
+            "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+        )
+        .bind(committed.snapshot_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let physical: String = sqlx::query_scalar(
+            "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+        )
+        .bind(write.table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let sql = format!(
+            "SELECT row_id, begin_snapshot, value FROM {} ORDER BY row_id",
+            quote_ident(&physical)
+        );
+        let rows: Vec<(i64, i64, i64)> = sqlx::query_as(AssertSqlSafe(sql))
+            .fetch_all(&writer.pool)
+            .await
+            .unwrap();
+        assert_eq!(schema_version, 1);
+        assert_eq!(
+            physical,
+            format!("ducklake_inlined_data_{}_1", write.table_id)
+        );
+        assert_eq!(
+            rows,
+            vec![(0, committed.snapshot_id, 7), (1, committed.snapshot_id, 11)]
+        );
+        let mut empty = write;
+        empty.data = StagedTableData::Inlined(Vec::new());
+        let error = writer
+            .commit_multi_table(&[empty], &SnapshotCommitMetadata::default(), None)
+            .unwrap_err();
+        let state: (i64, i64) = sqlx::query_as("SELECT (SELECT COUNT(*) FROM ducklake_snapshot), (SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name LIKE 'ducklake_inlined_data_%')").fetch_one(&writer.pool).await.unwrap();
+        assert!(matches!(error, crate::DuckLakeError::InvalidConfig(_)));
+        assert_eq!(state, (1, 2));
+    }
 
     #[test]
     fn mysql_inlined_types_follow_sqlite_style_encodings() {

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -14,19 +14,132 @@ use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    ExistingCatalogColumn, MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult,
-    assign_column_ids, catalog_column_defs, catalog_column_type_equal,
-    catalog_column_type_requires_migration, catalog_columns_differ, table_write_changes,
-    top_level_column_ids, validate_delete_entries, validate_name,
+    ExistingCatalogColumn, InlinedRowRef, MetadataWriter, MultiTableCommit, SnapshotCommitMetadata,
+    StagedTableData, StagedTableWrite, WriteMode, WriteSetupResult, assign_column_ids,
+    catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
+    catalog_columns_differ, table_write_changes, top_level_column_ids, validate_delete_entries,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, FixedSizeBinaryArray, LargeBinaryArray, LargeStringArray,
+    StringArray,
+};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
 use sqlx::AssertSqlSafe;
+use sqlx::QueryBuilder;
 use sqlx::Row;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::{PgPool, PgPoolOptions, Postgres};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
 pub const DEFAULT_LOCK_TIMEOUT_MS: u32 = 30_000;
+
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn inlined_postgres_type(data_type: &DataType) -> String {
+    match data_type {
+        DataType::Boolean => "BOOLEAN".to_string(),
+        DataType::Int8 | DataType::Int16 => "SMALLINT".to_string(),
+        DataType::Int32 => "INTEGER".to_string(),
+        DataType::Int64 => "BIGINT".to_string(),
+        DataType::UInt8 | DataType::UInt16 => "INTEGER".to_string(),
+        DataType::UInt32 => "BIGINT".to_string(),
+        DataType::Float32 => "REAL".to_string(),
+        DataType::Float64 => "DOUBLE PRECISION".to_string(),
+        DataType::Decimal32(precision, scale)
+        | DataType::Decimal64(precision, scale)
+        | DataType::Decimal128(precision, scale)
+        | DataType::Decimal256(precision, scale) => format!("DECIMAL({precision},{scale})"),
+        DataType::Time32(_) | DataType::Time64(_) => "TIME".to_string(),
+        DataType::Interval(_) => "INTERVAL".to_string(),
+        DataType::FixedSizeBinary(16) => "UUID".to_string(),
+        DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::FixedSizeBinary(_) => "BYTEA".to_string(),
+        _ => "VARCHAR".to_string(),
+    }
+}
+
+/// Scalar types the PostgreSQL inline path preserves through catalog
+/// normalization. Nested values remain on the Parquet path until their SQL
+/// representation has a matching parser.
+fn postgres_type_inlines(data_type: &DataType) -> bool {
+    crate::metadata_writer::scalar_type_supports_inlining(data_type)
+}
+
+fn push_inlined_postgres_value(
+    query: &mut QueryBuilder<Postgres>,
+    array: &dyn Array,
+    row: usize,
+    sql_type: &str,
+) -> Result<()> {
+    if sql_type == "BYTEA" {
+        if array.is_null(row) {
+            query.push_bind(Option::<Vec<u8>>::None);
+            return Ok(());
+        }
+        let value = match array.data_type() {
+            DataType::Utf8 => array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .as_bytes()
+                .to_vec(),
+            DataType::LargeUtf8 => array
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .as_bytes()
+                .to_vec(),
+            DataType::Binary => array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+            DataType::LargeBinary => array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+            DataType::BinaryView => array
+                .as_any()
+                .downcast_ref::<BinaryViewArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+            DataType::FixedSizeBinary(_) => array
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row)
+                .to_vec(),
+            _ => crate::metadata_writer::inlined_text_value(array, row)?.into_bytes(),
+        };
+        query.push_bind(value);
+        return Ok(());
+    }
+
+    query.push("CAST(");
+    if array.is_null(row) {
+        query.push_bind(Option::<String>::None);
+    } else {
+        query.push_bind(crate::metadata_writer::inlined_text_value(array, row)?);
+    }
+    query.push(" AS ").push(sql_type).push(')');
+    Ok(())
+}
 
 /// Each standard DuckLake table as a separate CREATE TABLE IF NOT EXISTS.
 /// sqlx executes each `query()` as a single statement, so we split.
@@ -121,6 +234,11 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
         record_count BIGINT NOT NULL DEFAULT 0,
         next_row_id BIGINT NOT NULL DEFAULT 0,
         file_size_bytes BIGINT NOT NULL DEFAULT 0
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
+        table_id BIGINT NOT NULL,
+        table_name VARCHAR NOT NULL,
+        schema_version BIGINT NOT NULL
     )"#,
     // Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
     // Column set mirrors the official extension and the SQLite writer.
@@ -771,6 +889,29 @@ async fn detect_replace_conflict(
              snapshot {base_snapshot}; aborting (retry the write against the new generation)"
         )));
     }
+    let inlined_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inlined_tables {
+        let table_name: String = row.try_get(0)?;
+        let sql = format!(
+            "SELECT 1 FROM {} WHERE begin_snapshot > $1 OR end_snapshot > $1 LIMIT 1",
+            quote_ident(&table_name)
+        );
+        if sqlx::query(AssertSqlSafe(sql))
+            .bind(base_snapshot)
+            .fetch_optional(&mut **tx)
+            .await?
+            .is_some()
+        {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "Replace on table {table_id} conflicts with inlined data committed since \
+                 snapshot {base_snapshot}; aborting"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -850,6 +991,24 @@ async fn retire_prior_generation(
     .bind(table_id)
     .execute(&mut **tx)
     .await?;
+
+    let inlined_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inlined_tables {
+        let table_name: String = row.try_get(0)?;
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = $1 \
+             WHERE end_snapshot IS NULL AND begin_snapshot < $1",
+            quote_ident(&table_name)
+        );
+        sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
+    }
 
     sqlx::query(
         "UPDATE ducklake_table_stats
@@ -1158,12 +1317,6 @@ async fn recompute_table_column_stats(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[tracing::instrument(
-    name = "ducklake.finalize_snapshot",
-    level = "info",
-    skip_all,
-    fields(catalog_id, schema_name, table_name)
-)]
 async fn finalize_snapshot(
     catalog_id: i64,
     schema_name: &str,
@@ -1175,6 +1328,54 @@ async fn finalize_snapshot(
     base_snapshot: i64,
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
 ) -> Result<(i64, i64, i64)> {
+    let snapshot_id: i64 = sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+         VALUES (NOW(), 0) RETURNING snapshot_id",
+    )
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    let mut schema_version = 0;
+    let mut schema_changed = false;
+    let (schema_id, table_id) = finalize_table_snapshot(
+        catalog_id,
+        snapshot_id,
+        &mut schema_version,
+        &mut schema_changed,
+        schema_name,
+        table_name,
+        table_id_hint,
+        columns,
+        column_ids,
+        mode,
+        base_snapshot,
+        tx,
+    )
+    .await?;
+    Ok((snapshot_id, schema_id, table_id))
+}
+
+#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(
+    name = "ducklake.finalize_table_snapshot",
+    level = "info",
+    skip_all,
+    fields(catalog_id, schema_name, table_name)
+)]
+async fn finalize_table_snapshot(
+    catalog_id: i64,
+    snapshot_id: i64,
+    schema_version: &mut i64,
+    schema_changed: &mut bool,
+    schema_name: &str,
+    table_name: &str,
+    table_id_hint: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(i64, i64)> {
     // 1. Resolve the live schema id under the lock. Reuse it if present; else
     //    reserve a fresh id from the sequence (the row is inserted in step 4 once
     //    the snapshot id exists for begin_snapshot).
@@ -1215,17 +1416,7 @@ async fn finalize_snapshot(
         }
     }
 
-    // 3. Allocate the snapshot id in commit order (plain IDENTITY). schema_version
-    //    is patched in below once we know it.
-    let snapshot_id: i64 = sqlx::query(
-        "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
-         VALUES (NOW(), 0) RETURNING snapshot_id",
-    )
-    .fetch_one(&mut **tx)
-    .await?
-    .try_get(0)?;
-
-    // 4. Insert the schema row (with its reserved id) if it is new. The catalog id
+    // 3. Insert the schema row (with its reserved id) if it is new. The catalog id
     //    is encoded into the schema's *path* (not its name) so two catalogs holding
     //    their own `public` land in disjoint physical subtrees: the reader's
     //    resolution chain (`data_path + schema.path + table.path + file.path`) then
@@ -1255,7 +1446,7 @@ async fn finalize_snapshot(
         .await?;
     }
 
-    // 5. get-or-create table under the lock. Capture whether we created it.
+    // 4. Get or create the table under the lock.
     let (table_id, table_was_created): (i64, bool) = {
         let existing = sqlx::query(
             "SELECT table_id FROM ducklake_table
@@ -1285,7 +1476,7 @@ async fn finalize_snapshot(
         }
     };
 
-    // 6. Read the columns live AT COMMIT (under the lock) to classify DDL vs DML
+    // 5. Read the columns live at commit to classify DDL vs DML
     //    and drive the surgical column update below.
     let proposed = catalog_column_defs(columns)?;
     if proposed.len() != column_ids.len() {
@@ -1361,20 +1552,20 @@ async fn finalize_snapshot(
     .fetch_one(&mut **tx)
     .await?
     .try_get(0)?;
-    let new_schema_version = if is_ddl {
-        prev_max + 1
-    } else if prev_max == 0 {
-        1
-    } else {
-        prev_max
-    };
+    if *schema_version == 0 {
+        *schema_version = prev_max.max(1);
+    }
+    if is_ddl && !*schema_changed {
+        *schema_version = prev_max + 1;
+        *schema_changed = true;
+    }
     sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
-        .bind(new_schema_version)
+        .bind(*schema_version)
         .bind(snapshot_id)
         .execute(&mut **tx)
         .await?;
 
-    // 7. Write the column generation SURGICALLY (mode-independent, matching the
+    // 6. Write the column generation surgically (mode-independent, matching the
     //    SQLite writer) so each kept column keeps a STABLE column_id (== parquet
     //    field_id). End only removed columns, insert only genuinely-new ones (with
     //    their reserved ids), and sync order/nullability on the rest in place.
@@ -1481,20 +1672,20 @@ async fn finalize_snapshot(
         }
     }
 
-    // 8. One ducklake_schema_versions row per DDL (UNIQUE(table_id, begin_snapshot)).
+    // 7. Write one schema-version row per DDL
     if is_ddl {
         sqlx::query(
             "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
              VALUES ($1, $2, $3)",
         )
         .bind(snapshot_id)
-        .bind(new_schema_version)
+        .bind(*schema_version)
         .bind(table_id)
         .execute(&mut **tx)
         .await?;
     }
 
-    // 9. Replace retirement: end the prior generation's files + zero the visible
+    // 8. Retire the prior generation and zero visible totals for Replace
     //    totals. The `begin_snapshot < S` guard spares this write's own files.
     if mode == WriteMode::Replace {
         sqlx::query(
@@ -1533,7 +1724,49 @@ async fn finalize_snapshot(
         .await?;
     }
 
-    Ok((snapshot_id, schema_id, table_id))
+    Ok((schema_id, table_id))
+}
+
+/// Whether `snapshot_id` ended prior rows of the table — Parquet files or
+/// inlined rows — i.e. a Replace actually replaced existing data.
+async fn replace_ended_prior_rows(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    snapshot_id: i64,
+) -> Result<bool> {
+    let replaced: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_data_file
+            WHERE table_id = $1 AND end_snapshot = $2
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    if replaced {
+        return Ok(true);
+    }
+    let inlined_tables: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    for table_name in inlined_tables {
+        let sql = format!(
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot = $1)",
+            quote_ident(&table_name)
+        );
+        if sqlx::query_scalar(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 async fn record_snapshot_changes(
@@ -1566,7 +1799,366 @@ async fn record_snapshot_changes(
     Ok(())
 }
 
+async fn commit_files_at_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    files: &[DataFileInfo],
+) -> Result<()> {
+    if files.is_empty() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table file stage must contain at least one file".to_string(),
+        ));
+    }
+    let live_partition_id: Option<i64> = sqlx::query_scalar(
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(write.table_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    for file in files {
+        crate::metadata_writer::enforce_partition_fence(write.table_id, live_partition_id, file)?;
+    }
+    sqlx::query(
+        "INSERT INTO ducklake_table_stats
+             (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES ($1, 0, 0, 0) ON CONFLICT DO NOTHING",
+    )
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut next_row_id: i64 =
+        sqlx::query_scalar("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+            .bind(write.table_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let mut total_records = 0;
+    let mut total_bytes = 0;
+    for file in files {
+        let data_file_id: i64 = sqlx::query_scalar(
+            "INSERT INTO ducklake_data_file
+                 (table_id, path, path_is_relative, file_size_bytes, footer_size,
+                  record_count, row_id_start, begin_snapshot)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             RETURNING data_file_id",
+        )
+        .bind(write.table_id)
+        .bind(&file.path)
+        .bind(file.path_is_relative)
+        .bind(file.file_size_bytes)
+        .bind(file.footer_size)
+        .bind(file.record_count)
+        .bind(next_row_id)
+        .bind(snapshot_id)
+        .fetch_one(&mut **tx)
+        .await?;
+        insert_file_column_stats(tx, write.table_id, data_file_id, &file.column_stats).await?;
+        insert_partition_metadata(tx, write.table_id, data_file_id, file).await?;
+        next_row_id += file.record_count;
+        total_records += file.record_count;
+        total_bytes += file.file_size_bytes;
+    }
+    recompute_table_column_stats(tx, write.table_id, &write.columns, &write.column_ids).await?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + $1, record_count = record_count + $2,
+             file_size_bytes = file_size_bytes + $3
+         WHERE table_id = $4",
+    )
+    .bind(total_records)
+    .bind(total_records)
+    .bind(total_bytes)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn commit_inlined_at_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    batches: &[RecordBatch],
+) -> Result<()> {
+    let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    if record_count == 0 {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table inline stage must contain at least one row".to_string(),
+        ));
+    }
+    let schema_version: i64 =
+        sqlx::query_scalar("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let physical_name = format!(
+        "ducklake_inlined_data_{}_{}",
+        write.table_id, schema_version
+    );
+    let sql_types = batches[0]
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| inlined_postgres_type(field.data_type()))
+        .collect::<Vec<_>>();
+    let mut ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {} (\
+         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+        quote_ident(&physical_name)
+    );
+    for ((column, _field), sql_type) in write
+        .columns
+        .iter()
+        .zip(batches[0].schema().fields())
+        .zip(&sql_types)
+    {
+        ddl.push_str(", ");
+        ddl.push_str(&quote_ident(column.name()));
+        ddl.push(' ');
+        ddl.push_str(sql_type);
+    }
+    ddl.push(')');
+    sqlx::query(AssertSqlSafe(ddl)).execute(&mut **tx).await?;
+    sqlx::query(
+        "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version)
+         SELECT $1, $2, $3
+         WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_inlined_data_tables
+             WHERE table_id = $1 AND schema_version = $3
+         )",
+    )
+    .bind(write.table_id)
+    .bind(&physical_name)
+    .bind(schema_version)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_table_stats
+             (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES ($1, 0, 0, 0) ON CONFLICT DO NOTHING",
+    )
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut row_id: i64 =
+        sqlx::query_scalar("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+            .bind(write.table_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let column_list = write
+        .columns
+        .iter()
+        .map(|column| quote_ident(column.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    for batch in batches {
+        for batch_row in 0..batch.num_rows() {
+            let mut query = QueryBuilder::<Postgres>::new(format!(
+                "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) VALUES (",
+                quote_ident(&physical_name),
+                column_list
+            ));
+            query.push_bind(row_id);
+            query.push(", ").push_bind(snapshot_id);
+            query.push(", NULL");
+            for ((array, sql_type), column) in
+                batch.columns().iter().zip(&sql_types).zip(&write.columns)
+            {
+                query.push(", ");
+                if write
+                    .snapshot_id_columns
+                    .iter()
+                    .any(|name| name == column.name())
+                    && array.is_null(batch_row)
+                {
+                    query.push_bind(snapshot_id);
+                } else {
+                    push_inlined_postgres_value(&mut query, array.as_ref(), batch_row, sql_type)?;
+                }
+            }
+            query.push(')');
+            query.build().execute(&mut **tx).await?;
+            row_id += 1;
+        }
+    }
+    let record_count = i64::try_from(record_count).map_err(|_| {
+        crate::DuckLakeError::InvalidConfig("multi-table inline row count exceeds i64".to_string())
+    })?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + $1, record_count = record_count + $2
+         WHERE table_id = $3",
+    )
+    .bind(record_count)
+    .bind(record_count)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn apply_positional_deletes_at_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    snapshot_id: i64,
+    base_snapshot: i64,
+    deletes: &[DeleteFileEntry],
+) -> Result<()> {
+    for entry in deletes {
+        let target_live: Option<i64> = sqlx::query_scalar(
+            "SELECT data_file_id FROM ducklake_data_file
+             WHERE data_file_id = $1 AND end_snapshot IS NULL",
+        )
+        .bind(entry.data_file_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if target_live.is_none() {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "DELETE on data file {} could not commit: the file is no longer live since snapshot {base_snapshot}",
+                entry.data_file_id
+            )));
+        }
+        let current_previous: Option<i64> = sqlx::query_scalar(
+            "SELECT delete_file_id FROM ducklake_delete_file
+             WHERE data_file_id = $1 AND end_snapshot IS NULL",
+        )
+        .bind(entry.data_file_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if current_previous != entry.expected_prev_delete_file {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "DELETE on data file {} could not commit: its live delete file changed from {:?} to {current_previous:?} since snapshot {base_snapshot}",
+                entry.data_file_id, entry.expected_prev_delete_file
+            )));
+        }
+        if let Some(previous) = entry.expected_prev_delete_file {
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = $1
+                 WHERE delete_file_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(previous)
+            .execute(&mut **tx)
+            .await?;
+        }
+        sqlx::query(
+            "INSERT INTO ducklake_delete_file
+                 (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, delete_count, begin_snapshot)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .bind(entry.data_file_id)
+        .bind(table_id)
+        .bind(&entry.delete.path)
+        .bind(entry.delete.path_is_relative)
+        .bind(entry.delete.file_size_bytes)
+        .bind(entry.delete.footer_size)
+        .bind(entry.delete.delete_count)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn apply_inlined_deletes_at_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    snapshot_id: i64,
+    base_snapshot: i64,
+    deletes: &[InlinedRowRef],
+) -> Result<()> {
+    let registered =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get(0))
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+    for row in deletes {
+        if !registered.contains(&row.table_name) {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} belongs to an unregistered table '{}'",
+                row.row_id, row.table_name
+            )));
+        }
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = $1
+             WHERE row_id = $2 AND begin_snapshot <= $3 AND end_snapshot IS NULL",
+            quote_ident(&row.table_name)
+        );
+        let affected = sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(row.row_id)
+            .bind(base_snapshot)
+            .execute(&mut **tx)
+            .await?
+            .rows_affected();
+        if affected != 1 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                row.row_id, row.table_name
+            )));
+        }
+    }
+    Ok(())
+}
+
 impl MetadataWriter for PostgresMetadataWriter {
+    fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        block_on(async {
+            let mut transaction = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut transaction).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut transaction).await?;
+
+            sqlx::query(
+                "DELETE FROM ducklake_metadata
+                 WHERE key = $1 AND scope = 'table' AND scope_id = $2",
+            )
+            .bind(key)
+            .bind(table_id)
+            .execute(&mut *transaction)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope, scope_id)
+                 VALUES ($1, $2, 'table', $3)",
+            )
+            .bind(key)
+            .bind(value)
+            .bind(table_id)
+            .execute(&mut *transaction)
+            .await?;
+            transaction.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn with_commit_lock(
+        &self,
+        identity: &str,
+        operation: Box<dyn FnOnce() -> Result<()> + '_>,
+    ) -> Result<()> {
+        block_on(async {
+            let mut transaction = self.pool.begin().await?;
+            let lock_key = format!("{}:{identity}", self.catalog_id);
+            sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+                .bind(lock_key)
+                .execute(&mut *transaction)
+                .await?;
+            let result = operation();
+            // The advisory lock is transaction-scoped; rollback releases it on
+            // both paths, and an operation error takes precedence.
+            let unlock = transaction.rollback().await;
+            match (result, unlock) {
+                (Ok(()), Ok(())) => Ok(()),
+                (Ok(()), Err(e)) => Err(e.into()),
+                (Err(e), _) => Err(e),
+            }
+        })
+    }
+
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;
@@ -2119,16 +2711,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            let replaced_existing_data: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = $1 AND end_snapshot = $2
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
 
@@ -2289,16 +2873,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
-            let replaced_existing_data: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = $1 AND end_snapshot = $2
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             // advance_catalog_head MUST be the last write before commit.
@@ -2308,6 +2884,353 @@ impl MetadataWriter for PostgresMetadataWriter {
                 snapshot_id,
                 schema_id,
                 table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn supports_data_inlining(&self, schema: &arrow::datatypes::Schema) -> bool {
+        schema
+            .fields()
+            .iter()
+            .all(|field| postgres_type_inlines(field.data_type()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_inlined_data(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        batches: &[RecordBatch],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        if record_count == 0 {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: batches must contain at least one row".to_string(),
+            ));
+        }
+        if batches
+            .iter()
+            .any(|batch| batch.num_columns() != columns.len())
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_inlined_data: batch schema does not match table columns".to_string(),
+            ));
+        }
+
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+                self.catalog_id,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+                &mut tx,
+            )
+            .await?;
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
+            }
+            let schema_version: i64 = sqlx::query_scalar(
+                "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1",
+            )
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let physical_name = format!("ducklake_inlined_data_{table_id}_{schema_version}");
+            let sql_types = batches[0]
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| inlined_postgres_type(field.data_type()))
+                .collect::<Vec<_>>();
+            let mut ddl = format!(
+                "CREATE TABLE IF NOT EXISTS {} (\
+                 row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+                quote_ident(&physical_name)
+            );
+            for ((column, _field), sql_type) in columns
+                .iter()
+                .zip(batches[0].schema().fields())
+                .zip(&sql_types)
+            {
+                ddl.push_str(", ");
+                ddl.push_str(&quote_ident(column.name()));
+                ddl.push(' ');
+                ddl.push_str(sql_type);
+            }
+            ddl.push(')');
+            sqlx::query(AssertSqlSafe(ddl)).execute(&mut *tx).await?;
+            sqlx::query(
+                "INSERT INTO ducklake_inlined_data_tables
+                     (table_id, table_name, schema_version)
+                 SELECT $1, $2, $3
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM ducklake_inlined_data_tables
+                     WHERE table_id = $1 AND schema_version = $3)",
+            )
+            .bind(table_id)
+            .bind(&physical_name)
+            .bind(schema_version)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES ($1, 0, 0, 0)
+                 ON CONFLICT (table_id) DO NOTHING",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let mut row_id: i64 = sqlx::query_scalar(
+                "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            let column_list = columns
+                .iter()
+                .map(|column| quote_ident(column.name()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            for batch in batches {
+                for batch_row in 0..batch.num_rows() {
+                    let mut query = QueryBuilder::<Postgres>::new(format!(
+                        "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) VALUES (",
+                        quote_ident(&physical_name),
+                        column_list
+                    ));
+                    query.push_bind(row_id);
+                    query.push(", ").push_bind(snapshot_id);
+                    query.push(", NULL");
+                    for ((array, sql_type), _column) in
+                        batch.columns().iter().zip(&sql_types).zip(columns)
+                    {
+                        query.push(", ");
+                        push_inlined_postgres_value(
+                            &mut query,
+                            array.as_ref(),
+                            batch_row,
+                            sql_type,
+                        )?;
+                    }
+                    query.push(')');
+                    query.build().execute(&mut *tx).await?;
+                    row_id += 1;
+                }
+            }
+
+            let record_count = i64::try_from(record_count).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "register_inlined_data: record count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id = next_row_id + $1, record_count = record_count + $2
+                 WHERE table_id = $3",
+            )
+            .bind(record_count)
+            .bind(record_count)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            // Append to any ledger entries already recorded for this snapshot
+            // (created_schema:/created_table:) instead of replacing them, and
+            // record a Replace over prior data — Parquet or inlined — as delete
+            // + insert, the same semantics the Parquet path records.
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_multi_table(
+        &self,
+        writes: &[StagedTableWrite],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<MultiTableCommit> {
+        if writes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires at least one table stage".to_string(),
+            ));
+        }
+        let table_ids = writes
+            .iter()
+            .map(|write| write.table_id)
+            .collect::<std::collections::HashSet<_>>();
+        if table_ids.len() != writes.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires one stage per table".to_string(),
+            ));
+        }
+
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            for write in writes {
+                assert_table_not_in_other_catalog(self.catalog_id, write.table_id, &mut tx).await?;
+            }
+            if let Some(expected) = expected_base_snapshot_id {
+                for write in writes {
+                    detect_replace_conflict(write.table_id, expected, &mut tx).await?;
+                }
+            }
+            let mut had_live_data = Vec::with_capacity(writes.len());
+            for write in writes {
+                let files: bool = sqlx::query_scalar(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM ducklake_data_file
+                         WHERE table_id = $1 AND end_snapshot IS NULL
+                     )",
+                )
+                .bind(write.table_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                let mut inline_rows = 0i64;
+                let inline_tables = sqlx::query(
+                    "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+                )
+                .bind(write.table_id)
+                .fetch_all(&mut *tx)
+                .await?;
+                for row in inline_tables {
+                    let table_name: String = row.try_get(0)?;
+                    let sql = format!(
+                        "SELECT COUNT(*)::BIGINT FROM {} WHERE end_snapshot IS NULL",
+                        quote_ident(&table_name)
+                    );
+                    inline_rows += sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
+                        .fetch_one(&mut *tx)
+                        .await?;
+                }
+                had_live_data.push(files || inline_rows > 0);
+            }
+            let snapshot_id: i64 = sqlx::query_scalar(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?;
+            let mut schema_version = 0;
+            let mut schema_changed = false;
+            let mut committed_writes = Vec::with_capacity(writes.len());
+            let mut tables = Vec::with_capacity(writes.len());
+            for write in writes {
+                let (schema_id, table_id) = finalize_table_snapshot(
+                    self.catalog_id,
+                    snapshot_id,
+                    &mut schema_version,
+                    &mut schema_changed,
+                    &write.schema_name,
+                    &write.table_name,
+                    write.table_id,
+                    &write.columns,
+                    &write.column_ids,
+                    write.mode,
+                    write.base_snapshot_id,
+                    &mut tx,
+                )
+                .await?;
+                let mut committed_write = write.clone();
+                committed_write.table_id = table_id;
+                committed_writes.push(committed_write);
+                tables.push(CommitIds {
+                    snapshot_id,
+                    schema_id,
+                    table_id,
+                });
+            }
+
+            for (write, replaced_existing_data) in committed_writes.iter().zip(had_live_data) {
+                match &write.data {
+                    StagedTableData::Files(files) => {
+                        commit_files_at_snapshot(&mut tx, snapshot_id, write, files).await?;
+                    },
+                    StagedTableData::Inlined(batches) => {
+                        commit_inlined_at_snapshot(&mut tx, snapshot_id, write, batches).await?;
+                    },
+                    StagedTableData::None => {},
+                }
+                apply_positional_deletes_at_snapshot(
+                    &mut tx,
+                    write.table_id,
+                    snapshot_id,
+                    write.base_snapshot_id,
+                    &write.positional_deletes,
+                )
+                .await?;
+                apply_inlined_deletes_at_snapshot(
+                    &mut tx,
+                    write.table_id,
+                    snapshot_id,
+                    write.base_snapshot_id,
+                    &write.inlined_deletes,
+                )
+                .await?;
+                if !write.inlined_deletes.is_empty() {
+                    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
+                        crate::DuckLakeError::InvalidConfig(
+                            "multi-table inline delete count exceeds i64".to_string(),
+                        )
+                    })?;
+                    sqlx::query(
+                        "UPDATE ducklake_table_stats
+                         SET record_count = GREATEST(record_count - $1, 0)
+                         WHERE table_id = $2",
+                    )
+                    .bind(deleted)
+                    .bind(write.table_id)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+                let has_deletes =
+                    !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
+                let changes_made = if matches!(&write.data, StagedTableData::None) {
+                    format!("deleted_from_table:{}", write.table_id)
+                } else {
+                    table_write_changes(
+                        write.table_id,
+                        write.mode,
+                        has_deletes,
+                        replaced_existing_data,
+                    )
+                };
+                record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
+                    .await?;
+            }
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+            tx.commit().await?;
+            Ok(MultiTableCommit {
+                snapshot_id,
+                tables,
             })
         })
     }
@@ -3293,16 +4216,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = $1 AND end_snapshot = $2
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -3557,16 +4472,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = $1 AND end_snapshot = $2
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -3724,6 +4631,310 @@ impl MetadataWriter for PostgresMetadataWriter {
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_inlined_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        rows: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        if rows.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes requires at least one row".to_string(),
+            ));
+        }
+        if rows.iter().collect::<std::collections::HashSet<_>>().len() != rows.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes contains duplicate rows".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            let schema_version: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(schema_version.max(1))
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+            let registered = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get(0))
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+            for row in rows {
+                if !registered.contains(&row.table_name) {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} belongs to an unregistered table '{}'",
+                        row.row_id, row.table_name
+                    )));
+                }
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = $1 \
+                     WHERE row_id = $2 AND begin_snapshot <= $3 AND end_snapshot IS NULL",
+                    quote_ident(&row.table_name)
+                );
+                let affected = sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .bind(row.row_id)
+                    .bind(base_snapshot)
+                    .execute(&mut *tx)
+                    .await?
+                    .rows_affected();
+                if affected != 1 {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                        row.row_id, row.table_name
+                    )));
+                }
+            }
+            let deleted = i64::try_from(rows.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "commit_inlined_deletes row count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = GREATEST(record_count - $1, 0) WHERE table_id = $2",
+            )
+            .bind(deleted)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
+                 VALUES ($1, $2)",
+            )
+            .bind(snapshot_id)
+            .bind(format!("deleted_from_table:{table_id}"))
+            .execute(&mut *tx)
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        base_snapshot: i64,
+        positional: &[DeleteFileEntry],
+        inlined: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        if inlined.is_empty() {
+            return self.commit_positional_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                positional,
+            );
+        }
+        if positional.is_empty() {
+            return self.commit_inlined_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                inlined,
+            );
+        }
+        validate_delete_entries(WriteMode::Append, positional)?;
+        if inlined
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined.len()
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_deletes contains duplicate inlined rows".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            let schema_version: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(schema_version.max(1))
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+
+            for entry in positional {
+                let target_live: Option<i64> = sqlx::query_scalar(
+                    "SELECT data_file_id FROM ducklake_data_file
+                     WHERE data_file_id = $1 AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if target_live.is_none() {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "DELETE on data file {} could not commit: the file is no longer live \
+                         since snapshot {base_snapshot}",
+                        entry.data_file_id
+                    )));
+                }
+                let current_previous: Option<i64> = sqlx::query_scalar(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = $1 AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if current_previous != entry.expected_prev_delete_file {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "DELETE on data file {} could not commit: its live delete file changed \
+                         from {:?} to {current_previous:?} since snapshot {base_snapshot}",
+                        entry.data_file_id, entry.expected_prev_delete_file
+                    )));
+                }
+                if let Some(previous) = entry.expected_prev_delete_file {
+                    sqlx::query(
+                        "UPDATE ducklake_delete_file SET end_snapshot = $1
+                         WHERE delete_file_id = $2 AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(previous)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+                sqlx::query(
+                    "INSERT INTO ducklake_delete_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, delete_count, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                )
+                .bind(entry.data_file_id)
+                .bind(table_id)
+                .bind(&entry.delete.path)
+                .bind(entry.delete.path_is_relative)
+                .bind(entry.delete.file_size_bytes)
+                .bind(entry.delete.footer_size)
+                .bind(entry.delete.delete_count)
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            let registered = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|row| row.try_get(0))
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+            for row in inlined {
+                if !registered.contains(&row.table_name) {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} belongs to an unregistered table '{}'",
+                        row.row_id, row.table_name
+                    )));
+                }
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = $1 \
+                     WHERE row_id = $2 AND begin_snapshot <= $3 AND end_snapshot IS NULL",
+                    quote_ident(&row.table_name)
+                );
+                let affected = sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .bind(row.row_id)
+                    .bind(base_snapshot)
+                    .execute(&mut *tx)
+                    .await?
+                    .rows_affected();
+                if affected != 1 {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                        row.row_id, row.table_name
+                    )));
+                }
+            }
+            let deleted = i64::try_from(inlined.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "commit_deletes row count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = GREATEST(record_count - $1, 0) WHERE table_id = $2",
+            )
+            .bind(deleted)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
+                 VALUES ($1, $2)",
+            )
+            .bind(snapshot_id)
+            .bind(format!("deleted_from_table:{table_id}"))
+            .execute(&mut *tx)
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
             tx.commit().await?;
             Ok(CommitIds {
                 snapshot_id,
@@ -4016,7 +5227,24 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .fetch_optional(&mut *tx)
             .await?;
-            if has_live_data.is_none() {
+            let inlined_tables = sqlx::query(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            let mut live_inlined = 0i64;
+            for row in &inlined_tables {
+                let table_name: String = row.try_get(0)?;
+                let sql = format!(
+                    "SELECT COUNT(*)::BIGINT FROM {} WHERE end_snapshot IS NULL",
+                    quote_ident(&table_name)
+                );
+                live_inlined += sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
+                    .fetch_one(&mut *tx)
+                    .await?;
+            }
+            if has_live_data.is_none() && live_inlined == 0 {
                 return Ok(0);
             }
 
@@ -4095,6 +5323,17 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
+            for row in inlined_tables {
+                let table_name: String = row.try_get(0)?;
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = $1 WHERE end_snapshot IS NULL",
+                    quote_ident(&table_name)
+                );
+                sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
             sqlx::query(
                 "UPDATE ducklake_delete_file SET end_snapshot = $1
                  WHERE table_id = $2 AND end_snapshot IS NULL",
@@ -4295,16 +5534,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             )
             .await?;
 
-            let replaced_existing_data: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = $1 AND end_snapshot = $2
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(
                 &mut tx,
@@ -4651,7 +5882,35 @@ impl MetadataWriter for PostgresMetadataWriter {
 
 #[cfg(test)]
 mod tests {
+    use super::inlined_postgres_type;
     use crate::metadata_writer::{ColumnDef, columns_differ};
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
+
+    #[test]
+    fn postgres_inlined_types_follow_ducklake_encodings() {
+        assert_eq!(inlined_postgres_type(&DataType::Int8), "SMALLINT");
+        assert_eq!(inlined_postgres_type(&DataType::UInt32), "BIGINT");
+        assert_eq!(inlined_postgres_type(&DataType::UInt64), "VARCHAR");
+        assert_eq!(inlined_postgres_type(&DataType::Utf8), "BYTEA");
+        assert_eq!(
+            inlined_postgres_type(&DataType::FixedSizeBinary(16)),
+            "UUID"
+        );
+        assert_eq!(
+            inlined_postgres_type(&DataType::FixedSizeBinary(32)),
+            "BYTEA"
+        );
+        assert_eq!(inlined_postgres_type(&DataType::Date32), "VARCHAR");
+        assert_eq!(
+            inlined_postgres_type(&DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Int32,
+                true,
+            )))),
+            "VARCHAR"
+        );
+    }
 
     #[test]
     fn test_columns_differ_identical() {

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -17,8 +17,9 @@ use crate::metadata_writer::{
     ExistingCatalogColumn, InlinedRowRef, MetadataWriter, MultiTableCommit, SnapshotCommitMetadata,
     StagedTableData, StagedTableWrite, WriteMode, WriteSetupResult, assign_column_ids,
     catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
-    catalog_columns_differ, staged_table_write_changes, table_storage_changes, table_write_changes,
-    top_level_column_ids, validate_delete_entries, validate_name,
+    catalog_columns_differ, inlined_delete_conflicts, inlined_delete_groups, snapshot_has_change,
+    staged_table_write_changes, table_storage_changes, table_write_changes, top_level_column_ids,
+    validate_delete_entries, validate_name, validate_table_setting,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -32,7 +33,7 @@ use sqlx::QueryBuilder;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, Postgres};
 
-const SQL_CREATE_INLINED_DATA_TABLES: &str =
+pub(crate) const SQL_CREATE_INLINED_DATA_TABLES: &str =
     "CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
     table_id BIGINT,
     table_name VARCHAR,
@@ -43,7 +44,7 @@ const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
 pub const DEFAULT_LOCK_TIMEOUT_MS: u32 = 30_000;
 
-fn quote_ident(name: &str) -> String {
+pub(crate) fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
 }
 
@@ -870,7 +871,7 @@ async fn reserve_ids(
 /// and a DROP (end-stamp). The writer's own rows are not written yet, so the
 /// check never self-conflicts. (`Append` does not call this: concurrent appends
 /// commute, matching upstream DuckLake.)
-async fn detect_replace_conflict(
+pub(crate) async fn detect_replace_conflict(
     table_id: i64,
     base_snapshot: i64,
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -1714,12 +1715,7 @@ async fn finalize_table_snapshot(
         .fetch_optional(&mut **tx)
         .await?
         .flatten();
-        if !recorded
-            .as_deref()
-            .unwrap_or_default()
-            .split(',')
-            .any(|token| token == schema_entry)
-        {
+        if !snapshot_has_change(recorded.as_deref().unwrap_or_default(), &schema_entry) {
             ddl_changes.push(schema_entry);
         }
     }
@@ -1745,7 +1741,7 @@ async fn finalize_table_snapshot(
 }
 
 // The flags report retired Parquet files and inlined rows, respectively
-async fn replaced_storage(
+pub(crate) async fn replaced_storage(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
     snapshot_id: i64,
@@ -1812,7 +1808,47 @@ async fn record_snapshot_changes(
     Ok(())
 }
 
-async fn commit_files_at_snapshot(
+pub(crate) async fn validate_staged_table(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    write: &StagedTableWrite,
+) -> Result<()> {
+    let ended: Option<Option<i64>> =
+        sqlx::query_scalar("SELECT end_snapshot FROM ducklake_table WHERE table_id = $1")
+            .bind(write.table_id)
+            .fetch_optional(&mut **tx)
+            .await?;
+    if matches!(ended, Some(Some(_))) {
+        return Err(crate::DuckLakeError::Conflict(
+            "staged table was dropped".to_string(),
+        ));
+    }
+    let current = sqlx::query("SELECT column_id, column_type, nulls_allowed, parent_column FROM ducklake_column WHERE table_id = $1 AND end_snapshot IS NULL ORDER BY column_order").bind(write.table_id).fetch_all(&mut **tx).await?;
+    let proposed = catalog_column_defs(&write.columns)?;
+    if current.is_empty() && proposed.len() == write.column_ids.len() {
+        return Ok(());
+    }
+    let mut matches = current.len() == proposed.len() && proposed.len() == write.column_ids.len();
+    if matches {
+        for (index, (row, column)) in current.iter().zip(&proposed).enumerate() {
+            let column_id: i64 = row.try_get("column_id")?;
+            let column_type: String = row.try_get("column_type")?;
+            let nullable: Option<bool> = row.try_get("nulls_allowed")?;
+            let parent: Option<i64> = row.try_get("parent_column")?;
+            matches &= column_id == write.column_ids[index]
+                && catalog_column_type_equal(&column_type, column)
+                && nullable.unwrap_or(true) == column.is_nullable
+                && parent == column.parent_index.map(|i| write.column_ids[i]);
+        }
+    }
+    if !matches {
+        return Err(crate::DuckLakeError::Conflict(
+            "table schema changed after staging".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) async fn commit_files_at_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     snapshot_id: i64,
     write: &StagedTableWrite,
@@ -1888,7 +1924,7 @@ async fn commit_files_at_snapshot(
     Ok(())
 }
 
-async fn commit_inlined_at_snapshot(
+pub(crate) async fn commit_inlined_at_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     snapshot_id: i64,
     write: &StagedTableWrite,
@@ -2011,7 +2047,7 @@ async fn commit_inlined_at_snapshot(
     Ok(())
 }
 
-async fn apply_positional_deletes_at_snapshot(
+pub(crate) async fn apply_positional_deletes_at_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
     snapshot_id: i64,
@@ -2075,77 +2111,126 @@ async fn apply_positional_deletes_at_snapshot(
     Ok(())
 }
 
-async fn apply_inlined_deletes_at_snapshot(
+pub(crate) async fn apply_inlined_deletes_at_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
     snapshot_id: i64,
     base_snapshot: i64,
     deletes: &[InlinedRowRef],
 ) -> Result<()> {
-    let registered =
-        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1")
-            .bind(table_id)
-            .fetch_all(&mut **tx)
-            .await?
-            .into_iter()
-            .map(|row| row.try_get(0))
-            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
-    for row in deletes {
-        if !registered.contains(&row.table_name) {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} belongs to an unregistered table '{}'",
-                row.row_id, row.table_name
-            )));
-        }
+    if deletes.is_empty() {
+        return Ok(());
+    }
+    let registered: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let changes: Vec<Option<String>> = sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id > $1 AND snapshot_id < $2").bind(base_snapshot).bind(snapshot_id).fetch_all(&mut **tx).await?;
+    if changes
+        .iter()
+        .flatten()
+        .any(|changes| inlined_delete_conflicts(changes, table_id))
+    {
+        return Err(crate::DuckLakeError::Conflict(
+            "table changed since the inlined delete snapshot".to_string(),
+        ));
+    }
+    for name in &registered {
         let sql = format!(
-            "UPDATE {} SET end_snapshot = $1
-             WHERE row_id = $2 AND begin_snapshot <= $3 AND end_snapshot IS NULL",
-            quote_ident(&row.table_name)
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE (begin_snapshot > $1 AND begin_snapshot < $2) OR (end_snapshot > $1 AND end_snapshot < $2))",
+            quote_ident(name)
         );
-        let affected = sqlx::query(AssertSqlSafe(sql))
-            .bind(snapshot_id)
-            .bind(row.row_id)
+        let changed: bool = sqlx::query_scalar(AssertSqlSafe(sql))
             .bind(base_snapshot)
-            .execute(&mut **tx)
-            .await?
-            .rows_affected();
-        if affected != 1 {
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
+        if changed {
+            return Err(crate::DuckLakeError::Conflict(
+                "inlined rows changed since the delete snapshot".to_string(),
+            ));
+        }
+    }
+    for (name, row_ids) in inlined_delete_groups(deletes) {
+        if !registered.iter().any(|table| table == name) {
             return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                row.row_id, row.table_name
+                "inlined deletes reference unregistered table '{name}'"
             )));
         }
+        let ids = row_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = $1 WHERE row_id IN ({ids}) AND end_snapshot IS NULL AND begin_snapshot <> $2",
+            quote_ident(name)
+        );
+        sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
     }
     Ok(())
 }
 
+pub(crate) fn set_postgres_table_setting(
+    pool: &PgPool,
+    catalog_id: Option<i64>,
+    table_id: i64,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    let key = validate_table_setting(key)?;
+    block_on(async {
+        let mut tx = pool.begin().await?;
+        if let Some(catalog_id) = catalog_id {
+            assert_table_in_catalog(catalog_id, table_id, &mut tx).await?;
+        }
+        let live: Option<i64> = sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE table_id = $1 AND end_snapshot IS NULL FOR UPDATE").bind(table_id).fetch_optional(&mut *tx).await?;
+        if live.is_none() {
+            return Err(crate::DuckLakeError::TableNotFound(table_id.to_string()));
+        }
+        sqlx::query(
+            "DELETE FROM ducklake_metadata WHERE key = $1 AND scope = 'table' AND scope_id = $2",
+        )
+        .bind(&key)
+        .bind(table_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("INSERT INTO ducklake_metadata (key, value, scope, scope_id) VALUES ($1, $2, 'table', $3)").bind(&key).bind(value).bind(table_id).execute(&mut *tx).await?;
+        tx.commit().await?;
+        Ok(())
+    })
+}
+
+pub(crate) fn with_postgres_commit_lock(
+    pool: &PgPool,
+    identity: &str,
+    operation: Box<dyn FnOnce() -> Result<()> + '_>,
+) -> Result<()> {
+    block_on(async {
+        let mut tx = pool.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(identity)
+            .execute(&mut *tx)
+            .await?;
+        let result = operation();
+        let unlock = tx.rollback().await;
+        match (result, unlock) {
+            (Err(e), _) => Err(e),
+            (Ok(()), Ok(())) => Ok(()),
+            (Ok(()), Err(e)) => Err(e.into()),
+        }
+    })
+}
+
 impl MetadataWriter for PostgresMetadataWriter {
     fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
-        block_on(async {
-            let mut transaction = self.pool.begin().await?;
-            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut transaction).await?;
-            assert_table_in_catalog(self.catalog_id, table_id, &mut transaction).await?;
-
-            sqlx::query(
-                "DELETE FROM ducklake_metadata
-                 WHERE key = $1 AND scope = 'table' AND scope_id = $2",
-            )
-            .bind(key)
-            .bind(table_id)
-            .execute(&mut *transaction)
-            .await?;
-            sqlx::query(
-                "INSERT INTO ducklake_metadata (key, value, scope, scope_id)
-                 VALUES ($1, $2, 'table', $3)",
-            )
-            .bind(key)
-            .bind(value)
-            .bind(table_id)
-            .execute(&mut *transaction)
-            .await?;
-            transaction.commit().await?;
-            Ok(())
-        })
+        set_postgres_table_setting(&self.pool, Some(self.catalog_id), table_id, key, value)
     }
 
     fn with_commit_lock(
@@ -2153,23 +2238,11 @@ impl MetadataWriter for PostgresMetadataWriter {
         identity: &str,
         operation: Box<dyn FnOnce() -> Result<()> + '_>,
     ) -> Result<()> {
-        block_on(async {
-            let mut transaction = self.pool.begin().await?;
-            let lock_key = format!("{}:{identity}", self.catalog_id);
-            sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-                .bind(lock_key)
-                .execute(&mut *transaction)
-                .await?;
-            let result = operation();
-            // The advisory lock is transaction-scoped; rollback releases it on
-            // both paths, and an operation error takes precedence.
-            let unlock = transaction.rollback().await;
-            match (result, unlock) {
-                (Ok(()), Ok(())) => Ok(()),
-                (Ok(()), Err(e)) => Err(e.into()),
-                (Err(e), _) => Err(e),
-            }
-        })
+        with_postgres_commit_lock(
+            &self.pool,
+            &format!("{}:{identity}", self.catalog_id),
+            operation,
+        )
     }
 
     fn create_snapshot(&self) -> Result<i64> {
@@ -3112,6 +3185,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             for write in writes {
+                validate_staged_table(&mut tx, write).await?;
                 assert_table_not_in_other_catalog(self.catalog_id, write.table_id, &mut tx).await?;
             }
             if let Some(expected) = expected_base_snapshot_id {
@@ -3212,22 +3286,6 @@ impl MetadataWriter for PostgresMetadataWriter {
                     &write.inlined_deletes,
                 )
                 .await?;
-                if !write.inlined_deletes.is_empty() {
-                    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
-                        crate::DuckLakeError::InvalidConfig(
-                            "multi-table inline delete count exceeds i64".to_string(),
-                        )
-                    })?;
-                    sqlx::query(
-                        "UPDATE ducklake_table_stats
-                         SET record_count = GREATEST(record_count - $1, 0)
-                         WHERE table_id = $2",
-                    )
-                    .bind(deleted)
-                    .bind(write.table_id)
-                    .execute(&mut *tx)
-                    .await?;
-                }
                 let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
                 record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
                     .await?;
@@ -4657,11 +4715,6 @@ impl MetadataWriter for PostgresMetadataWriter {
                 "commit_inlined_deletes requires at least one row".to_string(),
             ));
         }
-        if rows.iter().collect::<std::collections::HashSet<_>>().len() != rows.len() {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "commit_inlined_deletes contains duplicate rows".to_string(),
-            ));
-        }
         block_on(async {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
@@ -4686,60 +4739,14 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .bind(snapshot_id)
                 .execute(&mut *tx)
                 .await?;
-            let registered = sqlx::query(
-                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
-            )
-            .bind(table_id)
-            .fetch_all(&mut *tx)
-            .await?
-            .into_iter()
-            .map(|row| row.try_get(0))
-            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
-            for row in rows {
-                if !registered.contains(&row.table_name) {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "inlined row {} belongs to an unregistered table '{}'",
-                        row.row_id, row.table_name
-                    )));
-                }
-                let sql = format!(
-                    "UPDATE {} SET end_snapshot = $1 \
-                     WHERE row_id = $2 AND begin_snapshot <= $3 AND end_snapshot IS NULL",
-                    quote_ident(&row.table_name)
-                );
-                let affected = sqlx::query(AssertSqlSafe(sql))
-                    .bind(snapshot_id)
-                    .bind(row.row_id)
-                    .bind(base_snapshot)
-                    .execute(&mut *tx)
-                    .await?
-                    .rows_affected();
-                if affected != 1 {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                        row.row_id, row.table_name
-                    )));
-                }
-            }
-            let deleted = i64::try_from(rows.len()).map_err(|_| {
-                crate::DuckLakeError::InvalidConfig(
-                    "commit_inlined_deletes row count exceeds i64".to_string(),
-                )
-            })?;
-            sqlx::query(
-                "UPDATE ducklake_table_stats
-                 SET record_count = GREATEST(record_count - $1, 0) WHERE table_id = $2",
-            )
-            .bind(deleted)
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
+            apply_inlined_deletes_at_snapshot(&mut tx, table_id, snapshot_id, base_snapshot, rows)
+                .await?;
             sqlx::query(
                 "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
                  VALUES ($1, $2)",
             )
             .bind(snapshot_id)
-            .bind(format!("deleted_from_table:{table_id}"))
+            .bind(format!("inlined_delete:{table_id}"))
             .execute(&mut *tx)
             .await?;
             let schema_id: i64 =
@@ -4785,16 +4792,6 @@ impl MetadataWriter for PostgresMetadataWriter {
             );
         }
         validate_delete_entries(WriteMode::Append, positional)?;
-        if inlined
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-            != inlined.len()
-        {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "commit_deletes contains duplicate inlined rows".to_string(),
-            ));
-        }
         block_on(async {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
@@ -4877,60 +4874,25 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
-            let registered = sqlx::query(
-                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+            apply_inlined_deletes_at_snapshot(
+                &mut tx,
+                table_id,
+                snapshot_id,
+                base_snapshot,
+                inlined,
             )
-            .bind(table_id)
-            .fetch_all(&mut *tx)
-            .await?
-            .into_iter()
-            .map(|row| row.try_get(0))
-            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
-            for row in inlined {
-                if !registered.contains(&row.table_name) {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "inlined row {} belongs to an unregistered table '{}'",
-                        row.row_id, row.table_name
-                    )));
-                }
-                let sql = format!(
-                    "UPDATE {} SET end_snapshot = $1 \
-                     WHERE row_id = $2 AND begin_snapshot <= $3 AND end_snapshot IS NULL",
-                    quote_ident(&row.table_name)
-                );
-                let affected = sqlx::query(AssertSqlSafe(sql))
-                    .bind(snapshot_id)
-                    .bind(row.row_id)
-                    .bind(base_snapshot)
-                    .execute(&mut *tx)
-                    .await?
-                    .rows_affected();
-                if affected != 1 {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                        row.row_id, row.table_name
-                    )));
-                }
-            }
-            let deleted = i64::try_from(inlined.len()).map_err(|_| {
-                crate::DuckLakeError::InvalidConfig(
-                    "commit_deletes row count exceeds i64".to_string(),
-                )
-            })?;
-            sqlx::query(
-                "UPDATE ducklake_table_stats
-                 SET record_count = GREATEST(record_count - $1, 0) WHERE table_id = $2",
-            )
-            .bind(deleted)
-            .bind(table_id)
-            .execute(&mut *tx)
             .await?;
             sqlx::query(
                 "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
                  VALUES ($1, $2)",
             )
             .bind(snapshot_id)
-            .bind(format!("deleted_from_table:{table_id}"))
+            .bind(table_storage_changes(
+                table_id,
+                None,
+                !positional.is_empty(),
+                !inlined.is_empty(),
+            ))
             .execute(&mut *tx)
             .await?;
             let schema_id: i64 =

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -17,8 +17,8 @@ use crate::metadata_writer::{
     ExistingCatalogColumn, InlinedRowRef, MetadataWriter, MultiTableCommit, SnapshotCommitMetadata,
     StagedTableData, StagedTableWrite, WriteMode, WriteSetupResult, assign_column_ids,
     catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
-    catalog_columns_differ, table_write_changes, top_level_column_ids, validate_delete_entries,
-    validate_name,
+    catalog_columns_differ, staged_table_write_changes, table_storage_changes, table_write_changes,
+    top_level_column_ids, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -31,6 +31,13 @@ use sqlx::AssertSqlSafe;
 use sqlx::QueryBuilder;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, Postgres};
+
+const SQL_CREATE_INLINED_DATA_TABLES: &str =
+    "CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
+    table_id BIGINT,
+    table_name VARCHAR,
+    schema_version BIGINT
+)";
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
@@ -235,11 +242,7 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
         next_row_id BIGINT NOT NULL DEFAULT 0,
         file_size_bytes BIGINT NOT NULL DEFAULT 0
     )"#,
-    r#"CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
-        table_id BIGINT NOT NULL,
-        table_name VARCHAR NOT NULL,
-        schema_version BIGINT NOT NULL
-    )"#,
+    SQL_CREATE_INLINED_DATA_TABLES,
     // Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
     // Column set mirrors the official extension and the SQLite writer.
     r#"CREATE TABLE IF NOT EXISTS ducklake_file_column_stats (
@@ -637,6 +640,9 @@ impl PostgresMetadataWriter {
     /// Use [`crate::multicatalog::MulticatalogManager::create_catalog`] to obtain
     /// or create a catalog id by name.
     pub async fn with_pool(pool: PgPool, catalog_id: i64) -> Result<Self> {
+        sqlx::query(SQL_CREATE_INLINED_DATA_TABLES)
+            .execute(&pool)
+            .await?;
         Ok(Self {
             pool,
             catalog_id,
@@ -657,11 +663,7 @@ impl PostgresMetadataWriter {
             .max_connections(max_connections)
             .connect(connection_string)
             .await?;
-        Ok(Self {
-            pool,
-            catalog_id,
-            lock_timeout_ms: DEFAULT_LOCK_TIMEOUT_MS,
-        })
+        Self::with_pool(pool, catalog_id).await
     }
 
     /// Sets the Postgres `lock_timeout` (ms) applied before `FOR UPDATE`.
@@ -1701,10 +1703,25 @@ async fn finalize_table_snapshot(
 
     let mut ddl_changes = Vec::new();
     if schema_was_created {
-        ddl_changes.push(format!(
+        let schema_entry = format!(
             "created_schema:{}",
-            crate::metadata_writer::quote_snapshot_name(schema_name),
-        ));
+            crate::metadata_writer::quote_snapshot_name(schema_name)
+        );
+        let recorded: Option<String> = sqlx::query_scalar(
+            "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
+        )
+        .bind(snapshot_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .flatten();
+        if !recorded
+            .as_deref()
+            .unwrap_or_default()
+            .split(',')
+            .any(|token| token == schema_entry)
+        {
+            ddl_changes.push(schema_entry);
+        }
     }
     if table_was_created {
         ddl_changes.push(format!(
@@ -1727,13 +1744,12 @@ async fn finalize_table_snapshot(
     Ok((schema_id, table_id))
 }
 
-/// Whether `snapshot_id` ended prior rows of the table — Parquet files or
-/// inlined rows — i.e. a Replace actually replaced existing data.
-async fn replace_ended_prior_rows(
+// The flags report retired Parquet files and inlined rows, respectively
+async fn replaced_storage(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
     snapshot_id: i64,
-) -> Result<bool> {
+) -> Result<(bool, bool)> {
     let replaced: bool = sqlx::query_scalar(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
@@ -1744,9 +1760,6 @@ async fn replace_ended_prior_rows(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
-    if replaced {
-        return Ok(true);
-    }
     let inlined_tables: Vec<String> = sqlx::query_scalar(
         "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
     )
@@ -1763,10 +1776,10 @@ async fn replace_ended_prior_rows(
             .fetch_one(&mut **tx)
             .await?
         {
-            return Ok(true);
+            return Ok((replaced, true));
         }
     }
-    Ok(false)
+    Ok((replaced, false))
 }
 
 async fn record_snapshot_changes(
@@ -1904,7 +1917,7 @@ async fn commit_inlined_at_snapshot(
         .collect::<Vec<_>>();
     let mut ddl = format!(
         "CREATE TABLE IF NOT EXISTS {} (\
-         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+         row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT",
         quote_ident(&physical_name)
     );
     for ((column, _field), sql_type) in write
@@ -2711,8 +2724,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
 
@@ -2873,8 +2885,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             // advance_catalog_head MUST be the last write before commit.
@@ -2962,7 +2973,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .collect::<Vec<_>>();
             let mut ddl = format!(
                 "CREATE TABLE IF NOT EXISTS {} (\
-                 row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+                 row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT",
                 quote_ident(&physical_name)
             );
             for ((column, _field), sql_type) in columns
@@ -3057,9 +3068,14 @@ impl MetadataWriter for PostgresMetadataWriter {
             // (created_schema:/created_table:) instead of replacing them, and
             // record a Replace over prior data — Parquet or inlined — as delete
             // + insert, the same semantics the Parquet path records.
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
-            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            let (replaced_files, replaced_inlined) =
+                replaced_storage(&mut tx, table_id, snapshot_id).await?;
+            let changes_made = table_storage_changes(
+                table_id,
+                Some(true),
+                mode == WriteMode::Replace && replaced_files,
+                mode == WriteMode::Replace && replaced_inlined,
+            );
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
             tx.commit().await?;
@@ -3131,7 +3147,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                         .fetch_one(&mut *tx)
                         .await?;
                 }
-                had_live_data.push(files || inline_rows > 0);
+                had_live_data.push((files, inline_rows > 0));
             }
             let snapshot_id: i64 = sqlx::query_scalar(
                 "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
@@ -3169,7 +3185,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 });
             }
 
-            for (write, replaced_existing_data) in committed_writes.iter().zip(had_live_data) {
+            for (write, (had_files, had_inlined_rows)) in committed_writes.iter().zip(had_live_data)
+            {
                 match &write.data {
                     StagedTableData::Files(files) => {
                         commit_files_at_snapshot(&mut tx, snapshot_id, write, files).await?;
@@ -3211,18 +3228,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .execute(&mut *tx)
                     .await?;
                 }
-                let has_deletes =
-                    !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
-                let changes_made = if matches!(&write.data, StagedTableData::None) {
-                    format!("deleted_from_table:{}", write.table_id)
-                } else {
-                    table_write_changes(
-                        write.table_id,
-                        write.mode,
-                        has_deletes,
-                        replaced_existing_data,
-                    )
-                };
+                let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
                 record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
                     .await?;
             }
@@ -4216,8 +4222,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -4472,8 +4477,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -5534,8 +5538,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             )
             .await?;
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(
                 &mut tx,

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -537,7 +537,7 @@ async fn record_table_write_changes(
         table_id,
         mode,
         false,
-        replaced_existing_data,
+        (replaced_existing_data, false),
     ));
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
 }

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -24,14 +24,21 @@ use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, ExistingCatalogColumn, MetadataWriter,
-    SnapshotCommitMetadata, WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs,
-    catalog_column_type_equal, catalog_column_type_requires_migration, catalog_columns_differ,
-    quote_snapshot_name, quote_snapshot_table, table_write_changes, top_level_column_ids,
-    validate_name,
+    MultiTableCommit, SnapshotCommitMetadata, StagedTableData, StagedTableWrite, WriteMode,
+    WriteSetupResult, assign_column_ids, catalog_column_defs, catalog_column_type_equal,
+    catalog_column_type_requires_migration, catalog_columns_differ, quote_snapshot_name,
+    quote_snapshot_table, snapshot_has_change, staged_table_write_changes, table_write_changes,
+    top_level_column_ids, validate_name,
+};
+use crate::metadata_writer_postgres::{
+    SQL_CREATE_INLINED_DATA_TABLES, apply_inlined_deletes_at_snapshot,
+    apply_positional_deletes_at_snapshot, commit_files_at_snapshot, commit_inlined_at_snapshot,
+    detect_replace_conflict as detect_staged_conflict, quote_ident, set_postgres_table_setting,
+    validate_staged_table, with_postgres_commit_lock,
 };
 use crate::partition::PartitionTransform;
-use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::{AssertSqlSafe, Row};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
@@ -39,6 +46,7 @@ const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 /// the SQLite and MySQL writers (and so upstream); only the SQL types differ. Split
 /// one per entry because sqlx runs each `query()` as a single prepared statement.
 const SQL_CREATE_TABLES: &[&str] = &[
+    SQL_CREATE_INLINED_DATA_TABLES,
     r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
         key VARCHAR NOT NULL,
         value VARCHAR NOT NULL,
@@ -485,6 +493,39 @@ async fn record_table_write_changes(
     mode: WriteMode,
     commit_metadata: &SnapshotCommitMetadata,
 ) -> Result<()> {
+    let replaced_existing_data: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_data_file
+            WHERE table_id = $1 AND end_snapshot = $2
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    let write_changes = table_write_changes(table_id, mode, false, (replaced_existing_data, false));
+    record_table_changes(
+        tx,
+        snapshot_id,
+        table_id,
+        schema_name,
+        table_name,
+        &write_changes,
+        commit_metadata,
+    )
+    .await
+}
+
+async fn record_table_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    write_changes: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
     let row = sqlx::query(
         "SELECT s.begin_snapshot AS schema_begin_snapshot,
                 t.begin_snapshot AS table_begin_snapshot
@@ -507,23 +548,19 @@ async fn record_table_write_changes(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
-    let replaced_existing_data: bool = sqlx::query_scalar(
-        "SELECT EXISTS(
-            SELECT 1 FROM ducklake_data_file
-            WHERE table_id = $1 AND end_snapshot = $2
-         )",
-    )
-    .bind(table_id)
-    .bind(snapshot_id)
-    .fetch_one(&mut **tx)
-    .await?;
-
     let mut changes = Vec::new();
     if schema_begin_snapshot == snapshot_id {
-        changes.push(format!(
-            "created_schema:{}",
-            quote_snapshot_name(schema_name)
-        ));
+        let entry = format!("created_schema:{}", quote_snapshot_name(schema_name));
+        let recorded: Option<String> = sqlx::query_scalar(
+            "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
+        )
+        .bind(snapshot_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .flatten();
+        if !snapshot_has_change(recorded.as_deref().unwrap_or_default(), &entry) {
+            changes.push(entry);
+        }
     }
     if table_begin_snapshot == snapshot_id {
         changes.push(format!(
@@ -533,12 +570,7 @@ async fn record_table_write_changes(
     } else if altered {
         changes.push(format!("altered_table:{table_id}"));
     }
-    changes.push(table_write_changes(
-        table_id,
-        mode,
-        false,
-        (replaced_existing_data, false),
-    ));
+    changes.push(write_changes.to_string());
     record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
 }
 
@@ -753,10 +785,41 @@ async fn finalize_snapshot(
     mode: WriteMode,
     base_snapshot: i64,
 ) -> Result<CommitIds> {
+    let (snapshot_id, _) = insert_snapshot(tx).await?;
+    finalize_table_snapshot(
+        tx,
+        snapshot_id,
+        schema_name,
+        table_name,
+        table_id_hint,
+        columns,
+        column_ids,
+        mode,
+        base_snapshot,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_table_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    table_id_hint: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<CommitIds> {
     // Allocate the snapshot FIRST (carrying schema_version forward): this takes
     // the counter lock up front, serializing concurrent commits. schema_version is
     // corrected to a DDL bump below once we've classified the commit.
-    let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
+    let mut schema_version: i64 =
+        sqlx::query_scalar("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
 
     let schema_id: i64 =
         match sqlx::query_scalar(
@@ -994,6 +1057,134 @@ async fn finalize_snapshot(
 }
 
 impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
+    fn commit_multi_table(
+        &self,
+        writes: &[StagedTableWrite],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<MultiTableCommit> {
+        if writes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires at least one table stage".to_string(),
+            ));
+        }
+        let ids = writes
+            .iter()
+            .map(|write| write.table_id)
+            .collect::<std::collections::HashSet<_>>();
+        if ids.len() != writes.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires one stage per table".to_string(),
+            ));
+        }
+        block_on(async {
+            sqlx::query(SQL_CREATE_INLINED_DATA_TABLES)
+                .execute(&self.pool)
+                .await?;
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _) = insert_snapshot(&mut tx).await?;
+            let mut had_data = Vec::with_capacity(writes.len());
+            for write in writes {
+                validate_staged_table(&mut tx, write).await?;
+                if let Some(expected) = expected_base_snapshot_id {
+                    detect_staged_conflict(write.table_id, expected, &mut tx).await?;
+                }
+                let files: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL)").bind(write.table_id).fetch_one(&mut *tx).await?;
+                let names: Vec<String> = sqlx::query_scalar(
+                    "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+                )
+                .bind(write.table_id)
+                .fetch_all(&mut *tx)
+                .await?;
+                let mut inline = false;
+                for name in names {
+                    let sql = format!(
+                        "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot IS NULL)",
+                        quote_ident(&name)
+                    );
+                    inline |= sqlx::query_scalar::<_, bool>(AssertSqlSafe(sql))
+                        .fetch_one(&mut *tx)
+                        .await?;
+                }
+                had_data.push((files, inline));
+            }
+            let mut tables = Vec::with_capacity(writes.len());
+            for write in writes {
+                tables.push(
+                    finalize_table_snapshot(
+                        &mut tx,
+                        snapshot_id,
+                        &write.schema_name,
+                        &write.table_name,
+                        write.table_id,
+                        &write.columns,
+                        &write.column_ids,
+                        write.mode,
+                        write.base_snapshot_id,
+                    )
+                    .await?,
+                );
+            }
+            for ((write, ids), (files, inline)) in writes.iter().zip(&tables).zip(had_data) {
+                let mut write = write.clone();
+                write.table_id = ids.table_id;
+                match &write.data {
+                    StagedTableData::Files(files) => {
+                        commit_files_at_snapshot(&mut tx, snapshot_id, &write, files).await?;
+                    },
+                    StagedTableData::Inlined(batches) => {
+                        commit_inlined_at_snapshot(&mut tx, snapshot_id, &write, batches).await?;
+                    },
+                    StagedTableData::None => {},
+                }
+                apply_positional_deletes_at_snapshot(
+                    &mut tx,
+                    write.table_id,
+                    snapshot_id,
+                    write.base_snapshot_id,
+                    &write.positional_deletes,
+                )
+                .await?;
+                apply_inlined_deletes_at_snapshot(
+                    &mut tx,
+                    write.table_id,
+                    snapshot_id,
+                    write.base_snapshot_id,
+                    &write.inlined_deletes,
+                )
+                .await?;
+                let changes = staged_table_write_changes(&write, files, inline);
+                record_table_changes(
+                    &mut tx,
+                    snapshot_id,
+                    write.table_id,
+                    &write.schema_name,
+                    &write.table_name,
+                    &changes,
+                    commit_metadata,
+                )
+                .await?;
+            }
+            tx.commit().await?;
+            Ok(MultiTableCommit {
+                snapshot_id,
+                tables,
+            })
+        })
+    }
+
+    fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        set_postgres_table_setting(&self.pool, None, table_id, key, value)
+    }
+
+    fn with_commit_lock(
+        &self,
+        identity: &str,
+        operation: Box<dyn FnOnce() -> Result<()> + '_>,
+    ) -> Result<()> {
+        with_postgres_commit_lock(&self.pool, &format!("single:{identity}"), operation)
+    }
+
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -2,6 +2,13 @@
 //!
 //! Requires multi-threaded Tokio runtime (`#[tokio::test(flavor = "multi_thread")]`).
 
+use std::{
+    fs::{File, OpenOptions},
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
+
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::maintenance::{
@@ -10,17 +17,205 @@ use crate::maintenance::{
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    ExistingCatalogColumn, MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult,
-    assign_column_ids, catalog_column_defs, catalog_column_type_equal,
-    catalog_column_type_requires_migration, catalog_columns_differ, table_write_changes,
-    top_level_column_ids, validate_delete_entries, validate_name,
+    ExistingCatalogColumn, InlinedRowRef, MetadataWriter, MultiTableCommit, SnapshotCommitMetadata,
+    StagedTableData, StagedTableWrite, WriteMode, WriteSetupResult, assign_column_ids,
+    catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
+    catalog_columns_differ, table_write_changes, top_level_column_ids, validate_delete_entries,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, BooleanArray, FixedSizeBinaryArray, Float32Array,
+    Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeBinaryArray,
+    LargeStringArray, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
 use sqlx::AssertSqlSafe;
+use sqlx::QueryBuilder;
 use sqlx::Row;
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{Sqlite, SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn inlined_sqlite_type(data_type: &DataType) -> &'static str {
+    match data_type {
+        DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32 => "BIGINT",
+        // DOUBLE has numeric affinity, so a bound f64 stays REAL; a VARCHAR
+        // column's TEXT affinity would coerce it to text, which the inline
+        // reader (which expects REAL) cannot decode.
+        DataType::Float32 | DataType::Float64 => "DOUBLE",
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => "BLOB",
+        DataType::FixedSizeBinary(size) if *size != 16 => "BLOB",
+        _ => "VARCHAR",
+    }
+}
+
+/// Scalar types the SQLite inline path preserves through catalog normalization.
+/// Nested values remain on the Parquet path until their SQL representation has
+/// a matching parser.
+fn sqlite_type_inlines(data_type: &DataType) -> bool {
+    crate::metadata_writer::scalar_type_supports_inlining(data_type)
+}
+
+fn push_inlined_sqlite_value(
+    query: &mut QueryBuilder<Sqlite>,
+    array: &dyn Array,
+    row: usize,
+) -> Result<()> {
+    if array.is_null(row) {
+        query.push_bind(Option::<String>::None);
+        return Ok(());
+    }
+
+    macro_rules! signed {
+        ($array:ty) => {{
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<$array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row) as i64,
+            );
+        }};
+    }
+    macro_rules! unsigned {
+        ($array:ty) => {{
+            let value = array
+                .as_any()
+                .downcast_ref::<$array>()
+                .expect("Arrow data type and array implementation agree")
+                .value(row);
+            query.push_bind(i64::try_from(value).map_err(|_| {
+                crate::error::DuckLakeError::Unsupported(format!(
+                    "SQLite inlined data cannot represent unsigned value {value}"
+                ))
+            })?);
+        }};
+    }
+
+    match array.data_type() {
+        DataType::Boolean => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row),
+            );
+        },
+        DataType::Int8 => signed!(Int8Array),
+        DataType::Int16 => signed!(Int16Array),
+        DataType::Int32 => signed!(Int32Array),
+        DataType::Int64 => signed!(Int64Array),
+        DataType::UInt8 => unsigned!(UInt8Array),
+        DataType::UInt16 => unsigned!(UInt16Array),
+        DataType::UInt32 => unsigned!(UInt32Array),
+        DataType::UInt64 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_string(),
+            );
+        },
+        DataType::Float32 => {
+            query.push_bind(f64::from(
+                array
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row),
+            ));
+        },
+        DataType::Float64 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row),
+            );
+        },
+        DataType::Utf8 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_owned(),
+            );
+        },
+        DataType::LargeUtf8 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_owned(),
+            );
+        },
+        DataType::Binary => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        DataType::LargeBinary => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<LargeBinaryArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        DataType::BinaryView => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<BinaryViewArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        DataType::FixedSizeBinary(size) if *size != 16 => {
+            query.push_bind(
+                array
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .expect("Arrow data type and array implementation agree")
+                    .value(row)
+                    .to_vec(),
+            );
+        },
+        _ => {
+            query.push_bind(crate::metadata_writer::inlined_text_value(array, row)?);
+        },
+    };
+    Ok(())
+}
 
 /// Render a slice of ids as a SQL `IN (...)` body. Safe to interpolate because
 /// the values are `i64` (no injection surface) — same approach the upstream
@@ -172,6 +367,12 @@ CREATE TABLE IF NOT EXISTS ducklake_table_stats (
     file_size_bytes INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
+    table_id INTEGER NOT NULL,
+    table_name VARCHAR NOT NULL,
+    schema_version INTEGER NOT NULL
+);
+
 -- Per-file, per-column statistics (DuckLake spec zone maps). Powers file-level
 -- pruning: min/max are the DuckDB-canonical VARCHAR encoding of the bounds,
 -- value_count is the non-null count, null_count the null count. Column set
@@ -300,6 +501,8 @@ CREATE TABLE IF NOT EXISTS ducklake_sort_expression (
 #[derive(Debug, Clone)]
 pub struct SqliteMetadataWriter {
     pool: SqlitePool,
+    lock_path: Option<PathBuf>,
+    commit_lock: Arc<Mutex<()>>,
 }
 
 impl SqliteMetadataWriter {
@@ -311,6 +514,11 @@ impl SqliteMetadataWriter {
         connection_string: &str,
         max_connections: u32,
     ) -> Result<Self> {
+        let options = SqliteConnectOptions::from_str(connection_string)?;
+        let filename = options.get_filename();
+        let lock_path = (!filename.as_os_str().is_empty()
+            && filename != std::path::Path::new(":memory:"))
+        .then(|| filename.with_extension("commit.lock"));
         let pool = SqlitePoolOptions::new()
             .max_connections(max_connections)
             .connect(connection_string)
@@ -320,6 +528,8 @@ impl SqliteMetadataWriter {
         migrate_snapshot_changes_nullable(&pool).await?;
         Ok(Self {
             pool,
+            lock_path,
+            commit_lock: Arc::new(Mutex::new(())),
         })
     }
 
@@ -1123,6 +1333,29 @@ async fn detect_replace_conflict(
              snapshot {base_snapshot}; aborting (retry the write against the new generation)"
         )));
     }
+    let inlined_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inlined_tables {
+        let table_name: String = row.try_get(0)?;
+        let sql = format!(
+            "SELECT 1 FROM {} WHERE begin_snapshot > ? OR end_snapshot > ? LIMIT 1",
+            quote_ident(&table_name)
+        );
+        let conflict: Option<i64> = sqlx::query_scalar(AssertSqlSafe(sql))
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut **tx)
+            .await?;
+        if conflict.is_some() {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "Replace on table {table_id} conflicts with inlined data committed since \
+                 snapshot {base_snapshot}; aborting"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -1196,12 +1429,202 @@ async fn retire_prior_generation(
     .execute(&mut **tx)
     .await?;
 
+    let inlined_tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in inlined_tables {
+        let table_name: String = row.try_get(0)?;
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? \
+             WHERE end_snapshot IS NULL AND begin_snapshot < ?",
+            quote_ident(&table_name)
+        );
+        sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
+    }
+
     sqlx::query(
         "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = ?",
     )
     .bind(table_id)
     .execute(&mut **tx)
     .await?;
+    Ok(())
+}
+
+/// Whether `snapshot_id` ended prior rows of the table — Parquet files or
+/// inlined rows — i.e. a Replace actually replaced existing data.
+async fn replace_ended_prior_rows(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    snapshot_id: i64,
+) -> Result<bool> {
+    let replaced: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_data_file
+            WHERE table_id = ? AND end_snapshot = ?
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    if replaced {
+        return Ok(true);
+    }
+    for table_name in inlined_table_names(tx, table_id).await? {
+        let sql = format!(
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot = ?)",
+            quote_ident(&table_name)
+        );
+        if sqlx::query_scalar(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn inlined_table_names(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+) -> Result<Vec<String>> {
+    let rows =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    rows.into_iter().map(|row| Ok(row.try_get(0)?)).collect()
+}
+
+async fn live_inlined_row_count(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+) -> Result<i64> {
+    let mut total = 0;
+    for table_name in inlined_table_names(tx, table_id).await? {
+        let sql = format!(
+            "SELECT COUNT(*) FROM {} WHERE end_snapshot IS NULL",
+            quote_ident(&table_name)
+        );
+        total += sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
+            .fetch_one(&mut **tx)
+            .await?;
+    }
+    Ok(total)
+}
+
+async fn apply_positional_deletes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    snapshot_id: i64,
+    base_snapshot: i64,
+    deletes: &[DeleteFileEntry],
+) -> Result<()> {
+    for entry in deletes {
+        let target_live: Option<i64> = sqlx::query_scalar(
+            "SELECT 1 FROM ducklake_data_file
+             WHERE data_file_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(entry.data_file_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if target_live.is_none() {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "DELETE on data file {} could not commit: the file is no longer live since \
+                 snapshot {base_snapshot}",
+                entry.data_file_id
+            )));
+        }
+        let current_prev: Option<i64> = sqlx::query_scalar(
+            "SELECT delete_file_id FROM ducklake_delete_file
+             WHERE data_file_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(entry.data_file_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if current_prev != entry.expected_prev_delete_file {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "DELETE on data file {} could not commit: its live delete file changed from \
+                 {:?} to {current_prev:?} since snapshot {base_snapshot}",
+                entry.data_file_id, entry.expected_prev_delete_file
+            )));
+        }
+        if let Some(previous) = entry.expected_prev_delete_file {
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = ?
+                 WHERE delete_file_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(previous)
+            .execute(&mut **tx)
+            .await?;
+        }
+        sqlx::query(
+            "INSERT INTO ducklake_delete_file
+                 (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, delete_count, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(entry.data_file_id)
+        .bind(table_id)
+        .bind(&entry.delete.path)
+        .bind(entry.delete.path_is_relative)
+        .bind(entry.delete.file_size_bytes)
+        .bind(entry.delete.footer_size)
+        .bind(entry.delete.delete_count)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn apply_inlined_deletes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    snapshot_id: i64,
+    base_snapshot: i64,
+    rows: &[InlinedRowRef],
+) -> Result<()> {
+    let registered = inlined_table_names(tx, table_id)
+        .await?
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    for row in rows {
+        if !registered.contains(&row.table_name) {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} belongs to an unregistered table '{}'",
+                row.row_id, row.table_name
+            )));
+        }
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? \
+             WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+            quote_ident(&row.table_name)
+        );
+        let affected = sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(row.row_id)
+            .bind(base_snapshot)
+            .execute(&mut **tx)
+            .await?
+            .rows_affected();
+        if affected != 1 {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                row.row_id, row.table_name
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -1506,12 +1929,44 @@ async fn finalize_snapshot(
     mode: WriteMode,
     base_snapshot: i64,
 ) -> Result<i64> {
-    // Allocate the snapshot FIRST (carrying schema_version forward): this INSERT
-    // takes the SQLite write lock up front, so concurrent writers can't collide,
-    // publish out of order, or deadlock on a read→write lock upgrade. schema_version
-    // is corrected to a DDL bump below once we've classified the commit.
+    // One write-lock-first snapshot is shared by every table finalized by a
+    // multi-table transaction. A single-table write uses the same path once.
     let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
+    let mut schema_changed = false;
+    finalize_table_snapshot(
+        tx,
+        snapshot_id,
+        &mut schema_version,
+        &mut schema_changed,
+        table_id,
+        schema_name,
+        table_name,
+        columns,
+        column_ids,
+        mode,
+        base_snapshot,
+    )
+    .await?;
+    Ok(snapshot_id)
+}
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "table finalization requires the complete atomic write state"
+)]
+async fn finalize_table_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    snapshot_id: i64,
+    schema_version: &mut i64,
+    schema_changed: &mut bool,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<()> {
     // Classify this commit as DDL vs pure data write. The table's begin snapshot
     // identifies creation even when it has no columns; using an empty live-column
     // set would misclassify a later schemaless Replace as another create.
@@ -1581,10 +2036,11 @@ async fn finalize_snapshot(
             &proposed,
             column_ids,
         );
-    if is_ddl {
+    if is_ddl && !*schema_changed {
         // A DDL commit bumps the per-catalog schema_version (the insert above only
         // carried it forward). A pure data write keeps the carried value.
-        schema_version = bump_schema_version(tx, snapshot_id).await?;
+        *schema_version = bump_schema_version(tx, snapshot_id).await?;
+        *schema_changed = true;
     }
 
     // Reconcile the column generation SURGICALLY so each column keeps a stable
@@ -1709,15 +2165,31 @@ async fn finalize_snapshot(
     // forward and writes no row. (Drop is handled in `drop_table`: it bumps but
     // writes no row, since the table has no live schema afterward.)
     if is_ddl {
-        record_schema_version(tx, snapshot_id, schema_version, table_id).await?;
+        record_schema_version(tx, snapshot_id, *schema_version, table_id).await?;
     }
     let mut ddl_changes = Vec::new();
     if table_was_created {
         if schema_begin_snapshot == table_begin_snapshot {
-            ddl_changes.push(format!(
+            // A multi-table commit finalizes each staged table in turn; two
+            // tables born with a fresh schema share its begin snapshot, and the
+            // schema's creation must reach the ledger exactly once.
+            let schema_entry = format!(
                 "created_schema:{}",
                 crate::metadata_writer::quote_snapshot_name(schema_name),
-            ));
+            );
+            let recorded: Option<Option<String>> = sqlx::query_scalar(
+                "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+            )
+            .bind(snapshot_id)
+            .fetch_optional(&mut **tx)
+            .await?;
+            let duplicate = matches!(
+                recorded,
+                Some(Some(ref changes)) if changes.split(',').any(|token| token == schema_entry)
+            );
+            if !duplicate {
+                ddl_changes.push(schema_entry);
+            }
         }
         ddl_changes.push(format!(
             "created_table:{}",
@@ -1735,7 +2207,7 @@ async fn finalize_snapshot(
         )
         .await?;
     }
-    Ok(snapshot_id)
+    Ok(())
 }
 
 async fn record_snapshot_changes(
@@ -1767,11 +2239,273 @@ async fn record_snapshot_changes(
     Ok(())
 }
 
+async fn commit_files_at_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    files: &[DataFileInfo],
+) -> Result<bool> {
+    if files.is_empty() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table file stage must contain at least one file".to_string(),
+        ));
+    }
+    let live_partition_id: Option<i64> = sqlx::query_scalar(
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(write.table_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    for file in files {
+        crate::metadata_writer::enforce_partition_fence(write.table_id, live_partition_id, file)?;
+    }
+    sqlx::query(
+        "INSERT OR IGNORE INTO ducklake_table_stats
+             (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES (?, 0, 0, 0)",
+    )
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut next_row_id: i64 =
+        sqlx::query_scalar("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+            .bind(write.table_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let mut total_records = 0;
+    let mut total_bytes = 0;
+    for file in files {
+        sqlx::query(
+            "INSERT INTO ducklake_data_file
+                 (table_id, path, path_is_relative, file_size_bytes, footer_size,
+                  record_count, row_id_start, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(write.table_id)
+        .bind(&file.path)
+        .bind(file.path_is_relative)
+        .bind(file.file_size_bytes)
+        .bind(file.footer_size)
+        .bind(file.record_count)
+        .bind(next_row_id)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+        let data_file_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
+            .fetch_one(&mut **tx)
+            .await?;
+        insert_file_column_stats(tx, write.table_id, data_file_id, &file.column_stats).await?;
+        insert_partition_metadata(tx, write.table_id, data_file_id, file).await?;
+        next_row_id += file.record_count;
+        total_records += file.record_count;
+        total_bytes += file.file_size_bytes;
+    }
+    recompute_table_column_stats(tx, write.table_id, &write.columns, &write.column_ids).await?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + ?, record_count = record_count + ?,
+             file_size_bytes = file_size_bytes + ?
+         WHERE table_id = ?",
+    )
+    .bind(total_records)
+    .bind(total_records)
+    .bind(total_bytes)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(sqlx::query_scalar(
+        "SELECT EXISTS(
+             SELECT 1 FROM ducklake_data_file
+             WHERE table_id = ? AND end_snapshot = ?
+         )",
+    )
+    .bind(write.table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?)
+}
+
+async fn commit_inlined_at_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    snapshot_id: i64,
+    write: &StagedTableWrite,
+    batches: &[RecordBatch],
+) -> Result<()> {
+    let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    if record_count == 0 {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "multi-table inline stage must contain at least one row".to_string(),
+        ));
+    }
+    let schema_version: i64 =
+        sqlx::query_scalar("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?")
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let physical_name = format!(
+        "ducklake_inlined_data_{}_{}",
+        write.table_id, schema_version
+    );
+    let mut ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {} (\
+         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+        quote_ident(&physical_name)
+    );
+    for (field, column) in batches[0].schema().fields().iter().zip(&write.columns) {
+        ddl.push_str(", ");
+        ddl.push_str(&quote_ident(column.name()));
+        ddl.push(' ');
+        ddl.push_str(inlined_sqlite_type(field.data_type()));
+    }
+    ddl.push(')');
+    sqlx::query(AssertSqlSafe(ddl)).execute(&mut **tx).await?;
+    sqlx::query(
+        "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version)
+         SELECT ?, ?, ?
+         WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_inlined_data_tables
+             WHERE table_id = ? AND schema_version = ?
+         )",
+    )
+    .bind(write.table_id)
+    .bind(&physical_name)
+    .bind(schema_version)
+    .bind(write.table_id)
+    .bind(schema_version)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "INSERT OR IGNORE INTO ducklake_table_stats
+             (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES (?, 0, 0, 0)",
+    )
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut row_id: i64 =
+        sqlx::query_scalar("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+            .bind(write.table_id)
+            .fetch_one(&mut **tx)
+            .await?;
+    let column_list = write
+        .columns
+        .iter()
+        .map(|column| quote_ident(column.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    for batch in batches {
+        for batch_row in 0..batch.num_rows() {
+            let mut query = QueryBuilder::<Sqlite>::new(format!(
+                "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) VALUES (",
+                quote_ident(&physical_name),
+                column_list
+            ));
+            query.push_bind(row_id);
+            query.push(", ").push_bind(snapshot_id);
+            query.push(", NULL");
+            for (array, column) in batch.columns().iter().zip(&write.columns) {
+                query.push(", ");
+                if write
+                    .snapshot_id_columns
+                    .iter()
+                    .any(|name| name == column.name())
+                    && array.is_null(batch_row)
+                {
+                    query.push_bind(snapshot_id);
+                } else {
+                    push_inlined_sqlite_value(&mut query, array.as_ref(), batch_row)?;
+                }
+            }
+            query.push(')');
+            query.build().execute(&mut **tx).await?;
+            row_id += 1;
+        }
+    }
+    let record_count = i64::try_from(record_count).map_err(|_| {
+        crate::DuckLakeError::InvalidConfig("multi-table inline row count exceeds i64".to_string())
+    })?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id = next_row_id + ?, record_count = record_count + ?
+         WHERE table_id = ?",
+    )
+    .bind(record_count)
+    .bind(record_count)
+    .bind(write.table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 impl MetadataWriter for SqliteMetadataWriter {
     /// SQLite implements the atomic append-with-deletes commit, so it supports
     /// row-level `UPDATE`.
     fn supports_update(&self) -> bool {
         true
+    }
+
+    fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        block_on(async {
+            let mut transaction = self.pool.begin().await?;
+            let table_exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM ducklake_table WHERE table_id = ?)",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *transaction)
+            .await?;
+            if !table_exists {
+                return Err(crate::DuckLakeError::TableNotFound(table_id.to_string()));
+            }
+
+            sqlx::query(
+                "DELETE FROM ducklake_metadata
+                 WHERE key = ? AND scope = 'table' AND scope_id = ?",
+            )
+            .bind(key)
+            .bind(table_id)
+            .execute(&mut *transaction)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope, scope_id)
+                 VALUES (?, ?, 'table', ?)",
+            )
+            .bind(key)
+            .bind(value)
+            .bind(table_id)
+            .execute(&mut *transaction)
+            .await?;
+            transaction.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn with_commit_lock(
+        &self,
+        _identity: &str,
+        operation: Box<dyn FnOnce() -> Result<()> + '_>,
+    ) -> Result<()> {
+        if let Some(lock_path) = &self.lock_path {
+            let lock_file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .truncate(false)
+                .write(true)
+                .open(lock_path)?;
+            File::lock(&lock_file)?;
+            let result = operation();
+            let unlock = File::unlock(&lock_file);
+            return match (result, unlock) {
+                (Ok(()), Ok(())) => Ok(()),
+                (Ok(()), Err(e)) => Err(e.into()),
+                (Err(e), _) => Err(e),
+            };
+        }
+
+        let _guard = self.commit_lock.lock().map_err(|_| {
+            crate::DuckLakeError::Internal("SQLite commit lock is poisoned".to_string())
+        })?;
+        operation()
     }
 
     fn create_snapshot(&self) -> Result<i64> {
@@ -2581,16 +3315,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            let replaced_existing_data = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = ? AND end_snapshot = ?
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
 
@@ -2754,16 +3480,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
-            let replaced_existing_data = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = ? AND end_snapshot = ?
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             let schema_id: i64 =
@@ -2777,6 +3495,314 @@ impl MetadataWriter for SqliteMetadataWriter {
                 snapshot_id,
                 schema_id,
                 table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn supports_data_inlining(&self, schema: &arrow::datatypes::Schema) -> bool {
+        schema
+            .fields()
+            .iter()
+            .all(|field| sqlite_type_inlines(field.data_type()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_inlined_data(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        batches: &[RecordBatch],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        block_on(async {
+            let record_count: usize = batches.iter().map(RecordBatch::num_rows).sum();
+            if record_count == 0 {
+                return Err(crate::DuckLakeError::InvalidConfig(
+                    "register_inlined_data: batches must contain at least one row".to_string(),
+                ));
+            }
+            if batches
+                .iter()
+                .any(|batch| batch.num_columns() != columns.len())
+            {
+                return Err(crate::DuckLakeError::InvalidConfig(
+                    "register_inlined_data: batch schema does not match table columns".to_string(),
+                ));
+            }
+
+            let mut tx = self.pool.begin().await?;
+            let snapshot_id = finalize_snapshot(
+                &mut tx,
+                table_id,
+                schema_name,
+                table_name,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+            }
+            let schema_version: i64 = sqlx::query_scalar(
+                "SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = ?",
+            )
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let physical_name = format!("ducklake_inlined_data_{table_id}_{schema_version}");
+
+            let mut ddl = format!(
+                "CREATE TABLE IF NOT EXISTS {} (\
+                 row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+                quote_ident(&physical_name)
+            );
+            for (field, column) in batches[0].schema().fields().iter().zip(columns) {
+                ddl.push_str(", ");
+                ddl.push_str(&quote_ident(column.name()));
+                ddl.push(' ');
+                ddl.push_str(inlined_sqlite_type(field.data_type()));
+            }
+            ddl.push(')');
+            sqlx::query(AssertSqlSafe(ddl)).execute(&mut *tx).await?;
+            sqlx::query(
+                "INSERT INTO ducklake_inlined_data_tables
+                     (table_id, table_name, schema_version)
+                 SELECT ?, ?, ?
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM ducklake_inlined_data_tables
+                     WHERE table_id = ? AND schema_version = ?)",
+            )
+            .bind(table_id)
+            .bind(&physical_name)
+            .bind(schema_version)
+            .bind(table_id)
+            .bind(schema_version)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "INSERT OR IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let mut row_id: i64 = sqlx::query_scalar(
+                "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            let column_list = columns
+                .iter()
+                .map(|column| quote_ident(column.name()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            for batch in batches {
+                for batch_row in 0..batch.num_rows() {
+                    let mut query = QueryBuilder::<Sqlite>::new(format!(
+                        "INSERT INTO {} (row_id, begin_snapshot, end_snapshot, {}) VALUES (",
+                        quote_ident(&physical_name),
+                        column_list
+                    ));
+                    query.push_bind(row_id);
+                    query.push(", ").push_bind(snapshot_id);
+                    query.push(", NULL");
+                    for array in batch.columns() {
+                        query.push(", ");
+                        push_inlined_sqlite_value(&mut query, array.as_ref(), batch_row)?;
+                    }
+                    query.push(')');
+                    query.build().execute(&mut *tx).await?;
+                    row_id += 1;
+                }
+            }
+
+            let record_count = i64::try_from(record_count).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "register_inlined_data: record count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id = next_row_id + ?, record_count = record_count + ?
+                 WHERE table_id = ?",
+            )
+            .bind(record_count)
+            .bind(record_count)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            // Append to the ledger row finalize_snapshot seeded (which may already
+            // carry created_schema:/created_table: entries) instead of replacing
+            // it, and record a Replace over prior data — Parquet or inlined — as
+            // delete + insert, the same semantics the Parquet path records.
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
+
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_multi_table(
+        &self,
+        writes: &[StagedTableWrite],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<MultiTableCommit> {
+        if writes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires at least one table stage".to_string(),
+            ));
+        }
+        let table_ids = writes
+            .iter()
+            .map(|write| write.table_id)
+            .collect::<std::collections::HashSet<_>>();
+        if table_ids.len() != writes.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_multi_table requires one stage per table".to_string(),
+            ));
+        }
+
+        block_on(async {
+            let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+            if let Some(expected) = expected_base_snapshot_id {
+                for write in writes {
+                    detect_replace_conflict(&mut tx, write.table_id, expected).await?;
+                }
+            }
+            let mut had_live_data = Vec::with_capacity(writes.len());
+            for write in writes {
+                let files: bool = sqlx::query_scalar(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM ducklake_data_file
+                         WHERE table_id = ? AND end_snapshot IS NULL
+                     )",
+                )
+                .bind(write.table_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                had_live_data
+                    .push(files || live_inlined_row_count(&mut tx, write.table_id).await? > 0);
+            }
+            let (snapshot_id, mut schema_version) = insert_snapshot(&mut tx).await?;
+            let mut schema_changed = false;
+            for write in writes {
+                finalize_table_snapshot(
+                    &mut tx,
+                    snapshot_id,
+                    &mut schema_version,
+                    &mut schema_changed,
+                    write.table_id,
+                    &write.schema_name,
+                    &write.table_name,
+                    &write.columns,
+                    &write.column_ids,
+                    write.mode,
+                    write.base_snapshot_id,
+                )
+                .await?;
+            }
+
+            let mut tables = Vec::with_capacity(writes.len());
+            for (write, replaced_existing_data) in writes.iter().zip(had_live_data) {
+                match &write.data {
+                    StagedTableData::Files(files) => {
+                        commit_files_at_snapshot(&mut tx, snapshot_id, write, files).await?;
+                    },
+                    StagedTableData::Inlined(batches) => {
+                        commit_inlined_at_snapshot(&mut tx, snapshot_id, write, batches).await?;
+                    },
+                    StagedTableData::None => {},
+                }
+                apply_positional_deletes(
+                    &mut tx,
+                    write.table_id,
+                    snapshot_id,
+                    write.base_snapshot_id,
+                    &write.positional_deletes,
+                )
+                .await?;
+                apply_inlined_deletes(
+                    &mut tx,
+                    write.table_id,
+                    snapshot_id,
+                    write.base_snapshot_id,
+                    &write.inlined_deletes,
+                )
+                .await?;
+                if !write.inlined_deletes.is_empty() {
+                    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
+                        crate::DuckLakeError::InvalidConfig(
+                            "multi-table inline delete count exceeds i64".to_string(),
+                        )
+                    })?;
+                    sqlx::query(
+                        "UPDATE ducklake_table_stats
+                         SET record_count = MAX(record_count - ?, 0)
+                         WHERE table_id = ?",
+                    )
+                    .bind(deleted)
+                    .bind(write.table_id)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+                let has_deletes =
+                    !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
+                let changes_made = if matches!(&write.data, StagedTableData::None) {
+                    format!("deleted_from_table:{}", write.table_id)
+                } else {
+                    table_write_changes(
+                        write.table_id,
+                        write.mode,
+                        has_deletes,
+                        replaced_existing_data,
+                    )
+                };
+                record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
+                    .await?;
+                let schema_id: i64 =
+                    sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                        .bind(write.table_id)
+                        .fetch_one(&mut *tx)
+                        .await?;
+                tables.push(CommitIds {
+                    snapshot_id,
+                    schema_id,
+                    table_id: write.table_id,
+                });
+            }
+            tx.commit().await?;
+            Ok(MultiTableCommit {
+                snapshot_id,
+                tables,
             })
         })
     }
@@ -3123,16 +4149,8 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = ? AND end_snapshot = ?
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -3389,16 +4407,8 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = ? AND end_snapshot = ?
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -3540,6 +4550,175 @@ impl MetadataWriter for SqliteMetadataWriter {
                     .fetch_one(&mut *tx)
                     .await?;
 
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_inlined_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        rows: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        if rows.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes requires at least one row".to_string(),
+            ));
+        }
+        if rows.iter().collect::<std::collections::HashSet<_>>().len() != rows.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_inlined_deletes contains duplicate rows".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let registered = inlined_table_names(&mut tx, table_id)
+                .await?
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>();
+            for row in rows {
+                if !registered.contains(&row.table_name) {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} belongs to an unregistered table '{}'",
+                        row.row_id, row.table_name
+                    )));
+                }
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = ? \
+                     WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
+                    quote_ident(&row.table_name)
+                );
+                let affected = sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .bind(row.row_id)
+                    .bind(base_snapshot)
+                    .execute(&mut *tx)
+                    .await?
+                    .rows_affected();
+                if affected != 1 {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
+                        row.row_id, row.table_name
+                    )));
+                }
+            }
+            let deleted = i64::try_from(rows.len()).map_err(|_| {
+                crate::DuckLakeError::InvalidConfig(
+                    "commit_inlined_deletes row count exceeds i64".to_string(),
+                )
+            })?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = MAX(record_count - ?, 0)
+                 WHERE table_id = ?",
+            )
+            .bind(deleted)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        base_snapshot: i64,
+        positional: &[DeleteFileEntry],
+        inlined: &[InlinedRowRef],
+    ) -> Result<CommitIds> {
+        if inlined.is_empty() {
+            return self.commit_positional_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                positional,
+            );
+        }
+        if positional.is_empty() {
+            return self.commit_inlined_deletes(
+                table_id,
+                schema_name,
+                table_name,
+                base_snapshot,
+                inlined,
+            );
+        }
+        validate_delete_entries(WriteMode::Append, positional)?;
+        if inlined
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined.len()
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_deletes contains duplicate inlined rows".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            apply_positional_deletes(&mut tx, table_id, snapshot_id, base_snapshot, positional)
+                .await?;
+            apply_inlined_deletes(&mut tx, table_id, snapshot_id, base_snapshot, inlined).await?;
+            if !inlined.is_empty() {
+                let deleted = i64::try_from(inlined.len()).map_err(|_| {
+                    crate::DuckLakeError::InvalidConfig(
+                        "commit_deletes row count exceeds i64".to_string(),
+                    )
+                })?;
+                sqlx::query(
+                    "UPDATE ducklake_table_stats
+                     SET record_count = MAX(record_count - ?, 0)
+                     WHERE table_id = ?",
+                )
+                .bind(deleted)
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
             tx.commit().await?;
             Ok(CommitIds {
                 snapshot_id,
@@ -3951,7 +5130,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(table_id)
             .fetch_optional(&mut *tx)
             .await?;
-            if has_live_data.is_none() {
+            let live_inlined = live_inlined_row_count(&mut tx, table_id).await?;
+            if has_live_data.is_none() && live_inlined == 0 {
                 return Ok(0);
             }
 
@@ -4003,6 +5183,16 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
+            for table_name in inlined_table_names(&mut tx, table_id).await? {
+                let sql = format!(
+                    "UPDATE {} SET end_snapshot = ? WHERE end_snapshot IS NULL",
+                    quote_ident(&table_name)
+                );
+                sqlx::query(AssertSqlSafe(sql))
+                    .bind(snapshot_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
             sqlx::query(
                 "UPDATE ducklake_delete_file SET end_snapshot = ?
                  WHERE table_id = ? AND end_snapshot IS NULL",
@@ -4064,16 +5254,8 @@ impl MetadataWriter for SqliteMetadataWriter {
                 base_snapshot,
             )
             .await?;
-            let replaced_existing_data = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM ducklake_data_file
-                    WHERE table_id = ? AND end_snapshot = ?
-                 )",
-            )
-            .bind(table_id)
-            .bind(snapshot_id)
-            .fetch_one(&mut *tx)
-            .await?;
+            let replaced_existing_data =
+                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(
                 &mut tx,
@@ -4435,6 +5617,22 @@ impl MetadataWriter for SqliteMetadataWriter {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn sqlite_inlined_types_follow_ducklake_encodings() {
+        assert_eq!(inlined_sqlite_type(&DataType::Int32), "BIGINT");
+        assert_eq!(inlined_sqlite_type(&DataType::UInt64), "VARCHAR");
+        assert_eq!(inlined_sqlite_type(&DataType::Float64), "DOUBLE");
+        assert_eq!(inlined_sqlite_type(&DataType::Float32), "DOUBLE");
+        assert_eq!(inlined_sqlite_type(&DataType::Binary), "BLOB");
+        assert_eq!(inlined_sqlite_type(&DataType::BinaryView), "BLOB");
+        assert_eq!(
+            inlined_sqlite_type(&DataType::FixedSizeBinary(16)),
+            "VARCHAR"
+        );
+        assert_eq!(inlined_sqlite_type(&DataType::FixedSizeBinary(32)), "BLOB");
+        assert_eq!(inlined_sqlite_type(&DataType::Date32), "VARCHAR");
+    }
 
     async fn create_test_writer() -> (SqliteMetadataWriter, TempDir) {
         let temp_dir = TempDir::new().unwrap();

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -20,8 +20,9 @@ use crate::metadata_writer::{
     ExistingCatalogColumn, InlinedRowRef, MetadataWriter, MultiTableCommit, SnapshotCommitMetadata,
     StagedTableData, StagedTableWrite, WriteMode, WriteSetupResult, assign_column_ids,
     catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
-    catalog_columns_differ, staged_table_write_changes, table_storage_changes, table_write_changes,
-    top_level_column_ids, validate_delete_entries, validate_name,
+    catalog_columns_differ, inlined_delete_conflicts, inlined_delete_groups, snapshot_has_change,
+    staged_table_write_changes, table_storage_changes, table_write_changes, top_level_column_ids,
+    validate_delete_entries, validate_name, validate_table_setting,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -1599,35 +1600,63 @@ async fn apply_inlined_deletes(
     base_snapshot: i64,
     rows: &[InlinedRowRef],
 ) -> Result<()> {
-    let registered = inlined_table_names(tx, table_id)
-        .await?
-        .into_iter()
-        .collect::<std::collections::HashSet<_>>();
-    for row in rows {
-        if !registered.contains(&row.table_name) {
-            return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} belongs to an unregistered table '{}'",
-                row.row_id, row.table_name
-            )));
-        }
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let registered: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let changes: Vec<Option<String>> = sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id > ? AND snapshot_id < ?").bind(base_snapshot).bind(snapshot_id).fetch_all(&mut **tx).await?;
+    if changes
+        .iter()
+        .flatten()
+        .any(|changes| inlined_delete_conflicts(changes, table_id))
+    {
+        return Err(crate::DuckLakeError::Conflict(
+            "table changed since the inlined delete snapshot".to_string(),
+        ));
+    }
+    for name in &registered {
         let sql = format!(
-            "UPDATE {} SET end_snapshot = ? \
-             WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
-            quote_ident(&row.table_name)
+            "SELECT EXISTS(SELECT 1 FROM {} WHERE (begin_snapshot > ? AND begin_snapshot < ?) OR (end_snapshot > ? AND end_snapshot < ?))",
+            quote_ident(name)
         );
-        let affected = sqlx::query(AssertSqlSafe(sql))
-            .bind(snapshot_id)
-            .bind(row.row_id)
+        let changed: bool = sqlx::query_scalar(AssertSqlSafe(sql))
             .bind(base_snapshot)
-            .execute(&mut **tx)
-            .await?
-            .rows_affected();
-        if affected != 1 {
+            .bind(snapshot_id)
+            .bind(base_snapshot)
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?;
+        if changed {
+            return Err(crate::DuckLakeError::Conflict(
+                "inlined rows changed since the delete snapshot".to_string(),
+            ));
+        }
+    }
+    for (name, row_ids) in inlined_delete_groups(rows) {
+        if !registered.iter().any(|table| table == name) {
             return Err(crate::DuckLakeError::Conflict(format!(
-                "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                row.row_id, row.table_name
+                "inlined deletes reference unregistered table '{name}'"
             )));
         }
+        let ids = row_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE {} SET end_snapshot = ? WHERE row_id IN ({ids}) AND end_snapshot IS NULL AND begin_snapshot <> ?",
+            quote_ident(name)
+        );
+        sqlx::query(AssertSqlSafe(sql))
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
     }
     Ok(())
 }
@@ -2189,7 +2218,7 @@ async fn finalize_table_snapshot(
             .await?;
             let duplicate = matches!(
                 recorded,
-                Some(Some(ref changes)) if changes.split(',').any(|token| token == schema_entry)
+                Some(Some(ref changes)) if snapshot_has_change(changes, &schema_entry)
             );
             if !duplicate {
                 ddl_changes.push(schema_entry);
@@ -2240,6 +2269,46 @@ async fn record_snapshot_changes(
     .bind(snapshot_id)
     .execute(&mut **tx)
     .await?;
+    Ok(())
+}
+
+async fn validate_staged_table(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    write: &StagedTableWrite,
+) -> Result<()> {
+    let ended: Option<Option<i64>> =
+        sqlx::query_scalar("SELECT end_snapshot FROM ducklake_table WHERE table_id = ?")
+            .bind(write.table_id)
+            .fetch_optional(&mut **tx)
+            .await?;
+    if ended.is_none() || matches!(ended, Some(Some(_))) {
+        return Err(crate::DuckLakeError::Conflict(
+            "staged table was dropped".to_string(),
+        ));
+    }
+    let current = sqlx::query("SELECT column_id, column_type, nulls_allowed, parent_column FROM ducklake_column WHERE table_id = ? AND end_snapshot IS NULL ORDER BY column_order").bind(write.table_id).fetch_all(&mut **tx).await?;
+    let proposed = catalog_column_defs(&write.columns)?;
+    if current.is_empty() && proposed.len() == write.column_ids.len() {
+        return Ok(());
+    }
+    let mut matches = current.len() == proposed.len() && proposed.len() == write.column_ids.len();
+    if matches {
+        for (index, (row, column)) in current.iter().zip(&proposed).enumerate() {
+            let column_id: i64 = row.try_get("column_id")?;
+            let column_type: String = row.try_get("column_type")?;
+            let nullable: Option<bool> = row.try_get("nulls_allowed")?;
+            let parent: Option<i64> = row.try_get("parent_column")?;
+            matches &= column_id == write.column_ids[index]
+                && catalog_column_type_equal(&column_type, column)
+                && nullable.unwrap_or(true) == column.is_nullable
+                && parent == column.parent_index.map(|i| write.column_ids[i]);
+        }
+    }
+    if !matches {
+        return Err(crate::DuckLakeError::Conflict(
+            "table schema changed after staging".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -2450,10 +2519,11 @@ impl MetadataWriter for SqliteMetadataWriter {
     }
 
     fn set_table_setting(&self, table_id: i64, key: &str, value: &str) -> Result<()> {
+        let key = validate_table_setting(key)?;
         block_on(async {
             let mut transaction = self.pool.begin().await?;
             let table_exists: bool = sqlx::query_scalar(
-                "SELECT EXISTS(SELECT 1 FROM ducklake_table WHERE table_id = ?)",
+                "SELECT EXISTS(SELECT 1 FROM ducklake_table WHERE table_id = ? AND end_snapshot IS NULL)",
             )
             .bind(table_id)
             .fetch_one(&mut *transaction)
@@ -2466,7 +2536,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                 "DELETE FROM ducklake_metadata
                  WHERE key = ? AND scope = 'table' AND scope_id = ?",
             )
-            .bind(key)
+            .bind(&key)
             .bind(table_id)
             .execute(&mut *transaction)
             .await?;
@@ -2474,7 +2544,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                 "INSERT INTO ducklake_metadata (key, value, scope, scope_id)
                  VALUES (?, ?, 'table', ?)",
             )
-            .bind(key)
+            .bind(&key)
             .bind(value)
             .bind(table_id)
             .execute(&mut *transaction)
@@ -3700,6 +3770,9 @@ impl MetadataWriter for SqliteMetadataWriter {
 
         block_on(async {
             let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+            for write in writes {
+                validate_staged_table(&mut tx, write).await?;
+            }
             if let Some(expected) = expected_base_snapshot_id {
                 for write in writes {
                     detect_replace_conflict(&mut tx, write.table_id, expected).await?;
@@ -3767,22 +3840,6 @@ impl MetadataWriter for SqliteMetadataWriter {
                     &write.inlined_deletes,
                 )
                 .await?;
-                if !write.inlined_deletes.is_empty() {
-                    let deleted = i64::try_from(write.inlined_deletes.len()).map_err(|_| {
-                        crate::DuckLakeError::InvalidConfig(
-                            "multi-table inline delete count exceeds i64".to_string(),
-                        )
-                    })?;
-                    sqlx::query(
-                        "UPDATE ducklake_table_stats
-                         SET record_count = MAX(record_count - ?, 0)
-                         WHERE table_id = ?",
-                    )
-                    .bind(deleted)
-                    .bind(write.table_id)
-                    .execute(&mut *tx)
-                    .await?;
-                }
                 let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
                 record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
                     .await?;
@@ -4568,59 +4625,11 @@ impl MetadataWriter for SqliteMetadataWriter {
                 "commit_inlined_deletes requires at least one row".to_string(),
             ));
         }
-        if rows.iter().collect::<std::collections::HashSet<_>>().len() != rows.len() {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "commit_inlined_deletes contains duplicate rows".to_string(),
-            ));
-        }
         block_on(async {
             let mut tx = self.pool.begin().await?;
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
-            let registered = inlined_table_names(&mut tx, table_id)
-                .await?
-                .into_iter()
-                .collect::<std::collections::HashSet<_>>();
-            for row in rows {
-                if !registered.contains(&row.table_name) {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "inlined row {} belongs to an unregistered table '{}'",
-                        row.row_id, row.table_name
-                    )));
-                }
-                let sql = format!(
-                    "UPDATE {} SET end_snapshot = ? \
-                     WHERE row_id = ? AND begin_snapshot <= ? AND end_snapshot IS NULL",
-                    quote_ident(&row.table_name)
-                );
-                let affected = sqlx::query(AssertSqlSafe(sql))
-                    .bind(snapshot_id)
-                    .bind(row.row_id)
-                    .bind(base_snapshot)
-                    .execute(&mut *tx)
-                    .await?
-                    .rows_affected();
-                if affected != 1 {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "inlined row {} in '{}' is no longer live at snapshot {base_snapshot}",
-                        row.row_id, row.table_name
-                    )));
-                }
-            }
-            let deleted = i64::try_from(rows.len()).map_err(|_| {
-                crate::DuckLakeError::InvalidConfig(
-                    "commit_inlined_deletes row count exceeds i64".to_string(),
-                )
-            })?;
-            sqlx::query(
-                "UPDATE ducklake_table_stats
-                 SET record_count = MAX(record_count - ?, 0)
-                 WHERE table_id = ?",
-            )
-            .bind(deleted)
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
-            let changes_made = format!("deleted_from_table:{table_id}");
+            apply_inlined_deletes(&mut tx, table_id, snapshot_id, base_snapshot, rows).await?;
+            let changes_made = format!("inlined_delete:{table_id}");
             record_snapshot_changes(
                 &mut tx,
                 snapshot_id,
@@ -4670,39 +4679,14 @@ impl MetadataWriter for SqliteMetadataWriter {
             );
         }
         validate_delete_entries(WriteMode::Append, positional)?;
-        if inlined
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-            != inlined.len()
-        {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "commit_deletes contains duplicate inlined rows".to_string(),
-            ));
-        }
         block_on(async {
             let mut tx = self.pool.begin().await?;
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
             apply_positional_deletes(&mut tx, table_id, snapshot_id, base_snapshot, positional)
                 .await?;
             apply_inlined_deletes(&mut tx, table_id, snapshot_id, base_snapshot, inlined).await?;
-            if !inlined.is_empty() {
-                let deleted = i64::try_from(inlined.len()).map_err(|_| {
-                    crate::DuckLakeError::InvalidConfig(
-                        "commit_deletes row count exceeds i64".to_string(),
-                    )
-                })?;
-                sqlx::query(
-                    "UPDATE ducklake_table_stats
-                     SET record_count = MAX(record_count - ?, 0)
-                     WHERE table_id = ?",
-                )
-                .bind(deleted)
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-            }
-            let changes_made = format!("deleted_from_table:{table_id}");
+            let changes_made =
+                table_storage_changes(table_id, None, !positional.is_empty(), !inlined.is_empty());
             record_snapshot_changes(
                 &mut tx,
                 snapshot_id,
@@ -5614,8 +5598,10 @@ impl MetadataWriter for SqliteMetadataWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DuckLakeCatalog;
     use crate::metadata_provider::MetadataProvider;
     use arrow::array::Int64Array;
+    use datafusion::prelude::SessionContext;
     use tempfile::TempDir;
 
     #[test]
@@ -5648,6 +5634,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn staged_inline_changes_follow_storage_and_share_snapshot() {
         let (writer, temp) = create_test_writer().await;
+        writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
         let columns = vec![ColumnDef::new("value", "BIGINT", false).unwrap()];
         let batch = RecordBatch::try_from_iter(vec![(
             "value",
@@ -5784,6 +5771,90 @@ mod tests {
                 .unwrap()
                 .changes_made,
             Some(format!("inlined_delete:{}", writes[1].table_id))
+        );
+        let gross: i64 =
+            sqlx::query_scalar("SELECT record_count FROM ducklake_table_stats WHERE table_id = ?")
+                .bind(writes[1].table_id)
+                .fetch_one(&writer.pool)
+                .await
+                .unwrap();
+        assert_eq!(gross, 2);
+        let mut update = writes[1].clone();
+        update.base_snapshot_id = deleted.snapshot_id;
+        update.data = StagedTableData::Inlined(vec![
+            RecordBatch::try_from_iter(vec![(
+                "value",
+                Arc::new(Int64Array::from(vec![59])) as Arc<dyn Array>,
+            )])
+            .unwrap(),
+        ]);
+        update.inlined_deletes = [3, 3, 4, 999]
+            .into_iter()
+            .map(|row_id| InlinedRowRef {
+                table_name: remaining[0].table_name.clone(),
+                row_id,
+            })
+            .collect();
+        let updated = writer
+            .commit_multi_table(
+                &[update],
+                &SnapshotCommitMetadata::default(),
+                Some(deleted.snapshot_id),
+            )
+            .unwrap();
+        let latest = provider
+            .get_inlined_data_with_row_ids(writes[1].table_id, updated.snapshot_id, &table_columns)
+            .unwrap();
+        let gross: i64 =
+            sqlx::query_scalar("SELECT record_count FROM ducklake_table_stats WHERE table_id = ?")
+                .bind(writes[1].table_id)
+                .fetch_one(&writer.pool)
+                .await
+                .unwrap();
+        assert_eq!(latest[0].row_ids, vec![4]);
+        assert_eq!(
+            latest[0]
+                .batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values(),
+            &[59]
+        );
+        assert_eq!(gross, 3);
+        let mut stale = writes[1].clone();
+        stale.base_snapshot_id = deleted.snapshot_id;
+        stale.data = StagedTableData::None;
+        stale.inlined_deletes = vec![InlinedRowRef {
+            table_name: remaining[0].table_name.clone(),
+            row_id: 3,
+        }];
+        let error = writer
+            .commit_multi_table(&[stale], &SnapshotCommitMetadata::default(), None)
+            .unwrap_err();
+        assert!(matches!(error, crate::DuckLakeError::Conflict(_)));
+        assert_eq!(
+            provider.get_current_snapshot().unwrap(),
+            updated.snapshot_id
+        );
+        let ctx = SessionContext::new();
+        ctx.register_catalog("dl", Arc::new(DuckLakeCatalog::new(provider).unwrap()));
+        let actual = ctx
+            .sql("SELECT COUNT(*) FROM dl.main.inline")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            actual[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values(),
+            &[1]
         );
     }
 

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -20,8 +20,8 @@ use crate::metadata_writer::{
     ExistingCatalogColumn, InlinedRowRef, MetadataWriter, MultiTableCommit, SnapshotCommitMetadata,
     StagedTableData, StagedTableWrite, WriteMode, WriteSetupResult, assign_column_ids,
     catalog_column_defs, catalog_column_type_equal, catalog_column_type_requires_migration,
-    catalog_columns_differ, table_write_changes, top_level_column_ids, validate_delete_entries,
-    validate_name,
+    catalog_columns_differ, staged_table_write_changes, table_storage_changes, table_write_changes,
+    top_level_column_ids, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use arrow::array::{
@@ -367,12 +367,6 @@ CREATE TABLE IF NOT EXISTS ducklake_table_stats (
     file_size_bytes INTEGER NOT NULL DEFAULT 0
 );
 
-CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
-    table_id INTEGER NOT NULL,
-    table_name VARCHAR NOT NULL,
-    schema_version INTEGER NOT NULL
-);
-
 -- Per-file, per-column statistics (DuckLake spec zone maps). Powers file-level
 -- pruning: min/max are the DuckDB-canonical VARCHAR encoding of the bounds,
 -- value_count is the non-null count, null_count the null count. Column set
@@ -497,6 +491,13 @@ CREATE TABLE IF NOT EXISTS ducklake_sort_expression (
 );
 "#;
 
+const SQL_CREATE_INLINED_DATA_TABLES: &str =
+    "CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (
+    table_id INTEGER,
+    table_name VARCHAR,
+    schema_version INTEGER
+);";
+
 /// SQLite-based metadata writer for DuckLake catalogs.
 #[derive(Debug, Clone)]
 pub struct SqliteMetadataWriter {
@@ -518,7 +519,11 @@ impl SqliteMetadataWriter {
         let filename = options.get_filename();
         let lock_path = (!filename.as_os_str().is_empty()
             && filename != std::path::Path::new(":memory:"))
-        .then(|| filename.with_extension("commit.lock"));
+        .then(|| {
+            let mut path = filename.as_os_str().to_os_string();
+            path.push(".commit.lock");
+            PathBuf::from(path)
+        });
         let pool = SqlitePoolOptions::new()
             .max_connections(max_connections)
             .connect(connection_string)
@@ -526,6 +531,9 @@ impl SqliteMetadataWriter {
 
         // Existing catalogs must migrate even when callers skip `initialize_schema`
         migrate_snapshot_changes_nullable(&pool).await?;
+        sqlx::query(SQL_CREATE_INLINED_DATA_TABLES)
+            .execute(&pool)
+            .await?;
         Ok(Self {
             pool,
             lock_path,
@@ -1457,13 +1465,12 @@ async fn retire_prior_generation(
     Ok(())
 }
 
-/// Whether `snapshot_id` ended prior rows of the table — Parquet files or
-/// inlined rows — i.e. a Replace actually replaced existing data.
-async fn replace_ended_prior_rows(
+// The flags report retired Parquet files and inlined rows, respectively
+async fn replaced_storage(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     table_id: i64,
     snapshot_id: i64,
-) -> Result<bool> {
+) -> Result<(bool, bool)> {
     let replaced: bool = sqlx::query_scalar(
         "SELECT EXISTS(
             SELECT 1 FROM ducklake_data_file
@@ -1474,9 +1481,6 @@ async fn replace_ended_prior_rows(
     .bind(snapshot_id)
     .fetch_one(&mut **tx)
     .await?;
-    if replaced {
-        return Ok(true);
-    }
     for table_name in inlined_table_names(tx, table_id).await? {
         let sql = format!(
             "SELECT EXISTS(SELECT 1 FROM {} WHERE end_snapshot = ?)",
@@ -1487,10 +1491,10 @@ async fn replace_ended_prior_rows(
             .fetch_one(&mut **tx)
             .await?
         {
-            return Ok(true);
+            return Ok((replaced, true));
         }
     }
-    Ok(false)
+    Ok((replaced, false))
 }
 
 async fn inlined_table_names(
@@ -2349,7 +2353,7 @@ async fn commit_inlined_at_snapshot(
     );
     let mut ddl = format!(
         "CREATE TABLE IF NOT EXISTS {} (\
-         row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+         row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT",
         quote_ident(&physical_name)
     );
     for (field, column) in batches[0].schema().fields().iter().zip(&write.columns) {
@@ -3315,8 +3319,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
 
@@ -3480,8 +3483,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             let schema_id: i64 =
@@ -3565,7 +3567,7 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             let mut ddl = format!(
                 "CREATE TABLE IF NOT EXISTS {} (\
-                 row_id BIGINT NOT NULL, begin_snapshot BIGINT NOT NULL, end_snapshot BIGINT",
+                 row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT",
                 quote_ident(&physical_name)
             );
             for (field, column) in batches[0].schema().fields().iter().zip(columns) {
@@ -3651,9 +3653,14 @@ impl MetadataWriter for SqliteMetadataWriter {
             // carry created_schema:/created_table: entries) instead of replacing
             // it, and record a Replace over prior data — Parquet or inlined — as
             // delete + insert, the same semantics the Parquet path records.
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
-            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            let (replaced_files, replaced_inlined) =
+                replaced_storage(&mut tx, table_id, snapshot_id).await?;
+            let changes_made = table_storage_changes(
+                table_id,
+                Some(true),
+                mode == WriteMode::Replace && replaced_files,
+                mode == WriteMode::Replace && replaced_inlined,
+            );
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
 
             let schema_id: i64 =
@@ -3709,8 +3716,10 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .bind(write.table_id)
                 .fetch_one(&mut *tx)
                 .await?;
-                had_live_data
-                    .push(files || live_inlined_row_count(&mut tx, write.table_id).await? > 0);
+                had_live_data.push((
+                    files,
+                    live_inlined_row_count(&mut tx, write.table_id).await? > 0,
+                ));
             }
             let (snapshot_id, mut schema_version) = insert_snapshot(&mut tx).await?;
             let mut schema_changed = false;
@@ -3732,7 +3741,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             }
 
             let mut tables = Vec::with_capacity(writes.len());
-            for (write, replaced_existing_data) in writes.iter().zip(had_live_data) {
+            for (write, (had_files, had_inlined_rows)) in writes.iter().zip(had_live_data) {
                 match &write.data {
                     StagedTableData::Files(files) => {
                         commit_files_at_snapshot(&mut tx, snapshot_id, write, files).await?;
@@ -3774,18 +3783,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                     .execute(&mut *tx)
                     .await?;
                 }
-                let has_deletes =
-                    !write.positional_deletes.is_empty() || !write.inlined_deletes.is_empty();
-                let changes_made = if matches!(&write.data, StagedTableData::None) {
-                    format!("deleted_from_table:{}", write.table_id)
-                } else {
-                    table_write_changes(
-                        write.table_id,
-                        write.mode,
-                        has_deletes,
-                        replaced_existing_data,
-                    )
-                };
+                let changes_made = staged_table_write_changes(write, had_files, had_inlined_rows);
                 record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata)
                     .await?;
                 let schema_id: i64 =
@@ -4149,8 +4147,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -4407,8 +4404,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
             }
 
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made =
                 table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
             record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
@@ -5254,8 +5250,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                 base_snapshot,
             )
             .await?;
-            let replaced_existing_data =
-                replace_ended_prior_rows(&mut tx, table_id, snapshot_id).await?;
+            let replaced_existing_data = replaced_storage(&mut tx, table_id, snapshot_id).await?;
             let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
             record_snapshot_changes(
                 &mut tx,
@@ -5349,6 +5344,9 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn initialize_schema(&self) -> Result<()> {
         block_on(async {
             sqlx::query(SQL_CREATE_SCHEMA).execute(&self.pool).await?;
+            sqlx::query(SQL_CREATE_INLINED_DATA_TABLES)
+                .execute(&self.pool)
+                .await?;
             // Upgrade a pre-existing catalog's `ducklake_column` from the legacy
             // single-row-PK shape to upstream's bare shape (idempotent, crash-safe).
             // `CREATE TABLE IF NOT EXISTS` above only shapes new catalogs.
@@ -5616,6 +5614,8 @@ impl MetadataWriter for SqliteMetadataWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metadata_provider::MetadataProvider;
+    use arrow::array::Int64Array;
     use tempfile::TempDir;
 
     #[test]
@@ -5642,6 +5642,149 @@ mod tests {
             .await
             .unwrap();
         (writer, temp_dir)
+    }
+
+    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn staged_inline_changes_follow_storage_and_share_snapshot() {
+        let (writer, temp) = create_test_writer().await;
+        let columns = vec![ColumnDef::new("value", "BIGINT", false).unwrap()];
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![31, 47])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let mut writes = Vec::new();
+        for (name, data) in [
+            (
+                "files",
+                StagedTableData::Files(vec![DataFileInfo::new("rows.parquet", 123, 3)]),
+            ),
+            ("inline", StagedTableData::Inlined(vec![batch.clone()])),
+        ] {
+            let setup = writer
+                .begin_write_transaction("main", name, &columns, WriteMode::Append)
+                .unwrap();
+            writes.push(StagedTableWrite {
+                table_id: setup.table_id,
+                schema_name: "main".to_string(),
+                table_name: name.to_string(),
+                base_snapshot_id: setup.base_snapshot_id,
+                mode: WriteMode::Append,
+                columns: columns.clone(),
+                column_ids: setup.column_ids,
+                data,
+                snapshot_id_columns: Vec::new(),
+                positional_deletes: Vec::new(),
+                inlined_deletes: Vec::new(),
+                inlined_flush: false,
+            });
+        }
+        let commit = writer
+            .commit_multi_table(&writes, &SnapshotCommitMetadata::default(), None)
+            .unwrap();
+        let provider = crate::SqliteMetadataProvider::new(&format!(
+            "sqlite:{}",
+            temp.path().join("test.db").display()
+        ))
+        .await
+        .unwrap();
+        let changes = provider.list_snapshot_changes().unwrap();
+        let changes = changes
+            .iter()
+            .find(|change| change.snapshot_id == commit.snapshot_id)
+            .unwrap()
+            .changes_made
+            .as_deref()
+            .unwrap();
+        assert_eq!(
+            changes,
+            format!(
+                "created_schema:\"main\",created_table:\"main\".\"files\",created_table:\"main\".\"inline\",inserted_into_table:{},inlined_insert:{}",
+                writes[0].table_id, writes[1].table_id
+            )
+        );
+        let table_columns = provider
+            .get_table_structure(writes[1].table_id, commit.snapshot_id)
+            .unwrap();
+        let inline = provider
+            .get_inlined_data_with_row_ids(writes[1].table_id, commit.snapshot_id, &table_columns)
+            .unwrap();
+        assert_eq!(inline.len(), 1);
+        assert_eq!(inline[0].row_ids, vec![0, 1]);
+        assert_eq!(inline[0].begin_snapshots, vec![commit.snapshot_id; 2]);
+        assert_eq!(inline[0].batch, batch);
+        let file_snapshot: i64 =
+            sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_data_file WHERE table_id = ?")
+                .bind(writes[0].table_id)
+                .fetch_one(&writer.pool)
+                .await
+                .unwrap();
+        assert_eq!(file_snapshot, commit.snapshot_id);
+
+        let mut replacement = writes[1].clone();
+        replacement.base_snapshot_id = commit.snapshot_id;
+        replacement.mode = WriteMode::Replace;
+        let replaced = writer
+            .commit_multi_table(
+                &[replacement.clone()],
+                &SnapshotCommitMetadata::default(),
+                Some(commit.snapshot_id),
+            )
+            .unwrap();
+        let changes = provider.list_snapshot_changes().unwrap();
+        assert_eq!(
+            changes.last().unwrap().changes_made,
+            Some(format!(
+                "inlined_delete:{},inlined_insert:{}",
+                replacement.table_id, replacement.table_id
+            ))
+        );
+        let current = provider
+            .get_inlined_data_with_row_ids(
+                replacement.table_id,
+                replaced.snapshot_id,
+                &table_columns,
+            )
+            .unwrap();
+        assert_eq!(current[0].row_ids, vec![2, 3]);
+        replacement.mode = WriteMode::Append;
+        replacement.base_snapshot_id = replaced.snapshot_id;
+        replacement.data = StagedTableData::None;
+        replacement.inlined_deletes = vec![InlinedRowRef {
+            table_name: current[0].table_name.clone(),
+            row_id: 2,
+        }];
+        let deleted = writer
+            .commit_multi_table(
+                &[replacement],
+                &SnapshotCommitMetadata::default(),
+                Some(replaced.snapshot_id),
+            )
+            .unwrap();
+        let remaining = provider
+            .get_inlined_data_with_row_ids(writes[1].table_id, deleted.snapshot_id, &table_columns)
+            .unwrap();
+        assert_eq!(remaining[0].row_ids, vec![3]);
+        assert_eq!(
+            remaining[0]
+                .batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values(),
+            &[47]
+        );
+        assert_eq!(
+            provider
+                .list_snapshot_changes()
+                .unwrap()
+                .last()
+                .unwrap()
+                .changes_made,
+            Some(format!("inlined_delete:{}", writes[1].table_id))
+        );
     }
 
     /// An existing user's catalog (legacy `column_id INTEGER PRIMARY KEY`) must be

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -11,7 +11,7 @@ use crate::metadata_writer_postgres::execute_ddl_statements;
 use chrono::{DateTime, Utc};
 use sqlx::AssertSqlSafe;
 use sqlx::Row;
-use sqlx::postgres::{PgPool, PgRow};
+use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 
 /// SQL expression yielding a file path resolved relative to the catalog `data_path`
 /// root (file → table → schema → data_path). An absolute path anywhere in the chain
@@ -58,11 +58,31 @@ pub struct MulticatalogManager {
 }
 
 impl MulticatalogManager {
+    /// Connect to PostgreSQL and initialize the multicatalog schema.
+    pub async fn connect(connection_string: &str, max_connections: u32) -> Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(connection_string)
+            .await?;
+        initialize_multicatalog_schema(&pool).await?;
+        Ok(Self::new(pool))
+    }
+
     /// Construct a manager bound to a Postgres pool.
     pub fn new(pool: PgPool) -> Self {
         Self {
             pool,
         }
+    }
+
+    /// Build a catalog-scoped provider sharing this manager's pool.
+    pub async fn provider(&self, catalog_id: i64) -> Result<crate::MulticatalogProvider> {
+        crate::MulticatalogProvider::with_pool_and_id(self.pool.clone(), catalog_id).await
+    }
+
+    /// Build a catalog-scoped writer sharing this manager's pool.
+    pub async fn writer(&self, catalog_id: i64) -> Result<crate::PostgresMetadataWriter> {
+        crate::PostgresMetadataWriter::with_pool(self.pool.clone(), catalog_id).await
     }
 
     /// Create a catalog with the given name, returning its `catalog_id`.

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -7,18 +7,21 @@
 //! extra scoping because the caller already obtained the id through a
 //! catalog-scoped lookup.
 //!
-//! This implementation is standalone; it does not wrap
-//! [`crate::PostgresMetadataProvider`] — the existing single-catalog provider
-//! is untouched.
+//! Catalog-scoped queries are implemented here. Reads keyed by globally unique table IDs reuse the
+//! single-catalog provider's storage-level implementation.
 
+use arrow::record_batch::RecordBatch;
+
+use crate::PostgresMetadataProvider;
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeNameMapping, DuckLakeNameMappingEntry,
-    DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableField,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, MetadataSetting,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema,
-    block_on, reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeInlinedData, DuckLakeInlinedDelete,
+    DuckLakeNameMapping, DuckLakeNameMappingEntry, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableField, DuckLakeTableFile, DuckLakeTableStatistics,
+    FileWithTable, MetadataProvider, MetadataSetting, SchemaMetadata, SnapshotChangeMetadata,
+    SnapshotMetadata, TableMetadata, TableWithSchema, ViewMetadata, ViewWithSchema, block_on,
+    reconstruct_columns, reconstruct_columns_with_table, resolve_metadata_settings,
 };
 use crate::metadata_provider_postgres::{
     PostgresStatsDialect, StatsFilterSql, fetch_data_file_page, stats_filter_sql,
@@ -141,6 +144,7 @@ impl SchemaCapabilities {
 #[derive(Debug, Clone)]
 pub struct MulticatalogProvider {
     pool: PgPool,
+    inlined_provider: PostgresMetadataProvider,
     catalog_id: i64,
     // Positive-only memo of the optional-schema capability probes. `Arc` so
     // derived `Clone` shares the cache across provider clones.
@@ -170,6 +174,7 @@ impl MulticatalogProvider {
             .ok_or_else(|| crate::DuckLakeError::CatalogNotFound(catalog_name.to_string()))?
             .try_get(0)?;
         Ok(Self {
+            inlined_provider: PostgresMetadataProvider::from_pool(pool.clone()),
             pool,
             catalog_id,
             schema_capabilities: Arc::new(OnceLock::new()),
@@ -180,6 +185,7 @@ impl MulticatalogProvider {
     /// name lookup. Caller is responsible for ensuring the id exists.
     pub async fn with_pool_and_id(pool: PgPool, catalog_id: i64) -> Result<Self> {
         Ok(Self {
+            inlined_provider: PostgresMetadataProvider::from_pool(pool.clone()),
             pool,
             catalog_id,
             schema_capabilities: Arc::new(OnceLock::new()),
@@ -619,6 +625,74 @@ impl MetadataProvider for MulticatalogProvider {
                     })
                 })
                 .collect()
+        })
+    }
+
+    fn list_snapshot_changes(&self) -> Result<Vec<SnapshotChangeMetadata>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT snapshot.snapshot_id,
+                        snapshot.snapshot_time::text AS snapshot_time,
+                        changes.changes_made,
+                        changes.author,
+                        changes.commit_message,
+                        changes.commit_extra_info
+                 FROM ducklake_snapshot AS snapshot
+                 JOIN ducklake_catalog_snapshot_map AS catalog
+                   ON catalog.snapshot_id = snapshot.snapshot_id
+                 JOIN ducklake_snapshot_changes AS changes
+                   ON changes.snapshot_id = snapshot.snapshot_id
+                 WHERE catalog.catalog_id = $1
+                 ORDER BY snapshot.snapshot_id",
+            )
+            .bind(self.catalog_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(SnapshotChangeMetadata {
+                        snapshot_id: row.try_get("snapshot_id")?,
+                        timestamp: row.try_get("snapshot_time")?,
+                        changes_made: row.try_get("changes_made")?,
+                        author: row.try_get("author")?,
+                        commit_message: row.try_get("commit_message")?,
+                        commit_extra_info: row.try_get("commit_extra_info")?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn find_snapshot_by_commit_extra_info(&self, needle: &str) -> Result<Option<i64>> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT changes.snapshot_id
+                 FROM ducklake_snapshot_changes AS changes
+                 JOIN ducklake_catalog_snapshot_map AS snapshots
+                   ON snapshots.snapshot_id = changes.snapshot_id
+                 WHERE snapshots.catalog_id = $1
+                   AND (changes.commit_extra_info = $2
+                        OR strpos(changes.commit_extra_info, $3) > 0)
+                   AND EXISTS (
+                       SELECT 1 FROM ducklake_data_file AS files
+                       JOIN ducklake_table AS tables ON tables.table_id = files.table_id
+                       JOIN ducklake_catalog_schema_map AS schemas
+                         ON schemas.schema_id = tables.schema_id
+                       WHERE schemas.catalog_id = $1
+                         AND files.begin_snapshot = changes.snapshot_id
+                         AND files.end_snapshot IS NULL
+                   )
+                 ORDER BY changes.snapshot_id
+                 LIMIT 1",
+            )
+            .bind(self.catalog_id)
+            .bind(needle)
+            .bind(needle)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            Ok(row.map(|row| row.try_get("snapshot_id")).transpose()?)
         })
     }
 
@@ -1276,6 +1350,35 @@ impl MetadataProvider for MulticatalogProvider {
                 files,
             })
         })
+    }
+
+    fn get_inlined_data(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        columns: &[DuckLakeTableColumn],
+    ) -> Result<Vec<RecordBatch>> {
+        self.inlined_provider
+            .get_inlined_data(table_id, snapshot_id, columns)
+    }
+
+    fn get_inlined_data_with_row_ids(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        columns: &[DuckLakeTableColumn],
+    ) -> Result<Vec<DuckLakeInlinedData>> {
+        self.inlined_provider
+            .get_inlined_data_with_row_ids(table_id, snapshot_id, columns)
+    }
+
+    fn get_inlined_deletes(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeInlinedDelete>> {
+        self.inlined_provider
+            .get_inlined_deletes(table_id, snapshot_id)
     }
 
     fn get_schema_by_name(&self, name: &str, snapshot_id: i64) -> Result<Option<SchemaMetadata>> {

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -640,7 +640,7 @@ impl MetadataProvider for MulticatalogProvider {
                  FROM ducklake_snapshot AS snapshot
                  JOIN ducklake_catalog_snapshot_map AS catalog
                    ON catalog.snapshot_id = snapshot.snapshot_id
-                 JOIN ducklake_snapshot_changes AS changes
+                 LEFT JOIN ducklake_snapshot_changes AS changes
                    ON changes.snapshot_id = snapshot.snapshot_id
                  WHERE catalog.catalog_id = $1
                  ORDER BY snapshot.snapshot_id",

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -10,9 +10,9 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::StreamExt;
-use object_store::ObjectStore;
 use object_store::buffered::BufWriter as ObjectBufWriter;
 use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel};
 use parquet::file::properties::{WriterProperties, WriterVersion};
@@ -21,9 +21,11 @@ use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::Result;
+use crate::metadata_provider::DuckLakeInlinedData;
 use crate::metadata_writer::{
-    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter,
-    SnapshotCommitMetadata, WriteMode, WriteResult, validate_delete_entries,
+    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, InlinedRowRef, MetadataWriter,
+    SnapshotCommitMetadata, StagedTableData, StagedTableWrite, WriteMode, WriteResult,
+    validate_delete_entries,
 };
 use crate::path_resolver::join_paths;
 use crate::row_id::{embedded_rowid_field, embedded_snapshot_id_field};
@@ -78,6 +80,9 @@ pub const DEFAULT_TARGET_FILE_SIZE: usize = 1 << 29;
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct DuckLakeWriteOptions {
+    /// Maximum rows written into catalog-backed inlined storage. `Some(0)`
+    /// disables inlining; `None` leaves direct writer calls on the Parquet path.
+    pub data_inlining_row_limit: Option<usize>,
     /// Parquet compression codec; `None` leaves the writer's codec unchanged.
     pub compression: Option<Compression>,
     /// Parquet format version; `None` leaves the writer's version unchanged.
@@ -121,6 +126,7 @@ impl DuckLakeWriteOptions {
             .flatten();
 
         Ok(Self {
+            data_inlining_row_limit: setting_usize(settings, "data_inlining_row_limit", Some(10))?,
             compression: Some(setting_compression(compression_name, compression_level)?),
             parquet_version: setting_parquet_version(settings)?,
             max_row_group_rows: setting_usize(settings, "parquet_row_group_size", Some(122_880))?,
@@ -151,6 +157,13 @@ impl DuckLakeWriteOptions {
         })
     }
 
+    /// Sets the maximum number of rows stored in catalog-backed inlined storage.
+    #[must_use]
+    pub fn with_data_inlining_row_limit(mut self, limit: usize) -> Self {
+        self.data_inlining_row_limit = Some(limit);
+        self
+    }
+
     pub(crate) fn validate(&self) -> Result<()> {
         match &self.deferred_error {
             Some(error) => Err(crate::error::DuckLakeError::InvalidConfig(format!(
@@ -161,6 +174,9 @@ impl DuckLakeWriteOptions {
     }
 
     pub(crate) fn with_overrides(mut self, overrides: &Self) -> Self {
+        if overrides.data_inlining_row_limit.is_some() {
+            self.data_inlining_row_limit = overrides.data_inlining_row_limit;
+        }
         if overrides.compression.is_some() {
             self.compression = overrides.compression;
         }
@@ -396,8 +412,29 @@ impl TableWriteOptions {
     }
 }
 
-/// High-level writer for DuckLake tables.
 #[derive(Debug)]
+struct PreparedTableWrite {
+    write: StagedTableWrite,
+    object_paths: Vec<ObjectPath>,
+    files_written: usize,
+    records_written: i64,
+}
+
+/// A set of table changes committed in one DuckLake snapshot.
+///
+/// The DuckDB, SQLite, MySQL, and multicatalog PostgreSQL metadata writers support this
+/// transaction. Other metadata writers return an unsupported-operation error when
+/// [`Self::commit`] is called.
+#[derive(Debug)]
+pub struct DuckLakeWriteTransaction<'a> {
+    writer: &'a DuckLakeTableWriter,
+    writes: Vec<PreparedTableWrite>,
+    commit_metadata: SnapshotCommitMetadata,
+    expected_base_snapshot_id: Option<i64>,
+}
+
+/// High-level writer for DuckLake tables.
+#[derive(Debug, Clone)]
 pub struct DuckLakeTableWriter {
     metadata: Arc<dyn MetadataWriter>,
     object_store: Arc<dyn ObjectStore>,
@@ -432,6 +469,7 @@ pub struct DuckLakeTableWriter {
     /// Defaults to [`DEFAULT_MAX_OPEN_PARTITIONS`]; override via
     /// [`DuckLakeTableWriter::with_max_open_partitions`].
     max_open_partitions: usize,
+    data_inlining_row_limit: Option<usize>,
     sort_on_insert: bool,
     hive_file_pattern: bool,
 }
@@ -455,9 +493,21 @@ impl DuckLakeTableWriter {
             upload_concurrency: DEFAULT_UPLOAD_CONCURRENCY,
             target_file_size: DEFAULT_TARGET_FILE_SIZE,
             max_open_partitions: DEFAULT_MAX_OPEN_PARTITIONS,
+            data_inlining_row_limit: None,
             sort_on_insert: true,
             hive_file_pattern: true,
         })
+    }
+
+    /// Starts a write transaction that can stage changes for multiple tables.
+    #[must_use]
+    pub fn transaction(&self) -> DuckLakeWriteTransaction<'_> {
+        DuckLakeWriteTransaction {
+            writer: self,
+            writes: Vec::new(),
+            commit_metadata: SnapshotCommitMetadata::default(),
+            expected_base_snapshot_id: None,
+        }
     }
 
     /// Override the parquet compression codec used for written data files.
@@ -521,6 +571,9 @@ impl DuckLakeTableWriter {
     /// target, open-partition cap, upload concurrency). Each field overrides the
     /// corresponding setting only when present.
     pub fn with_options(mut self, options: &DuckLakeWriteOptions) -> Self {
+        if let Some(limit) = options.data_inlining_row_limit {
+            self.data_inlining_row_limit = Some(limit);
+        }
         if let Some(compression) = options.compression {
             self.compression = compression;
         }
@@ -943,6 +996,83 @@ impl DuckLakeTableWriter {
     /// input of only empty batches keeps the single-file session path: `write_rows`
     /// produces no file at all, which for `Replace` would skip the truncation of the
     /// prior generation, whereas the session registers the 0-row file that carries it.
+    /// Materialize visible inlined rows as Parquet in one fenced snapshot.
+    ///
+    /// The caller reads `inlined_data` at `expected_base_snapshot_id`. The
+    /// commit registers the resulting data files and ends those exact inlined
+    /// row identities atomically. Empty input is a no-op.
+    pub async fn flush_inlined_data(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        inlined_data: &[DuckLakeInlinedData],
+        expected_base_snapshot_id: i64,
+    ) -> Result<Option<WriteResult>> {
+        if inlined_data.is_empty() {
+            return Ok(None);
+        }
+
+        let mut batches = Vec::with_capacity(inlined_data.len());
+        let mut rows = Vec::new();
+        for inlined in inlined_data {
+            if inlined.row_ids.len() != inlined.batch.num_rows()
+                || inlined.begin_snapshots.len() != inlined.batch.num_rows()
+            {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "inlined row identities for '{}' do not match its {} batch rows",
+                    inlined.table_name,
+                    inlined.batch.num_rows(),
+                )));
+            }
+            batches.push(inlined.batch.clone());
+            rows.extend(inlined.row_ids.iter().map(|row_id| InlinedRowRef {
+                table_name: inlined.table_name.clone(),
+                row_id: *row_id,
+            }));
+        }
+
+        let schema = batches[0].schema();
+        if batches
+            .iter()
+            .any(|batch| !batch.schema().contains(schema.as_ref()))
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "inlined flush batches do not share one compatible schema".to_string(),
+            ));
+        }
+
+        let write_options = DuckLakeWriteOptions {
+            data_inlining_row_limit: Some(0),
+            target_file_size: Some(usize::MAX),
+            ..DuckLakeWriteOptions::default()
+        };
+        let flush_writer = self.clone().with_options(&write_options);
+        let transaction_options =
+            TableWriteOptions::new().with_expected_base_snapshot_id(expected_base_snapshot_id);
+        let mut transaction = flush_writer
+            .transaction()
+            .with_options(&transaction_options);
+        transaction
+            .stage_write_with_deletes(
+                schema_name,
+                table_name,
+                schema.as_ref(),
+                WriteMode::Append,
+                &batches,
+                &[],
+                &rows,
+            )
+            .await?;
+        let mut results = transaction.commit().await?;
+        if results.len() != 1 {
+            return Err(crate::DuckLakeError::Internal(format!(
+                "inlined flush committed {} table results, expected 1",
+                results.len(),
+            )));
+        }
+        Ok(results.pop())
+    }
+
     async fn write_all(
         &self,
         schema_name: &str,
@@ -1301,21 +1431,20 @@ impl DuckLakeTableWriter {
         let setup =
             self.metadata
                 .begin_write_transaction(schema_name, table_name, &columns, mode)?;
-        let schema_with_ids =
-            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.field_ids)?);
 
-        let scoped_base = match self.metadata.catalog_id() {
-            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
-            None => self.base_key_path.clone(),
-        };
-        let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+        let records_written: usize = groups
+            .iter()
+            .flat_map(|(_, batches)| batches)
+            .map(RecordBatch::num_rows)
+            .sum();
 
         // Validate the caller's assignment against the live spec BEFORE writing
-        // anything, so a bad one costs no uploads. A wrong arity or an unparseable
-        // value would otherwise be persisted and then used as an exact pruning
-        // bound, silently dropping rows from later reads. (Whether each group's rows
-        // really carry its values is the caller's assertion — as in official
-        // DuckLake's add_data_files, that cannot be checked without reading data.)
+        // anything (inline or Parquet), so a bad one costs no uploads. A wrong
+        // arity or an unparseable value would otherwise be persisted and then
+        // used as an exact pruning bound, silently dropping rows from later
+        // reads. (Whether each group's rows really carry its values is the
+        // caller's assertion — as in official DuckLake's add_data_files, that
+        // cannot be checked without reading data.)
         if let Some(spec) =
             self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)?
         {
@@ -1330,6 +1459,41 @@ impl DuckLakeTableWriter {
                 spec.validate_values(arrow_schema, values)?;
             }
         }
+
+        if self.should_inline(records_written, arrow_schema) {
+            let batches: Vec<RecordBatch> = groups
+                .iter()
+                .flat_map(|(_, batches)| batches.iter().cloned())
+                .collect();
+            let committed = self.metadata.register_inlined_data(
+                setup.table_id,
+                schema_name,
+                table_name,
+                setup.snapshot_id,
+                &batches,
+                mode,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+                &options.commit_metadata,
+                options.expected_base_snapshot_id,
+            )?;
+            return Ok(WriteResult {
+                snapshot_id: committed.snapshot_id,
+                table_id: committed.table_id,
+                schema_id: committed.schema_id,
+                files_written: 0,
+                records_written: records_written as i64,
+            });
+        }
+        let schema_with_ids =
+            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.field_ids)?);
+
+        let scoped_base = match self.metadata.catalog_id() {
+            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+            None => self.base_key_path.clone(),
+        };
+        let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
 
         let file_infos = self
             .write_partition_groups(
@@ -1455,6 +1619,30 @@ impl DuckLakeTableWriter {
         let setup =
             self.metadata
                 .begin_write_transaction(schema_name, table_name, &columns, mode)?;
+
+        let records_written: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        if self.should_inline(records_written, arrow_schema) {
+            let committed = self.metadata.register_inlined_data(
+                setup.table_id,
+                schema_name,
+                table_name,
+                setup.snapshot_id,
+                batches,
+                mode,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+                &SnapshotCommitMetadata::new(),
+                None,
+            )?;
+            return Ok(WriteResult {
+                snapshot_id: committed.snapshot_id,
+                table_id: committed.table_id,
+                schema_id: committed.schema_id,
+                files_written: 0,
+                records_written: records_written as i64,
+            });
+        }
         let schema_with_ids =
             Arc::new(build_schema_with_field_ids(arrow_schema, &setup.field_ids)?);
 
@@ -1554,6 +1742,158 @@ impl DuckLakeTableWriter {
             files_written: file_infos.len(),
             records_written,
         })
+    }
+
+    async fn prepare_rows_inner(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+        resolve_layout: bool,
+    ) -> Result<PreparedTableWrite> {
+        let columns = arrow_schema_to_column_defs(arrow_schema)?;
+        let setup =
+            self.metadata
+                .begin_write_transaction(schema_name, table_name, &columns, mode)?;
+        let records_written: usize = batches.iter().map(RecordBatch::num_rows).sum();
+
+        if records_written == 0 {
+            return Err(crate::error::DuckLakeError::InvalidConfig(
+                "multi-table row stage requires at least one row".to_string(),
+            ));
+        }
+
+        if self.should_inline(records_written, arrow_schema) {
+            return Ok(PreparedTableWrite {
+                write: StagedTableWrite {
+                    table_id: setup.table_id,
+                    schema_name: schema_name.to_string(),
+                    table_name: table_name.to_string(),
+                    base_snapshot_id: setup.base_snapshot_id,
+                    mode,
+                    columns,
+                    column_ids: setup.column_ids,
+                    data: StagedTableData::Inlined(batches.to_vec()),
+                    snapshot_id_columns: Vec::new(),
+                    positional_deletes: Vec::new(),
+                    inlined_deletes: Vec::new(),
+                },
+                object_paths: Vec::new(),
+                files_written: 0,
+                records_written: records_written as i64,
+            });
+        }
+
+        let schema_with_ids =
+            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.field_ids)?);
+        let scoped_base = match self.metadata.catalog_id() {
+            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+            None => self.base_key_path.clone(),
+        };
+        let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+        let partition = if resolve_layout {
+            self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)?
+        } else {
+            None
+        };
+        let sorted_owned = if resolve_layout && self.sort_on_insert {
+            let lengths = batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .collect::<Vec<_>>();
+            let sorted = crate::sort::sort_batches_by_spec(
+                batches.to_vec(),
+                arrow_schema,
+                self.metadata.live_sort_spec(setup.table_id)?.as_ref(),
+            )?;
+            reslice_to_lengths(sorted, &lengths)
+        } else {
+            Vec::new()
+        };
+        let batches = if resolve_layout && self.sort_on_insert {
+            &sorted_owned
+        } else {
+            batches
+        };
+        let file_infos = match partition.as_ref() {
+            Some(spec) => {
+                let output_schema = Arc::new(arrow_schema.clone());
+                let groups =
+                    crate::partition::split_batches_by_partition(&output_schema, batches, spec)?;
+                self.write_partition_groups(
+                    &table_key,
+                    schema_with_ids,
+                    &setup.column_ids,
+                    spec.partition_id,
+                    &spec.key_names(),
+                    &groups,
+                )
+                .await?
+            },
+            None => {
+                self.write_rolled_files(
+                    &table_key,
+                    None,
+                    schema_with_ids,
+                    &setup.column_ids,
+                    batches,
+                )
+                .await?
+            },
+        };
+        let object_paths = file_infos
+            .iter()
+            .map(|file| {
+                self.staged_object_path(schema_name, table_name, &file.path, file.path_is_relative)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let records_written = file_infos.iter().map(|file| file.record_count).sum();
+        let files_written = file_infos.len();
+
+        Ok(PreparedTableWrite {
+            write: StagedTableWrite {
+                table_id: setup.table_id,
+                schema_name: schema_name.to_string(),
+                table_name: table_name.to_string(),
+                base_snapshot_id: setup.base_snapshot_id,
+                mode,
+                columns,
+                column_ids: setup.field_ids,
+                data: StagedTableData::Files(file_infos),
+                snapshot_id_columns: Vec::new(),
+                positional_deletes: Vec::new(),
+                inlined_deletes: Vec::new(),
+            },
+            object_paths,
+            files_written,
+            records_written,
+        })
+    }
+
+    fn staged_object_path(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        path: &str,
+        path_is_relative: bool,
+    ) -> Result<ObjectPath> {
+        let path = if path_is_relative {
+            let scoped_base = match self.metadata.catalog_id() {
+                Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+                None => self.base_key_path.clone(),
+            };
+            let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+            join_paths(&table_key, path)?
+        } else {
+            path.to_string()
+        };
+        Ok(ObjectPath::from(path.trim_start_matches('/')))
+    }
+
+    fn should_inline(&self, _rows: usize, _arrow_schema: &Schema) -> bool {
+        false
     }
 
     /// Resolve the table's live partition spec against the columns this write is
@@ -1669,6 +2009,357 @@ impl DuckLakeTableWriter {
             files.push(upload_staged_file(staged, &self.object_store, column_ids).await?);
         }
         Ok(files)
+    }
+}
+
+impl DuckLakeWriteTransaction<'_> {
+    /// Applies commit metadata and a shared table-state precondition.
+    #[must_use]
+    pub fn with_options(mut self, options: &TableWriteOptions) -> Self {
+        self.commit_metadata = options.commit_metadata.clone();
+        self.expected_base_snapshot_id = options.expected_base_snapshot_id;
+        self
+    }
+
+    /// Stages one table write without committing catalog metadata.
+    pub async fn stage_write(
+        &mut self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+    ) -> Result<()> {
+        let prepared = self
+            .writer
+            .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
+            .await?;
+        self.writes.push(prepared);
+        Ok(())
+    }
+
+    /// Stages one table write with options that apply only to this stage.
+    pub async fn stage_write_with_options(
+        &mut self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+        options: &DuckLakeWriteOptions,
+    ) -> Result<()> {
+        let writer = self.writer.clone().with_options(options);
+        let prepared = writer
+            .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
+            .await?;
+        self.writes.push(prepared);
+        Ok(())
+    }
+
+    /// Stages an inline write whose nullable snapshot columns use the commit snapshot.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stage_write_with_snapshot_columns(
+        &mut self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+        options: &DuckLakeWriteOptions,
+        snapshot_id_columns: &[&str],
+    ) -> Result<()> {
+        let writer = self.writer.clone().with_options(options);
+        let mut prepared = writer
+            .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
+            .await?;
+        if !matches!(&prepared.write.data, StagedTableData::Inlined(_)) {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit snapshot columns require an inlined table stage".to_string(),
+            ));
+        }
+        for name in snapshot_id_columns {
+            if !prepared
+                .write
+                .columns
+                .iter()
+                .any(|column| column.name() == *name)
+            {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "commit snapshot column '{name}' is not present in the staged schema"
+                )));
+            }
+        }
+        prepared.write.snapshot_id_columns = snapshot_id_columns
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect();
+        self.writes.push(prepared);
+        Ok(())
+    }
+
+    /// Stages an inline write with deletes and commit-snapshot columns.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stage_write_with_deletes_and_snapshot_columns(
+        &mut self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+        positional_deletes: &[DeleteFileEntry],
+        inlined_deletes: &[InlinedRowRef],
+        options: &DuckLakeWriteOptions,
+        snapshot_id_columns: &[&str],
+    ) -> Result<()> {
+        if !positional_deletes.is_empty() {
+            validate_delete_entries(mode, positional_deletes)?;
+        }
+        if inlined_deletes
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined_deletes.len()
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "multi-table write contains duplicate inlined deletes".to_string(),
+            ));
+        }
+        let delete_paths = positional_deletes
+            .iter()
+            .map(|entry| {
+                self.writer.staged_object_path(
+                    schema_name,
+                    table_name,
+                    &entry.delete.path,
+                    entry.delete.path_is_relative,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        self.stage_write_with_snapshot_columns(
+            schema_name,
+            table_name,
+            arrow_schema,
+            mode,
+            batches,
+            options,
+            snapshot_id_columns,
+        )
+        .await?;
+        let prepared = self
+            .writes
+            .last_mut()
+            .expect("snapshot-column stage appended one table");
+        prepared.object_paths.extend(delete_paths);
+        prepared.write.positional_deletes = positional_deletes.to_vec();
+        prepared.write.inlined_deletes = inlined_deletes.to_vec();
+        Ok(())
+    }
+
+    /// Stages inserted rows and deletes for one table.
+    ///
+    /// The transaction takes ownership of the positional delete objects and removes them if the
+    /// transaction aborts or its metadata commit fails.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stage_write_with_deletes(
+        &mut self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+        positional_deletes: &[DeleteFileEntry],
+        inlined_deletes: &[InlinedRowRef],
+    ) -> Result<()> {
+        if !positional_deletes.is_empty() {
+            validate_delete_entries(mode, positional_deletes)?;
+        }
+        if inlined_deletes
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined_deletes.len()
+        {
+            return Err(crate::error::DuckLakeError::InvalidConfig(
+                "multi-table write contains duplicate inlined deletes".to_string(),
+            ));
+        }
+
+        let delete_paths = positional_deletes
+            .iter()
+            .map(|entry| {
+                self.writer.staged_object_path(
+                    schema_name,
+                    table_name,
+                    &entry.delete.path,
+                    entry.delete.path_is_relative,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        self.stage_write(schema_name, table_name, arrow_schema, mode, batches)
+            .await?;
+        let prepared = self
+            .writes
+            .last_mut()
+            .expect("stage_write appended one table");
+        prepared.object_paths.extend(delete_paths);
+        prepared.write.positional_deletes = positional_deletes.to_vec();
+        prepared.write.inlined_deletes = inlined_deletes.to_vec();
+        Ok(())
+    }
+
+    /// Stages deletes for a table without inserting replacement rows.
+    ///
+    /// The transaction takes ownership of the positional delete objects and removes them if the
+    /// transaction aborts or its metadata commit fails.
+    pub fn stage_deletes(
+        &mut self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        positional_deletes: &[DeleteFileEntry],
+        inlined_deletes: &[InlinedRowRef],
+    ) -> Result<()> {
+        validate_delete_entries(WriteMode::Append, positional_deletes)?;
+        if inlined_deletes
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            != inlined_deletes.len()
+        {
+            return Err(crate::error::DuckLakeError::InvalidConfig(
+                "multi-table write contains duplicate inlined deletes".to_string(),
+            ));
+        }
+        if positional_deletes.is_empty() && inlined_deletes.is_empty() {
+            return Err(crate::error::DuckLakeError::InvalidConfig(
+                "delete-only table stage requires at least one delete".to_string(),
+            ));
+        }
+        let columns = arrow_schema_to_column_defs(arrow_schema)?;
+        let setup = self.writer.metadata.begin_write_transaction(
+            schema_name,
+            table_name,
+            &columns,
+            WriteMode::Append,
+        )?;
+        let object_paths = positional_deletes
+            .iter()
+            .map(|entry| {
+                self.writer.staged_object_path(
+                    schema_name,
+                    table_name,
+                    &entry.delete.path,
+                    entry.delete.path_is_relative,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        self.writes.push(PreparedTableWrite {
+            write: StagedTableWrite {
+                table_id: setup.table_id,
+                schema_name: schema_name.to_string(),
+                table_name: table_name.to_string(),
+                base_snapshot_id: setup.base_snapshot_id,
+                mode: WriteMode::Append,
+                columns,
+                column_ids: setup.field_ids,
+                data: StagedTableData::None,
+                snapshot_id_columns: Vec::new(),
+                positional_deletes: positional_deletes.to_vec(),
+                inlined_deletes: inlined_deletes.to_vec(),
+            },
+            object_paths,
+            files_written: 0,
+            records_written: 0,
+        });
+        Ok(())
+    }
+
+    /// Commits every staged table change in one metadata transaction.
+    pub async fn commit(mut self) -> Result<Vec<WriteResult>> {
+        if self.writes.is_empty() {
+            return Err(crate::error::DuckLakeError::InvalidConfig(
+                "multi-table write requires at least one table stage".to_string(),
+            ));
+        }
+        let writes = self
+            .writes
+            .iter()
+            .map(|prepared| prepared.write.clone())
+            .collect::<Vec<_>>();
+        let committed = self.writer.metadata.commit_multi_table(
+            &writes,
+            &self.commit_metadata,
+            self.expected_base_snapshot_id,
+        );
+        let committed = match committed {
+            Ok(committed) => committed,
+            Err(e) => {
+                // Remove the staged files only on a DEFINITE pre-commit
+                // rejection (fence conflict, validation). A database or
+                // transport error can surface after the server applied COMMIT
+                // (a lost ack), and deleting the staged objects then would
+                // leave a committed snapshot pointing at missing files.
+                // Ambiguous outcomes leave the objects to the guarded vacuum,
+                // which reclaims only unreferenced files.
+                let definitely_rolled_back = matches!(
+                    e,
+                    crate::error::DuckLakeError::Conflict(_)
+                        | crate::error::DuckLakeError::InvalidConfig(_)
+                        | crate::error::DuckLakeError::Unsupported(_)
+                );
+                if definitely_rolled_back && let Err(cleanup) = self.cleanup().await {
+                    return Err(crate::error::DuckLakeError::Internal(format!(
+                        "multi-table commit failed: {e}; staged-file cleanup failed: {cleanup}"
+                    )));
+                }
+                return Err(e);
+            },
+        };
+        if committed.tables.len() != self.writes.len() {
+            return Err(crate::error::DuckLakeError::Internal(format!(
+                "multi-table commit returned {} table ids for {} stages",
+                committed.tables.len(),
+                self.writes.len()
+            )));
+        }
+
+        Ok(self
+            .writes
+            .iter()
+            .zip(committed.tables)
+            .map(|(prepared, table)| WriteResult {
+                snapshot_id: committed.snapshot_id,
+                table_id: table.table_id,
+                schema_id: table.schema_id,
+                files_written: prepared.files_written,
+                records_written: prepared.records_written,
+            })
+            .collect())
+    }
+
+    /// Removes uploaded files without committing the staged metadata.
+    pub async fn abort(mut self) -> Result<()> {
+        self.cleanup().await
+    }
+
+    async fn cleanup(&mut self) -> Result<()> {
+        let mut failures = Vec::new();
+        for path in self
+            .writes
+            .iter()
+            .flat_map(|prepared| prepared.object_paths.iter())
+        {
+            if let Err(e) = self.writer.object_store.delete(path).await {
+                failures.push(format!("{path}: {e}"));
+            }
+        }
+        if !failures.is_empty() {
+            return Err(crate::error::DuckLakeError::Internal(format!(
+                "failed to remove staged files: {}",
+                failures.join("; ")
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -2979,6 +3670,7 @@ mod tests {
             options.compression,
             Some(Compression::ZSTD(ZstdLevel::try_new(5).unwrap()))
         );
+        assert_eq!(options.data_inlining_row_limit, Some(10));
         assert_eq!(options.max_row_group_rows, Some(122_880));
         assert_eq!(options.max_row_group_bytes, Some(2 * 1_048_576));
         assert_eq!(options.target_file_size, Some(5_000_000));
@@ -3004,6 +3696,7 @@ mod tests {
         let options = stored.with_overrides(&explicit);
 
         assert_eq!(options.compression, Some(Compression::LZ4_RAW));
+        assert_eq!(options.data_inlining_row_limit, Some(10));
         assert_eq!(options.target_file_size, Some(5_000_000));
         assert_eq!(options.sort_on_insert, Some(false));
         assert_eq!(options.hive_file_pattern, Some(true));

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -126,7 +126,7 @@ impl DuckLakeWriteOptions {
             .flatten();
 
         Ok(Self {
-            data_inlining_row_limit: setting_usize(settings, "data_inlining_row_limit", Some(10))?,
+            data_inlining_row_limit: None,
             compression: Some(setting_compression(compression_name, compression_level)?),
             parquet_version: setting_parquet_version(settings)?,
             max_row_group_rows: setting_usize(settings, "parquet_row_group_size", Some(122_880))?,
@@ -422,12 +422,12 @@ struct PreparedTableWrite {
 
 /// A set of table changes committed in one DuckLake snapshot.
 ///
-/// The DuckDB, SQLite, MySQL, and multicatalog PostgreSQL metadata writers support this
-/// transaction. Other metadata writers return an unsupported-operation error when
-/// [`Self::commit`] is called. Create and commit target tables before staging;
-/// DuckDB and MySQL require their column metadata to exist at commit time.
-/// Empty transactions, zero-row stages, and empty delete sets return an error.
-/// Inlined deletes must identify one live row visible at the stage's base snapshot.
+/// DuckDB, SQLite, MySQL, and both PostgreSQL writers finalize new or existing
+/// tables in this transaction. Empty staging calls add no result entry, and an
+/// empty transaction returns without publishing a snapshot. Inlined deletes
+/// ignore missing row identities and rows inserted by the same transaction;
+/// concurrent changes still conflict. An explicit expected-base snapshot adds
+/// a table-state precondition, including for append stages.
 #[derive(Debug)]
 pub struct DuckLakeWriteTransaction<'a> {
     writer: &'a DuckLakeTableWriter,
@@ -2041,6 +2041,10 @@ impl DuckLakeWriteTransaction<'_> {
         mode: WriteMode,
         batches: &[RecordBatch],
     ) -> Result<()> {
+        if batches.iter().all(|batch| batch.num_rows() == 0) {
+            return Ok(());
+        }
+
         let prepared = self
             .writer
             .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
@@ -2059,6 +2063,10 @@ impl DuckLakeWriteTransaction<'_> {
         batches: &[RecordBatch],
         options: &DuckLakeWriteOptions,
     ) -> Result<()> {
+        if batches.iter().all(|batch| batch.num_rows() == 0) {
+            return Ok(());
+        }
+
         let writer = self.writer.clone().with_options(options);
         let prepared = writer
             .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
@@ -2079,27 +2087,33 @@ impl DuckLakeWriteTransaction<'_> {
         options: &DuckLakeWriteOptions,
         snapshot_id_columns: &[&str],
     ) -> Result<()> {
+        if batches.iter().all(|batch| batch.num_rows() == 0) {
+            return Ok(());
+        }
+
         let writer = self.writer.clone().with_options(options);
-        let mut prepared = writer
-            .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
-            .await?;
-        if !matches!(&prepared.write.data, StagedTableData::Inlined(_)) {
+        if !writer.should_inline(
+            batches.iter().map(RecordBatch::num_rows).sum(),
+            arrow_schema,
+        ) {
             return Err(crate::DuckLakeError::InvalidConfig(
                 "commit snapshot columns require an inlined table stage".to_string(),
             ));
         }
         for name in snapshot_id_columns {
-            if !prepared
-                .write
-                .columns
+            if !arrow_schema
+                .fields()
                 .iter()
-                .any(|column| column.name() == *name)
+                .any(|field| field.name() == name)
             {
                 return Err(crate::DuckLakeError::InvalidConfig(format!(
                     "commit snapshot column '{name}' is not present in the staged schema"
                 )));
             }
         }
+        let mut prepared = writer
+            .prepare_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
+            .await?;
         prepared.write.snapshot_id_columns = snapshot_id_columns
             .iter()
             .map(|name| (*name).to_string())
@@ -2122,18 +2136,18 @@ impl DuckLakeWriteTransaction<'_> {
         options: &DuckLakeWriteOptions,
         snapshot_id_columns: &[&str],
     ) -> Result<()> {
+        if batches.iter().all(|batch| batch.num_rows() == 0) {
+            return self.stage_deletes(
+                schema_name,
+                table_name,
+                arrow_schema,
+                positional_deletes,
+                inlined_deletes,
+            );
+        }
+
         if !positional_deletes.is_empty() {
             validate_delete_entries(mode, positional_deletes)?;
-        }
-        if inlined_deletes
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-            != inlined_deletes.len()
-        {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "multi-table write contains duplicate inlined deletes".to_string(),
-            ));
         }
         let delete_paths = positional_deletes
             .iter()
@@ -2181,18 +2195,18 @@ impl DuckLakeWriteTransaction<'_> {
         positional_deletes: &[DeleteFileEntry],
         inlined_deletes: &[InlinedRowRef],
     ) -> Result<()> {
+        if batches.iter().all(|batch| batch.num_rows() == 0) {
+            return self.stage_deletes(
+                schema_name,
+                table_name,
+                arrow_schema,
+                positional_deletes,
+                inlined_deletes,
+            );
+        }
+
         if !positional_deletes.is_empty() {
             validate_delete_entries(mode, positional_deletes)?;
-        }
-        if inlined_deletes
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-            != inlined_deletes.len()
-        {
-            return Err(crate::error::DuckLakeError::InvalidConfig(
-                "multi-table write contains duplicate inlined deletes".to_string(),
-            ));
         }
 
         let delete_paths = positional_deletes
@@ -2231,20 +2245,8 @@ impl DuckLakeWriteTransaction<'_> {
         inlined_deletes: &[InlinedRowRef],
     ) -> Result<()> {
         validate_delete_entries(WriteMode::Append, positional_deletes)?;
-        if inlined_deletes
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-            != inlined_deletes.len()
-        {
-            return Err(crate::error::DuckLakeError::InvalidConfig(
-                "multi-table write contains duplicate inlined deletes".to_string(),
-            ));
-        }
         if positional_deletes.is_empty() && inlined_deletes.is_empty() {
-            return Err(crate::error::DuckLakeError::InvalidConfig(
-                "delete-only table stage requires at least one delete".to_string(),
-            ));
+            return Ok(());
         }
         let columns = arrow_schema_to_column_defs(arrow_schema)?;
         let setup = self.writer.metadata.begin_write_transaction(
@@ -2289,9 +2291,7 @@ impl DuckLakeWriteTransaction<'_> {
     /// Commits every staged table change in one metadata transaction.
     pub async fn commit(mut self) -> Result<Vec<WriteResult>> {
         if self.writes.is_empty() {
-            return Err(crate::error::DuckLakeError::InvalidConfig(
-                "multi-table write requires at least one table stage".to_string(),
-            ));
+            return Ok(Vec::new());
         }
         let writes = self
             .writes
@@ -3682,7 +3682,7 @@ mod tests {
             options.compression,
             Some(Compression::ZSTD(ZstdLevel::try_new(5).unwrap()))
         );
-        assert_eq!(options.data_inlining_row_limit, Some(10));
+        assert_eq!(options.data_inlining_row_limit, None);
         assert_eq!(options.max_row_group_rows, Some(122_880));
         assert_eq!(options.max_row_group_bytes, Some(2 * 1_048_576));
         assert_eq!(options.target_file_size, Some(5_000_000));
@@ -3708,7 +3708,7 @@ mod tests {
         let options = stored.with_overrides(&explicit);
 
         assert_eq!(options.compression, Some(Compression::LZ4_RAW));
-        assert_eq!(options.data_inlining_row_limit, Some(10));
+        assert_eq!(options.data_inlining_row_limit, None);
         assert_eq!(options.target_file_size, Some(5_000_000));
         assert_eq!(options.sort_on_insert, Some(false));
         assert_eq!(options.hive_file_pattern, Some(true));

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -80,8 +80,8 @@ pub const DEFAULT_TARGET_FILE_SIZE: usize = 1 << 29;
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct DuckLakeWriteOptions {
-    /// Maximum rows written into catalog-backed inlined storage. `Some(0)`
-    /// disables inlining; `None` leaves direct writer calls on the Parquet path.
+    /// Reserved limit for automatic catalog-backed inlining. High-level writes
+    /// currently use Parquet regardless of this value.
     pub data_inlining_row_limit: Option<usize>,
     /// Parquet compression codec; `None` leaves the writer's codec unchanged.
     pub compression: Option<Compression>,
@@ -157,7 +157,7 @@ impl DuckLakeWriteOptions {
         })
     }
 
-    /// Sets the maximum number of rows stored in catalog-backed inlined storage.
+    /// Sets the reserved automatic inlining limit; high-level writes currently use Parquet.
     #[must_use]
     pub fn with_data_inlining_row_limit(mut self, limit: usize) -> Self {
         self.data_inlining_row_limit = Some(limit);
@@ -424,7 +424,10 @@ struct PreparedTableWrite {
 ///
 /// The DuckDB, SQLite, MySQL, and multicatalog PostgreSQL metadata writers support this
 /// transaction. Other metadata writers return an unsupported-operation error when
-/// [`Self::commit`] is called.
+/// [`Self::commit`] is called. Create and commit target tables before staging;
+/// DuckDB and MySQL require their column metadata to exist at commit time.
+/// Empty transactions, zero-row stages, and empty delete sets return an error.
+/// Inlined deletes must identify one live row visible at the stage's base snapshot.
 #[derive(Debug)]
 pub struct DuckLakeWriteTransaction<'a> {
     writer: &'a DuckLakeTableWriter,
@@ -1063,6 +1066,12 @@ impl DuckLakeTableWriter {
                 &rows,
             )
             .await?;
+        transaction
+            .writes
+            .last_mut()
+            .expect("flush stages one table")
+            .write
+            .inlined_flush = true;
         let mut results = transaction.commit().await?;
         if results.len() != 1 {
             return Err(crate::DuckLakeError::Internal(format!(
@@ -1779,6 +1788,7 @@ impl DuckLakeTableWriter {
                     snapshot_id_columns: Vec::new(),
                     positional_deletes: Vec::new(),
                     inlined_deletes: Vec::new(),
+                    inlined_flush: false,
                 },
                 object_paths: Vec::new(),
                 files_written: 0,
@@ -1865,6 +1875,7 @@ impl DuckLakeTableWriter {
                 snapshot_id_columns: Vec::new(),
                 positional_deletes: Vec::new(),
                 inlined_deletes: Vec::new(),
+                inlined_flush: false,
             },
             object_paths,
             files_written,
@@ -2266,6 +2277,7 @@ impl DuckLakeWriteTransaction<'_> {
                 snapshot_id_columns: Vec::new(),
                 positional_deletes: positional_deletes.to_vec(),
                 inlined_deletes: inlined_deletes.to_vec(),
+                inlined_flush: false,
             },
             object_paths,
             files_written: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -781,6 +781,20 @@ pub fn build_arrow_schema(columns: &[DuckLakeTableColumn]) -> Result<Schema> {
     Ok(Schema::new(fields?))
 }
 
+pub(crate) fn build_strict_arrow_schema(columns: &[DuckLakeTableColumn]) -> Result<Schema> {
+    let fields = columns
+        .iter()
+        .map(|column| {
+            Ok(Field::new(
+                &column.column_name,
+                column.data_type()?,
+                column.is_nullable,
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Schema::new(fields))
+}
+
 /// Prefix of the synthetic name a read schema gives a column the file does not
 /// carry, so the scan null-fills it instead of matching a same-named column that
 /// happens to be present.

--- a/tests/it/append_with_deletes_postgres_tests.rs
+++ b/tests/it/append_with_deletes_postgres_tests.rs
@@ -18,8 +18,9 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
-    DeleteFileEntry, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MetadataProvider,
-    MetadataWriter, MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter, WriteMode,
+    ColumnDef, DeleteFileEntry, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter,
+    DuckLakeWriteOptions, MetadataProvider, MetadataWriter, MulticatalogManager,
+    MulticatalogProvider, PostgresMetadataWriter, WriteMode,
 };
 use object_store::local::LocalFileSystem;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -40,6 +41,122 @@ async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)
         .await?;
     datafusion_ducklake::initialize_multicatalog_schema(&pool).await?;
     Ok((pool, container))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn multi_table_write_commits_parquet_and_inline_rows_postgres() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let manager = MulticatalogManager::new(pool.clone());
+    let catalog_id = manager.create_catalog("pg_multi_table").await.unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let writer = writer_for(&pool, catalog_id, &data_path).await;
+    let columns = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
+    ];
+    for table_name in ["data", "coverage"] {
+        let setup = writer
+            .begin_write_transaction("public", table_name, &columns, WriteMode::Append)
+            .unwrap();
+        writer
+            .publish_snapshot(
+                setup.table_id,
+                "public",
+                table_name,
+                setup.snapshot_id,
+                WriteMode::Append,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+            )
+            .unwrap();
+    }
+    let options = DuckLakeWriteOptions::default().with_data_inlining_row_limit(2);
+    let table_writer = DuckLakeTableWriter::new(
+        writer,
+        Arc::new(LocalFileSystem::new()) as Arc<dyn object_store::ObjectStore>,
+    )
+    .unwrap()
+    .with_options(&options);
+    let mut transaction = table_writer.transaction();
+    transaction
+        .stage_write(
+            "public",
+            "data",
+            schema().as_ref(),
+            WriteMode::Append,
+            &[RecordBatch::try_new(
+                schema(),
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3])),
+                    Arc::new(Int32Array::from(vec![10, 20, 30])),
+                ],
+            )
+            .unwrap()],
+        )
+        .await
+        .unwrap();
+    transaction
+        .stage_write(
+            "public",
+            "coverage",
+            schema().as_ref(),
+            WriteMode::Append,
+            &[RecordBatch::try_new(
+                schema(),
+                vec![Arc::new(Int32Array::from(vec![1])), Arc::new(Int32Array::from(vec![10]))],
+            )
+            .unwrap()],
+        )
+        .await
+        .unwrap();
+
+    let results = transaction.commit().await.unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].snapshot_id, results[1].snapshot_id);
+    assert_eq!(results[0].files_written, 1);
+    assert_eq!(results[1].files_written, 0);
+    let data_snapshots: Vec<i64> = sqlx::query_scalar(
+        "SELECT DISTINCT begin_snapshot FROM ducklake_data_file WHERE table_id = $1",
+    )
+    .bind(results[0].table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let inline_table: String = sqlx::query_scalar(
+        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+    )
+    .bind(results[1].table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let inline_snapshots: Vec<i64> = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+        "SELECT DISTINCT begin_snapshot FROM \"{}\"",
+        inline_table.replace('"', "\"\"")
+    )))
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(data_snapshots, vec![results[0].snapshot_id]);
+    assert_eq!(inline_snapshots, vec![results[0].snapshot_id]);
+    let changes: String = sqlx::query_scalar(
+        "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
+    )
+    .bind(results[0].snapshot_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        changes,
+        format!(
+            "inserted_into_table:{},inserted_into_table:{}",
+            results[0].table_id, results[1].table_id
+        )
+    );
 }
 
 /// The `(id, val)` table schema used throughout.

--- a/tests/it/append_with_deletes_postgres_tests.rs
+++ b/tests/it/append_with_deletes_postgres_tests.rs
@@ -19,8 +19,8 @@ use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
     ColumnDef, DeleteFileEntry, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter,
-    DuckLakeWriteOptions, MetadataProvider, MetadataWriter, MulticatalogManager,
-    MulticatalogProvider, PostgresMetadataWriter, WriteMode,
+    MetadataProvider, MetadataWriter, MulticatalogManager, MulticatalogProvider,
+    PostgresMetadataWriter, WriteMode,
 };
 use object_store::local::LocalFileSystem;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -43,9 +43,12 @@ async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)
     Ok((pool, container))
 }
 
+#[rstest::rstest]
+#[case::existing_tables(true)]
+#[case::reserved_tables(false)]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
-async fn multi_table_write_commits_parquet_and_inline_rows_postgres() {
+async fn multi_table_write_commits_two_tables_postgres(#[case] existing: bool) {
     let (pool, _container) = spin_up_postgres().await.unwrap();
     let manager = MulticatalogManager::new(pool.clone());
     let catalog_id = manager.create_catalog("pg_multi_table").await.unwrap();
@@ -57,30 +60,30 @@ async fn multi_table_write_commits_parquet_and_inline_rows_postgres() {
         ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
         ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
     ];
-    for table_name in ["data", "coverage"] {
-        let setup = writer
-            .begin_write_transaction("public", table_name, &columns, WriteMode::Append)
-            .unwrap();
-        writer
-            .publish_snapshot(
-                setup.table_id,
-                "public",
-                table_name,
-                setup.snapshot_id,
-                WriteMode::Append,
-                setup.base_snapshot_id,
-                &columns,
-                &setup.column_ids,
-            )
-            .unwrap();
+    if existing {
+        for table_name in ["data", "coverage"] {
+            let setup = writer
+                .begin_write_transaction("public", table_name, &columns, WriteMode::Append)
+                .unwrap();
+            writer
+                .publish_snapshot(
+                    setup.table_id,
+                    "public",
+                    table_name,
+                    setup.snapshot_id,
+                    WriteMode::Append,
+                    setup.base_snapshot_id,
+                    &columns,
+                    &setup.column_ids,
+                )
+                .unwrap();
+        }
     }
-    let options = DuckLakeWriteOptions::default().with_data_inlining_row_limit(2);
     let table_writer = DuckLakeTableWriter::new(
         writer,
         Arc::new(LocalFileSystem::new()) as Arc<dyn object_store::ObjectStore>,
     )
-    .unwrap()
-    .with_options(&options);
+    .unwrap();
     let mut transaction = table_writer.transaction();
     transaction
         .stage_write(
@@ -119,7 +122,7 @@ async fn multi_table_write_commits_parquet_and_inline_rows_postgres() {
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].snapshot_id, results[1].snapshot_id);
     assert_eq!(results[0].files_written, 1);
-    assert_eq!(results[1].files_written, 0);
+    assert_eq!(results[1].files_written, 1);
     let data_snapshots: Vec<i64> = sqlx::query_scalar(
         "SELECT DISTINCT begin_snapshot FROM ducklake_data_file WHERE table_id = $1",
     )
@@ -127,22 +130,15 @@ async fn multi_table_write_commits_parquet_and_inline_rows_postgres() {
     .fetch_all(&pool)
     .await
     .unwrap();
-    let inline_table: String = sqlx::query_scalar(
-        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = $1",
+    let second_snapshots: Vec<i64> = sqlx::query_scalar(
+        "SELECT DISTINCT begin_snapshot FROM ducklake_data_file WHERE table_id = $1",
     )
     .bind(results[1].table_id)
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    let inline_snapshots: Vec<i64> = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
-        "SELECT DISTINCT begin_snapshot FROM \"{}\"",
-        inline_table.replace('"', "\"\"")
-    )))
     .fetch_all(&pool)
     .await
     .unwrap();
     assert_eq!(data_snapshots, vec![results[0].snapshot_id]);
-    assert_eq!(inline_snapshots, vec![results[0].snapshot_id]);
+    assert_eq!(second_snapshots, vec![results[0].snapshot_id]);
     let changes: String = sqlx::query_scalar(
         "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
     )
@@ -150,13 +146,18 @@ async fn multi_table_write_commits_parquet_and_inline_rows_postgres() {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(
-        changes,
-        format!(
-            "inserted_into_table:{},inserted_into_table:{}",
-            results[0].table_id, results[1].table_id
-        )
+    let inserts = format!(
+        "inserted_into_table:{},inserted_into_table:{}",
+        results[0].table_id, results[1].table_id
     );
+    let expected = if existing {
+        inserts
+    } else {
+        format!(
+            "created_schema:\"public\",created_table:\"public\".\"data\",created_table:\"public\".\"coverage\",{inserts}"
+        )
+    };
+    assert_eq!(changes, expected);
 }
 
 /// The `(id, val)` table schema used throughout.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -42,6 +42,7 @@ mod inlined_delete_tests;
 mod insert_partitioning_tests;
 mod keyed_mutation_after_compaction_tests;
 mod maintenance_sqlite_tests;
+mod metadata_contract_tests;
 mod missing_delete_file_tests;
 mod multicatalog_hardening_tests;
 mod multicatalog_postgres_tests;

--- a/tests/it/metadata_contract_tests.rs
+++ b/tests/it/metadata_contract_tests.rs
@@ -1,0 +1,479 @@
+#![cfg(all(feature = "write-sqlite", feature = "write-postgres"))]
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use arrow::array::{ArrayRef, Int64Array};
+use arrow::record_batch::RecordBatch;
+use datafusion_ducklake::maintenance::{
+    CleanupCriteria, ExpireCriteria, cleanup_old_files_duckdb, delete_orphaned_files_duckdb,
+};
+use datafusion_ducklake::{
+    ColumnDef, DataFileInfo, DuckLakeError, DuckLakeTableWriter, DuckLakeWriteOptions,
+    DuckdbMetadataProvider, DuckdbMetadataWriter, MetadataProvider, MetadataWriter,
+    MulticatalogManager, SnapshotCommitMetadata, SqliteMetadataProvider, SqliteMetadataWriter,
+    WriteMode,
+};
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+fn columns() -> Vec<ColumnDef> {
+    vec![ColumnDef::new("value", "BIGINT", false).unwrap()]
+}
+
+fn batch(values: Vec<i64>) -> RecordBatch {
+    RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(values)) as ArrayRef,
+    )])
+    .unwrap()
+}
+
+fn write_contract_data(writer: &dyn MetadataWriter, identity: &str) -> (i64, i64) {
+    let setup = writer
+        .begin_write_transaction("main", "events", &columns(), WriteMode::Replace)
+        .unwrap();
+    let commit = writer
+        .register_data_file_with_commit_metadata(
+            setup.table_id,
+            "main",
+            "events",
+            setup.snapshot_id,
+            &DataFileInfo::new("events.parquet", 128, 1),
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns(),
+            &setup.column_ids,
+            &SnapshotCommitMetadata::new()
+                .with_author("contract")
+                .with_message("metadata contract")
+                .with_extra_info(identity),
+            None,
+        )
+        .unwrap();
+    (setup.table_id, commit.snapshot_id)
+}
+
+fn assert_metadata_contract(
+    provider: &dyn MetadataProvider,
+    writer: &dyn MetadataWriter,
+    identity: &str,
+    table_id: i64,
+    snapshot_id: i64,
+) {
+    let changes = provider.list_snapshot_changes().unwrap();
+    let change = changes
+        .iter()
+        .find(|change| change.snapshot_id == snapshot_id)
+        .unwrap();
+    assert_eq!(change.author.as_deref(), Some("contract"));
+    assert_eq!(change.commit_message.as_deref(), Some("metadata contract"));
+    assert_eq!(change.commit_extra_info.as_deref(), Some(identity));
+    assert_eq!(
+        provider
+            .find_snapshot_by_commit_extra_info(identity)
+            .unwrap(),
+        Some(snapshot_id),
+    );
+
+    writer
+        .set_global_setting("data_inlining_row_limit", "17")
+        .unwrap();
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, None)
+            .unwrap()
+            .get("data_inlining_row_limit")
+            .map(String::as_str),
+        Some("17"),
+    );
+    writer
+        .set_table_setting(table_id, "data_inlining_row_limit", "42")
+        .unwrap();
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, Some(table_id))
+            .unwrap()
+            .get("data_inlining_row_limit")
+            .map(String::as_str),
+        Some("42"),
+    );
+
+    let called = AtomicBool::new(false);
+    writer
+        .with_commit_lock(
+            identity,
+            Box::new(|| {
+                called.store(true, Ordering::SeqCst);
+                Ok(())
+            }),
+        )
+        .unwrap();
+    assert!(called.load(Ordering::SeqCst));
+
+    let error = writer
+        .with_commit_lock(
+            identity,
+            Box::new(|| Err(DuckLakeError::Internal("operation failed".to_string()))),
+        )
+        .unwrap_err();
+    assert_eq!(error.to_string(), "Internal error: operation failed");
+
+    // The failed operation released the lock: re-acquiring under the same
+    // identity succeeds.
+    writer
+        .with_commit_lock(identity, Box::new(|| Ok(())))
+        .unwrap();
+}
+
+#[tokio::test]
+async fn duckdb_metadata_contract() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("catalog.ducklake");
+    let writer = DuckdbMetadataWriter::new_with_init(path.to_str().unwrap()).unwrap();
+    writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
+    let (table_id, snapshot_id) = write_contract_data(&writer, "duckdb-contract");
+
+    writer
+        .set_global_setting("data_inlining_row_limit", "17")
+        .unwrap();
+    writer
+        .set_table_setting(table_id, "data_inlining_row_limit", "42")
+        .unwrap();
+    let called = AtomicBool::new(false);
+    writer
+        .with_commit_lock(
+            "duckdb-contract",
+            Box::new(|| {
+                called.store(true, Ordering::SeqCst);
+                Ok(())
+            }),
+        )
+        .unwrap();
+    assert!(called.load(Ordering::SeqCst));
+    let error = writer
+        .with_commit_lock(
+            "duckdb-contract",
+            Box::new(|| Err(DuckLakeError::Internal("operation failed".to_string()))),
+        )
+        .unwrap_err();
+    assert_eq!(error.to_string(), "Internal error: operation failed");
+    writer
+        .with_commit_lock("duckdb-contract", Box::new(|| Ok(())))
+        .unwrap();
+
+    let setup = writer
+        .begin_write_transaction("main", "events", &columns(), WriteMode::Append)
+        .unwrap();
+    let inline_commit = writer
+        .register_inlined_data(
+            setup.table_id,
+            "main",
+            "events",
+            setup.snapshot_id,
+            &[batch(vec![99])],
+            WriteMode::Append,
+            setup.base_snapshot_id,
+            &columns(),
+            &setup.column_ids,
+            &SnapshotCommitMetadata::new(),
+            Some(setup.base_snapshot_id),
+        )
+        .unwrap();
+    let shared_provider = writer.metadata_provider();
+    assert_eq!(
+        shared_provider.get_current_snapshot().unwrap(),
+        inline_commit.snapshot_id,
+    );
+    drop(shared_provider);
+    drop(writer);
+
+    let provider = DuckdbMetadataProvider::new(path.to_str().unwrap()).unwrap();
+    let changes = provider.list_snapshot_changes().unwrap();
+    let change = changes
+        .iter()
+        .find(|change| change.snapshot_id == snapshot_id)
+        .unwrap();
+    assert_eq!(change.author.as_deref(), Some("contract"));
+    assert_eq!(change.commit_message.as_deref(), Some("metadata contract"));
+    assert_eq!(change.commit_extra_info.as_deref(), Some("duckdb-contract"));
+    assert_eq!(
+        provider
+            .find_snapshot_by_commit_extra_info("duckdb-contract")
+            .unwrap(),
+        Some(snapshot_id),
+    );
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, None)
+            .unwrap()
+            .get("data_inlining_row_limit")
+            .map(String::as_str),
+        Some("17"),
+    );
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, Some(table_id))
+            .unwrap()
+            .get("data_inlining_row_limit")
+            .map(String::as_str),
+        Some("42"),
+    );
+    let table_columns = provider
+        .get_table_structure(table_id, inline_commit.snapshot_id)
+        .unwrap();
+    let inlined = provider
+        .get_inlined_data_with_row_ids(table_id, inline_commit.snapshot_id, &table_columns)
+        .unwrap();
+    assert_eq!(inlined.len(), 1);
+    assert_eq!(inlined[0].row_ids, vec![1]);
+    assert_eq!(inlined[0].begin_snapshots, vec![inline_commit.snapshot_id],);
+    assert_eq!(
+        inlined[0]
+            .batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values(),
+        &[99],
+    );
+}
+
+#[tokio::test]
+async fn duckdb_commit_lock_child() {
+    let Ok(path) = std::env::var("DUCKLAKE_CRASH_LOCK_PATH") else {
+        return;
+    };
+    let writer = DuckdbMetadataWriter::new(path).unwrap();
+    writer
+        .with_commit_lock("crashed-holder", Box::new(|| std::process::exit(17)))
+        .unwrap();
+}
+
+#[tokio::test]
+async fn duckdb_commit_lock_survives_crashed_holder() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("crash-lock.ducklake");
+    drop(DuckdbMetadataWriter::new_with_init(path.to_str().unwrap()).unwrap());
+    let status = Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "metadata_contract_tests::duckdb_commit_lock_child", "--nocapture"])
+        .env("DUCKLAKE_CRASH_LOCK_PATH", path.as_os_str())
+        .status()
+        .unwrap();
+    assert_eq!(status.code(), Some(17));
+
+    let writer = DuckdbMetadataWriter::new(path.to_str().unwrap()).unwrap();
+    writer
+        .with_commit_lock("crashed-holder", Box::new(|| Ok(())))
+        .unwrap();
+}
+
+#[tokio::test]
+async fn duckdb_maintenance_contract() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("maintenance.ducklake");
+    let data_path = temp.path().join("data");
+    let table_path = data_path.join("main").join("events");
+    std::fs::create_dir_all(&table_path).unwrap();
+    let writer = DuckdbMetadataWriter::new_with_init(path.to_str().unwrap()).unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let first = writer
+        .begin_write_transaction("main", "events", &columns(), WriteMode::Replace)
+        .unwrap();
+    let first_commit = writer
+        .register_data_file(
+            first.table_id,
+            "main",
+            "events",
+            first.snapshot_id,
+            &DataFileInfo::new("first.parquet", 5, 1),
+            WriteMode::Replace,
+            first.base_snapshot_id,
+            &columns(),
+            &first.column_ids,
+        )
+        .unwrap();
+    std::fs::write(table_path.join("first.parquet"), b"first").unwrap();
+    let second = writer
+        .begin_write_transaction("main", "events", &columns(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            second.table_id,
+            "main",
+            "events",
+            second.snapshot_id,
+            &DataFileInfo::new("second.parquet", 6, 1),
+            WriteMode::Replace,
+            second.base_snapshot_id,
+            &columns(),
+            &second.column_ids,
+        )
+        .unwrap();
+    std::fs::write(table_path.join("second.parquet"), b"second").unwrap();
+    assert_eq!(
+        writer
+            .expire_snapshots(ExpireCriteria::Versions(vec![first_commit.snapshot_id]))
+            .unwrap()
+            .len(),
+        1,
+    );
+    let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let dry_run = cleanup_old_files_duckdb(
+        &writer,
+        Arc::clone(&object_store),
+        CleanupCriteria::All,
+        true,
+    )
+    .await
+    .unwrap();
+    assert_eq!(dry_run.len(), 1);
+    assert!(table_path.join("first.parquet").exists());
+    let deleted = cleanup_old_files_duckdb(
+        &writer,
+        Arc::clone(&object_store),
+        CleanupCriteria::All,
+        false,
+    )
+    .await
+    .unwrap();
+    assert_eq!(deleted, dry_run);
+    assert!(!table_path.join("first.parquet").exists());
+    assert!(table_path.join("second.parquet").exists());
+
+    let orphan = table_path.join("orphan.parquet");
+    std::fs::write(&orphan, b"orphan").unwrap();
+    let deleted = delete_orphaned_files_duckdb(&writer, object_store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert!(deleted[0].ends_with("main/events/orphan.parquet"));
+    assert!(!orphan.exists());
+    assert!(table_path.join("second.parquet").exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sqlite_metadata_contract() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("catalog.sqlite");
+    let url = format!("sqlite:{}?mode=rwc", path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&url).await.unwrap();
+    writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
+    let provider = SqliteMetadataProvider::new(&url).await.unwrap();
+    let (table_id, snapshot_id) = write_contract_data(&writer, "sqlite-contract");
+
+    assert_metadata_contract(&provider, &writer, "sqlite-contract", table_id, snapshot_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_metadata_contract() {
+    let container = Postgres::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let manager = MulticatalogManager::connect(&url, 5).await.unwrap();
+    let catalog_id = manager.create_catalog("metadata_contract").await.unwrap();
+    let writer = manager.writer(catalog_id).await.unwrap();
+    writer.set_data_path("/tmp/metadata-contract").unwrap();
+    let provider = manager.provider(catalog_id).await.unwrap();
+    let (table_id, snapshot_id) = write_contract_data(&writer, "postgres-contract");
+
+    assert_metadata_contract(
+        &provider,
+        &writer,
+        "postgres-contract",
+        table_id,
+        snapshot_id,
+    );
+    let second_id = manager
+        .create_catalog("metadata_contract_two")
+        .await
+        .unwrap();
+    let second_writer = manager.writer(second_id).await.unwrap();
+    second_writer
+        .set_global_setting("data_inlining_row_limit", "99")
+        .unwrap();
+    let second_provider = manager.provider(second_id).await.unwrap();
+    assert_eq!(
+        provider
+            .get_metadata_settings(None, None)
+            .unwrap()
+            .get("data_inlining_row_limit")
+            .map(String::as_str),
+        Some("17"),
+    );
+    assert_eq!(
+        second_provider
+            .get_metadata_settings(None, None)
+            .unwrap()
+            .get("data_inlining_row_limit")
+            .map(String::as_str),
+        Some("99"),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_flush_inlined_data() {
+    let container = Postgres::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let manager = MulticatalogManager::connect(&url, 5).await.unwrap();
+    let catalog_id = manager.create_catalog("flush_contract").await.unwrap();
+    let writer = Arc::new(manager.writer(catalog_id).await.unwrap());
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let options = DuckLakeWriteOptions::default().with_data_inlining_row_limit(10);
+    let table_writer = DuckLakeTableWriter::new(writer.clone(), Arc::clone(&object_store))
+        .unwrap()
+        .with_options(&options);
+    let inline_write = table_writer
+        .append_table("main", "events", &[batch(vec![5, 8])])
+        .await
+        .unwrap();
+    let provider = manager.provider(catalog_id).await.unwrap();
+    let schema = provider
+        .get_schema_by_name("main", inline_write.snapshot_id)
+        .unwrap()
+        .unwrap();
+    let table = provider
+        .get_table_by_name(schema.schema_id, "events", inline_write.snapshot_id)
+        .unwrap()
+        .unwrap();
+    let columns = provider
+        .get_table_structure(table.table_id, inline_write.snapshot_id)
+        .unwrap();
+    let inlined = provider
+        .get_inlined_data_with_row_ids(table.table_id, inline_write.snapshot_id, &columns)
+        .unwrap();
+    let flush_writer = DuckLakeTableWriter::new(writer, object_store).unwrap();
+    let flushed = flush_writer
+        .flush_inlined_data("main", "events", &inlined, inline_write.snapshot_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(flushed.records_written, 2);
+    assert_eq!(flushed.files_written, 1);
+    assert!(
+        provider
+            .get_inlined_data_with_row_ids(table.table_id, flushed.snapshot_id, &columns)
+            .unwrap()
+            .is_empty(),
+    );
+    assert_eq!(
+        provider
+            .get_inlined_data_with_row_ids(table.table_id, inline_write.snapshot_id, &columns,)
+            .unwrap()
+            .iter()
+            .map(|data| data.batch.num_rows())
+            .sum::<usize>(),
+        2,
+    );
+}

--- a/tests/it/metadata_contract_tests.rs
+++ b/tests/it/metadata_contract_tests.rs
@@ -1,29 +1,49 @@
-#![cfg(all(feature = "write-sqlite", feature = "write-postgres"))]
+#![cfg(feature = "write-sqlite")]
+#[cfg(feature = "write-duckdb")]
 use std::process::Command;
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use arrow::array::{ArrayRef, Int64Array};
 use arrow::record_batch::RecordBatch;
+#[cfg(feature = "write-duckdb")]
+use datafusion::prelude::SessionContext;
+#[cfg(feature = "write-duckdb")]
+use datafusion_ducklake::DuckLakeCatalog;
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
+use datafusion_ducklake::DuckLakeTableWriter;
+#[cfg(feature = "write-postgres")]
+use datafusion_ducklake::MulticatalogManager;
+#[cfg(feature = "write-duckdb")]
 use datafusion_ducklake::maintenance::{
     CleanupCriteria, ExpireCriteria, cleanup_old_files_duckdb, delete_orphaned_files_duckdb,
 };
 use datafusion_ducklake::{
-    ColumnDef, DataFileInfo, DuckLakeError, DuckLakeTableWriter, DuckLakeWriteOptions,
-    DuckdbMetadataProvider, DuckdbMetadataWriter, MetadataProvider, MetadataWriter,
-    MulticatalogManager, SnapshotCommitMetadata, SqliteMetadataProvider, SqliteMetadataWriter,
+    ColumnDef, DataFileInfo, DuckLakeError, MetadataProvider, MetadataWriter,
+    SnapshotChangeMetadata, SnapshotCommitMetadata, SqliteMetadataProvider, SqliteMetadataWriter,
     WriteMode,
 };
+#[cfg(feature = "write-duckdb")]
+use datafusion_ducklake::{DuckdbMetadataProvider, DuckdbMetadataWriter};
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use object_store::ObjectStore;
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use object_store::local::LocalFileSystem;
+#[cfg(feature = "write-duckdb")]
+use std::slice::from_ref;
 use tempfile::TempDir;
+#[cfg(feature = "write-postgres")]
 use testcontainers::runners::AsyncRunner;
+#[cfg(feature = "write-postgres")]
 use testcontainers_modules::postgres::Postgres;
 
 fn columns() -> Vec<ColumnDef> {
     vec![ColumnDef::new("value", "BIGINT", false).unwrap()]
 }
 
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 fn batch(values: Vec<i64>) -> RecordBatch {
     RecordBatch::try_from_iter(vec![(
         "value",
@@ -129,6 +149,7 @@ fn assert_metadata_contract(
         .unwrap();
 }
 
+#[cfg(feature = "write-duckdb")]
 #[tokio::test]
 async fn duckdb_metadata_contract() {
     let temp = TempDir::new().unwrap();
@@ -184,6 +205,15 @@ async fn duckdb_metadata_contract() {
         )
         .unwrap();
     let shared_provider = writer.metadata_provider();
+    assert_eq!(
+        shared_provider
+            .list_snapshot_changes()
+            .unwrap()
+            .last()
+            .unwrap()
+            .changes_made,
+        Some(format!("inlined_insert:{table_id}"))
+    );
     assert_eq!(
         shared_provider.get_current_snapshot().unwrap(),
         inline_commit.snapshot_id,
@@ -243,6 +273,7 @@ async fn duckdb_metadata_contract() {
     );
 }
 
+#[cfg(feature = "write-duckdb")]
 #[tokio::test]
 async fn duckdb_commit_lock_child() {
     let Ok(path) = std::env::var("DUCKLAKE_CRASH_LOCK_PATH") else {
@@ -254,6 +285,7 @@ async fn duckdb_commit_lock_child() {
         .unwrap();
 }
 
+#[cfg(feature = "write-duckdb")]
 #[tokio::test]
 async fn duckdb_commit_lock_survives_crashed_holder() {
     let temp = TempDir::new().unwrap();
@@ -272,6 +304,7 @@ async fn duckdb_commit_lock_survives_crashed_holder() {
         .unwrap();
 }
 
+#[cfg(feature = "write-duckdb")]
 #[tokio::test]
 async fn duckdb_maintenance_contract() {
     let temp = TempDir::new().unwrap();
@@ -369,6 +402,7 @@ async fn sqlite_metadata_contract() {
     assert_metadata_contract(&provider, &writer, "sqlite-contract", table_id, snapshot_id);
 }
 
+#[cfg(feature = "write-postgres")]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn postgres_metadata_contract() {
@@ -377,6 +411,11 @@ async fn postgres_metadata_contract() {
     let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
     let manager = MulticatalogManager::connect(&url, 5).await.unwrap();
     let catalog_id = manager.create_catalog("metadata_contract").await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+    sqlx::query("DROP TABLE ducklake_inlined_data_tables")
+        .execute(&pool)
+        .await
+        .unwrap();
     let writer = manager.writer(catalog_id).await.unwrap();
     writer.set_data_path("/tmp/metadata-contract").unwrap();
     let provider = manager.provider(catalog_id).await.unwrap();
@@ -416,6 +455,7 @@ async fn postgres_metadata_contract() {
     );
 }
 
+#[cfg(feature = "write-postgres")]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn postgres_flush_inlined_data() {
@@ -430,13 +470,23 @@ async fn postgres_flush_inlined_data() {
     std::fs::create_dir_all(&data_path).unwrap();
     writer.set_data_path(data_path.to_str().unwrap()).unwrap();
     let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
-    let options = DuckLakeWriteOptions::default().with_data_inlining_row_limit(10);
-    let table_writer = DuckLakeTableWriter::new(writer.clone(), Arc::clone(&object_store))
-        .unwrap()
-        .with_options(&options);
-    let inline_write = table_writer
-        .append_table("main", "events", &[batch(vec![5, 8])])
-        .await
+    let setup = writer
+        .begin_write_transaction("main", "events", &columns(), WriteMode::Append)
+        .unwrap();
+    let inline_write = writer
+        .register_inlined_data(
+            setup.table_id,
+            "main",
+            "events",
+            setup.snapshot_id,
+            &[batch(vec![5, 8])],
+            WriteMode::Append,
+            setup.base_snapshot_id,
+            &columns(),
+            &setup.column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
         .unwrap();
     let provider = manager.provider(catalog_id).await.unwrap();
     let schema = provider
@@ -459,6 +509,15 @@ async fn postgres_flush_inlined_data() {
         .await
         .unwrap()
         .unwrap();
+    assert_eq!(
+        provider
+            .list_snapshot_changes()
+            .unwrap()
+            .last()
+            .unwrap()
+            .changes_made,
+        Some(format!("inline_flush:{}", table.table_id))
+    );
     assert_eq!(flushed.records_written, 2);
     assert_eq!(flushed.files_written, 1);
     assert!(
@@ -475,5 +534,165 @@ async fn postgres_flush_inlined_data() {
             .map(|data| data.batch.num_rows())
             .sum::<usize>(),
         2,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sqlite_snapshot_changes_preserve_null_and_missing_ledger_rows() {
+    let temp = TempDir::new().unwrap();
+    let url = format!(
+        "sqlite:{}?mode=rwc",
+        temp.path().join("catalog.sqlite").display()
+    );
+    let writer = SqliteMetadataWriter::new_with_init(&url).await.unwrap();
+    let first = writer.create_snapshot().unwrap();
+    let second = writer.create_snapshot().unwrap();
+    let pool = sqlx::SqlitePool::connect(&url).await.unwrap();
+    sqlx::query("DELETE FROM ducklake_snapshot_changes WHERE snapshot_id = ?")
+        .bind(second)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE ducklake_snapshot SET snapshot_time = '2026-01-02 03:04:05.123456'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let provider = SqliteMetadataProvider::new(&url).await.unwrap();
+    let snapshots = provider.list_snapshots().unwrap();
+    let changes = provider.list_snapshot_changes().unwrap();
+    let expected: Vec<_> = snapshots
+        .into_iter()
+        .map(|snapshot| SnapshotChangeMetadata {
+            snapshot_id: snapshot.snapshot_id,
+            timestamp: snapshot.timestamp,
+            changes_made: None,
+            author: None,
+            commit_message: None,
+            commit_extra_info: None,
+        })
+        .collect();
+    assert_eq!(second, first + 1);
+    assert_eq!(changes, expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sqlite_reopens_legacy_catalog_without_schema_initialization() {
+    let temp = TempDir::new().unwrap();
+    let url = format!(
+        "sqlite:{}?mode=rwc",
+        temp.path().join("catalog.sqlite").display()
+    );
+    let writer = SqliteMetadataWriter::new_with_init(&url).await.unwrap();
+    let (table_id, _) = write_contract_data(&writer, "legacy");
+    let empty_snapshot = writer.create_snapshot().unwrap();
+    drop(writer);
+    let pool = sqlx::SqlitePool::connect(&url).await.unwrap();
+    sqlx::query("DROP TABLE ducklake_inlined_data_tables")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE ducklake_snapshot_changes RENAME TO legacy_changes")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("CREATE TABLE ducklake_snapshot_changes (snapshot_id INTEGER PRIMARY KEY, changes_made VARCHAR NOT NULL, author VARCHAR, commit_message VARCHAR, commit_extra_info VARCHAR)").execute(&pool).await.unwrap();
+    sqlx::query("INSERT INTO ducklake_snapshot_changes SELECT snapshot_id, COALESCE(changes_made, ''), author, commit_message, commit_extra_info FROM legacy_changes").execute(&pool).await.unwrap();
+    sqlx::query("DROP TABLE legacy_changes")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let writer = SqliteMetadataWriter::new(&url).await.unwrap();
+    let (replaced_table_id, replaced_snapshot) = write_contract_data(&writer, "replacement");
+    let removed = writer
+        .commit_truncate(table_id, "main", "events", replaced_snapshot)
+        .unwrap();
+    let provider = SqliteMetadataProvider::new(&url).await.unwrap();
+    let changes = provider.list_snapshot_changes().unwrap();
+    let migrated = changes
+        .iter()
+        .find(|change| change.snapshot_id == empty_snapshot)
+        .unwrap();
+    assert_eq!(replaced_table_id, table_id);
+    assert_eq!(removed, 1);
+    assert_eq!(migrated.changes_made, None);
+    assert_eq!(
+        provider
+            .get_inlined_data(
+                table_id,
+                provider.get_current_snapshot().unwrap(),
+                &provider
+                    .get_table_structure(table_id, provider.get_current_snapshot().unwrap())
+                    .unwrap()
+            )
+            .unwrap(),
+        Vec::<RecordBatch>::new()
+    );
+}
+
+#[cfg(feature = "write-duckdb")]
+#[tokio::test(flavor = "multi_thread")]
+async fn duckdb_multi_table_commit_reads_both_tables() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("catalog.ducklake");
+    let writer = Arc::new(DuckdbMetadataWriter::new_with_init(path.to_str().unwrap()).unwrap());
+    writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
+    let table_writer =
+        DuckLakeTableWriter::new(writer.clone(), Arc::new(LocalFileSystem::new())).unwrap();
+    let first = batch(vec![11, 23]);
+    let second = batch(vec![37]);
+    for (name, rows) in [("first", &first), ("second", &second)] {
+        table_writer
+            .append_table("main", name, from_ref(rows))
+            .await
+            .unwrap();
+    }
+    let mut transaction = table_writer.transaction();
+    for (name, rows) in [("first", &first), ("second", &second)] {
+        transaction
+            .stage_write(
+                "main",
+                name,
+                rows.schema().as_ref(),
+                WriteMode::Append,
+                from_ref(rows),
+            )
+            .await
+            .unwrap();
+    }
+    let results = transaction.commit().await.unwrap();
+    let provider = writer.metadata_provider();
+    let changes = provider.list_snapshot_changes().unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(DuckLakeCatalog::new(provider).unwrap()));
+    let actual = ctx.sql("SELECT value FROM test.main.first UNION ALL SELECT value FROM test.main.second ORDER BY value").await.unwrap().collect().await.unwrap();
+    let values: Vec<i64> = actual
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].snapshot_id, results[1].snapshot_id);
+    assert_eq!(
+        (results[0].files_written, results[0].records_written),
+        (1, 2)
+    );
+    assert_eq!(
+        (results[1].files_written, results[1].records_written),
+        (1, 1)
+    );
+    assert_eq!(values, vec![11, 11, 23, 23, 37, 37]);
+    assert_eq!(
+        changes.last().unwrap().changes_made,
+        Some(format!(
+            "inserted_into_table:{},inserted_into_table:{}",
+            results[0].table_id, results[1].table_id
+        ))
     );
 }

--- a/tests/it/metadata_contract_tests.rs
+++ b/tests/it/metadata_contract_tests.rs
@@ -8,9 +8,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use arrow::array::{ArrayRef, Int64Array};
 use arrow::record_batch::RecordBatch;
-#[cfg(feature = "write-duckdb")]
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use datafusion::prelude::SessionContext;
-#[cfg(feature = "write-duckdb")]
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use datafusion_ducklake::DuckLakeCatalog;
 #[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use datafusion_ducklake::DuckLakeTableWriter;
@@ -31,13 +31,22 @@ use datafusion_ducklake::{DuckdbMetadataProvider, DuckdbMetadataWriter};
 use object_store::ObjectStore;
 #[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use object_store::local::LocalFileSystem;
-#[cfg(feature = "write-duckdb")]
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
 use std::slice::from_ref;
 use tempfile::TempDir;
-#[cfg(feature = "write-postgres")]
+#[cfg(any(feature = "write-postgres", feature = "write-mysql"))]
 use testcontainers::runners::AsyncRunner;
 #[cfg(feature = "write-postgres")]
 use testcontainers_modules::postgres::Postgres;
+
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
+use datafusion_ducklake::WriteResult;
+#[cfg(feature = "write-mysql")]
+use datafusion_ducklake::{MySqlMetadataProvider, MySqlMetadataWriter};
+#[cfg(feature = "write-postgres")]
+use datafusion_ducklake::{PostgresMetadataProvider, PostgresSingleCatalogMetadataWriter};
+#[cfg(feature = "write-mysql")]
+use testcontainers_modules::mysql::Mysql;
 
 fn columns() -> Vec<ColumnDef> {
     vec![ColumnDef::new("value", "BIGINT", false).unwrap()]
@@ -83,7 +92,21 @@ fn assert_metadata_contract(
     identity: &str,
     table_id: i64,
     snapshot_id: i64,
+    test_global_settings: bool,
 ) {
+    let error = writer
+        .set_table_setting(table_id, "misspelled_option", "42")
+        .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Unsupported feature: unsupported table setting 'misspelled_option'"
+    );
+    assert_eq!(
+        provider
+            .find_snapshot_by_commit_extra_info(&identity.to_ascii_uppercase())
+            .unwrap(),
+        None
+    );
     let changes = provider.list_snapshot_changes().unwrap();
     let change = changes
         .iter()
@@ -99,19 +122,21 @@ fn assert_metadata_contract(
         Some(snapshot_id),
     );
 
+    if test_global_settings {
+        writer
+            .set_global_setting("data_inlining_row_limit", "17")
+            .unwrap();
+        assert_eq!(
+            provider
+                .get_metadata_settings(None, None)
+                .unwrap()
+                .get("data_inlining_row_limit")
+                .map(String::as_str),
+            Some("17"),
+        );
+    }
     writer
-        .set_global_setting("data_inlining_row_limit", "17")
-        .unwrap();
-    assert_eq!(
-        provider
-            .get_metadata_settings(None, None)
-            .unwrap()
-            .get("data_inlining_row_limit")
-            .map(String::as_str),
-        Some("17"),
-    );
-    writer
-        .set_table_setting(table_id, "data_inlining_row_limit", "42")
+        .set_table_setting(table_id, "DATA_INLINING_ROW_LIMIT", "42")
         .unwrap();
     assert_eq!(
         provider
@@ -127,6 +152,7 @@ fn assert_metadata_contract(
         .with_commit_lock(
             identity,
             Box::new(|| {
+                assert_eq!(provider.get_current_snapshot()?, snapshot_id);
                 called.store(true, Ordering::SeqCst);
                 Ok(())
             }),
@@ -399,7 +425,24 @@ async fn sqlite_metadata_contract() {
     let provider = SqliteMetadataProvider::new(&url).await.unwrap();
     let (table_id, snapshot_id) = write_contract_data(&writer, "sqlite-contract");
 
-    assert_metadata_contract(&provider, &writer, "sqlite-contract", table_id, snapshot_id);
+    assert_metadata_contract(
+        &provider,
+        &writer,
+        "sqlite-contract",
+        table_id,
+        snapshot_id,
+        true,
+    );
+    let pool = sqlx::SqlitePool::connect(&url).await.unwrap();
+    sqlx::query("UPDATE ducklake_table SET end_snapshot = ? WHERE table_id = ?")
+        .bind(snapshot_id)
+        .bind(table_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(
+        matches!(writer.set_table_setting(table_id, "auto_compact", "true"), Err(DuckLakeError::TableNotFound(id)) if id == table_id.to_string())
+    );
 }
 
 #[cfg(feature = "write-postgres")]
@@ -427,6 +470,7 @@ async fn postgres_metadata_contract() {
         "postgres-contract",
         table_id,
         snapshot_id,
+        true,
     );
     let second_id = manager
         .create_catalog("metadata_contract_two")
@@ -630,36 +674,16 @@ async fn sqlite_reopens_legacy_catalog_without_schema_initialization() {
 }
 
 #[cfg(feature = "write-duckdb")]
+#[rstest::rstest]
+#[case::existing_tables(true)]
+#[case::new_tables(false)]
 #[tokio::test(flavor = "multi_thread")]
-async fn duckdb_multi_table_commit_reads_both_tables() {
+async fn duckdb_multi_table_commit_reads_both_tables(#[case] existing: bool) {
     let temp = TempDir::new().unwrap();
     let path = temp.path().join("catalog.ducklake");
     let writer = Arc::new(DuckdbMetadataWriter::new_with_init(path.to_str().unwrap()).unwrap());
     writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
-    let table_writer =
-        DuckLakeTableWriter::new(writer.clone(), Arc::new(LocalFileSystem::new())).unwrap();
-    let first = batch(vec![11, 23]);
-    let second = batch(vec![37]);
-    for (name, rows) in [("first", &first), ("second", &second)] {
-        table_writer
-            .append_table("main", name, from_ref(rows))
-            .await
-            .unwrap();
-    }
-    let mut transaction = table_writer.transaction();
-    for (name, rows) in [("first", &first), ("second", &second)] {
-        transaction
-            .stage_write(
-                "main",
-                name,
-                rows.schema().as_ref(),
-                WriteMode::Append,
-                from_ref(rows),
-            )
-            .await
-            .unwrap();
-    }
-    let results = transaction.commit().await.unwrap();
+    let results = commit_tables(writer.clone(), existing).await;
     let provider = writer.metadata_provider();
     let changes = provider.list_snapshot_changes().unwrap();
     let ctx = SessionContext::new();
@@ -687,12 +711,160 @@ async fn duckdb_multi_table_commit_reads_both_tables() {
         (results[1].files_written, results[1].records_written),
         (1, 1)
     );
-    assert_eq!(values, vec![11, 11, 23, 23, 37, 37]);
     assert_eq!(
-        changes.last().unwrap().changes_made,
-        Some(format!(
+        values,
+        if existing {
+            vec![11, 11, 23, 23, 37, 37]
+        } else {
+            vec![11, 23, 37]
+        }
+    );
+    let expected = if existing {
+        format!(
             "inserted_into_table:{},inserted_into_table:{}",
             results[0].table_id, results[1].table_id
-        ))
+        )
+    } else {
+        format!(
+            "created_schema:\"main\",created_table:\"main\".\"first\",inserted_into_table:{},created_table:\"main\".\"second\",inserted_into_table:{}",
+            results[0].table_id, results[1].table_id
+        )
+    };
+    assert_eq!(
+        changes.last().unwrap().changes_made.as_deref(),
+        Some(expected.as_str())
     );
+}
+
+#[cfg(feature = "write-postgres")]
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_single_metadata_contract() {
+    let container = Postgres::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let writer = PostgresSingleCatalogMetadataWriter::new_with_init(&url)
+        .await
+        .unwrap();
+    let provider = PostgresMetadataProvider::new(&url).await.unwrap();
+    let (table_id, snapshot) = write_contract_data(&writer, "single-contract");
+    assert_metadata_contract(
+        &provider,
+        &writer,
+        "single-contract",
+        table_id,
+        snapshot,
+        true,
+    );
+}
+
+#[cfg(feature = "write-mysql")]
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_metadata_contract() {
+    let container = Mysql::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(3306).await.unwrap();
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+    let writer = MySqlMetadataWriter::new_with_init(&url).await.unwrap();
+    let provider = MySqlMetadataProvider::new(&url).await.unwrap();
+    let (table_id, snapshot) = write_contract_data(&writer, "mysql-contract");
+    assert_metadata_contract(
+        &provider,
+        &writer,
+        "mysql-contract",
+        table_id,
+        snapshot,
+        false,
+    );
+}
+
+#[cfg(feature = "write-postgres")]
+#[rstest::rstest]
+#[case::existing_tables(true)]
+#[case::new_tables(false)]
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_single_multi_table_commit_reads_both_tables(#[case] existing: bool) {
+    let container = Postgres::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let writer = Arc::new(
+        PostgresSingleCatalogMetadataWriter::new_with_init(&url)
+            .await
+            .unwrap(),
+    );
+    let temp = TempDir::new().unwrap();
+    writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
+    let results = commit_tables(writer, existing).await;
+    let provider = PostgresMetadataProvider::new(&url).await.unwrap();
+    let changes = provider.list_snapshot_changes().unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(DuckLakeCatalog::new(provider).unwrap()));
+    let actual = ctx.sql("SELECT value FROM test.main.first UNION ALL SELECT value FROM test.main.second ORDER BY value").await.unwrap().collect().await.unwrap();
+    let values: Vec<i64> = actual
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    let expected = if existing {
+        format!(
+            "inserted_into_table:{},inserted_into_table:{}",
+            results[0].table_id, results[1].table_id
+        )
+    } else {
+        format!(
+            "created_schema:\"main\",created_table:\"main\".\"first\",inserted_into_table:{},created_table:\"main\".\"second\",inserted_into_table:{}",
+            results[0].table_id, results[1].table_id
+        )
+    };
+    assert_eq!(results[0].snapshot_id, results[1].snapshot_id);
+    assert_eq!(
+        values,
+        if existing {
+            vec![11, 11, 23, 23, 37, 37]
+        } else {
+            vec![11, 23, 37]
+        }
+    );
+    assert_eq!(
+        changes.last().unwrap().changes_made.as_deref(),
+        Some(expected.as_str())
+    );
+}
+
+#[cfg(any(feature = "write-duckdb", feature = "write-postgres"))]
+async fn commit_tables(writer: Arc<dyn MetadataWriter>, existing: bool) -> Vec<WriteResult> {
+    let table_writer =
+        DuckLakeTableWriter::new(writer.clone(), Arc::new(LocalFileSystem::new())).unwrap();
+    let first = batch(vec![11, 23]);
+    let second = batch(vec![37]);
+    if existing {
+        for (name, rows) in [("first", &first), ("second", &second)] {
+            table_writer
+                .append_table("main", name, from_ref(rows))
+                .await
+                .unwrap();
+        }
+    }
+    let mut transaction = table_writer.transaction();
+    for (name, rows) in [("first", &first), ("second", &second)] {
+        transaction
+            .stage_write(
+                "main",
+                name,
+                rows.schema().as_ref(),
+                WriteMode::Append,
+                from_ref(rows),
+            )
+            .await
+            .unwrap();
+    }
+    transaction.commit().await.unwrap()
 }

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -39,6 +39,64 @@ async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)
     Ok((pool, container))
 }
 
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn multicatalog_provider_reads_inlined_rows() {
+    use std::sync::Arc;
+
+    use arrow::array::{Array, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion_ducklake::metadata_provider::MetadataProvider;
+    use datafusion_ducklake::{DuckLakeWriteOptions, MulticatalogProvider};
+    use object_store::memory::InMemory;
+    use tempfile::TempDir;
+
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let manager = MulticatalogManager::new(pool.clone());
+    let catalog_id = manager.create_catalog("inline_read").await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    writer.set_data_path(temp.path().to_str().unwrap()).unwrap();
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int64Array::from(vec![7]))],
+    )
+    .unwrap();
+    let options = DuckLakeWriteOptions::default().with_data_inlining_row_limit(10);
+    let result = DuckLakeTableWriter::new(Arc::new(writer), Arc::new(InMemory::new()))
+        .unwrap()
+        .with_options(&options)
+        .write_table("main", "values", &[batch])
+        .await
+        .unwrap();
+    let provider = MulticatalogProvider::with_pool_and_id(pool, catalog_id)
+        .await
+        .unwrap();
+    let columns = provider
+        .get_table_structure(result.table_id, result.snapshot_id)
+        .unwrap();
+    let batches = provider
+        .get_inlined_data(result.table_id, result.snapshot_id, &columns)
+        .unwrap();
+    let values = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+
+    assert_eq!(result.files_written, 0);
+    assert_eq!(batches.len(), 1);
+    assert_eq!(values.values(), &[7]);
+}
+
 fn cols() -> Vec<ColumnDef> {
     vec![
         ColumnDef::new("id", "int64", false).unwrap(),

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -48,8 +48,7 @@ async fn multicatalog_provider_reads_inlined_rows() {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use datafusion_ducklake::metadata_provider::MetadataProvider;
-    use datafusion_ducklake::{DuckLakeWriteOptions, MulticatalogProvider};
-    use object_store::memory::InMemory;
+    use datafusion_ducklake::{MulticatalogProvider, SnapshotCommitMetadata};
     use tempfile::TempDir;
 
     let (pool, _container) = spin_up_postgres().await.unwrap();
@@ -70,12 +69,24 @@ async fn multicatalog_provider_reads_inlined_rows() {
         vec![Arc::new(Int64Array::from(vec![7]))],
     )
     .unwrap();
-    let options = DuckLakeWriteOptions::default().with_data_inlining_row_limit(10);
-    let result = DuckLakeTableWriter::new(Arc::new(writer), Arc::new(InMemory::new()))
-        .unwrap()
-        .with_options(&options)
-        .write_table("main", "values", &[batch])
-        .await
+    let columns = vec![ColumnDef::new("value", "BIGINT", false).unwrap()];
+    let setup = writer
+        .begin_write_transaction("main", "values", &columns, WriteMode::Append)
+        .unwrap();
+    let result = writer
+        .register_inlined_data(
+            setup.table_id,
+            "main",
+            "values",
+            setup.snapshot_id,
+            &[batch],
+            WriteMode::Append,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
         .unwrap();
     let provider = MulticatalogProvider::with_pool_and_id(pool, catalog_id)
         .await
@@ -92,7 +103,6 @@ async fn multicatalog_provider_reads_inlined_rows() {
         .downcast_ref::<Int64Array>()
         .unwrap();
 
-    assert_eq!(result.files_written, 0);
     assert_eq!(batches.len(), 1);
     assert_eq!(values.values(), &[7]);
 }

--- a/tests/it/mysql_metadata_writer_test.rs
+++ b/tests/it/mysql_metadata_writer_test.rs
@@ -16,11 +16,14 @@ use datafusion_ducklake::maintenance::ExpireCriteria;
 use datafusion_ducklake::metadata_writer::InlinedRowRef;
 use datafusion_ducklake::{
     ColumnDef, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
-    DeleteFileEntry, DeleteFileInfo, MetadataProvider, MetadataWriter, MySqlMetadataProvider,
-    MySqlMetadataWriter, SnapshotCommitMetadata, SourceRetirement, WriteMode, WriteSetupResult,
+    DeleteFileEntry, DeleteFileInfo, DuckLakeTableWriter, DuckLakeWriteOptions, MetadataProvider,
+    MetadataWriter, MySqlMetadataProvider, MySqlMetadataWriter, SnapshotCommitMetadata,
+    SourceRetirement, WriteMode, WriteSetupResult,
 };
+use object_store::local::LocalFileSystem;
 use sqlx::{AssertSqlSafe, Row};
 use std::sync::Arc;
+use tempfile::TempDir;
 use testcontainers::ContainerAsync;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mysql::Mysql;
@@ -966,5 +969,110 @@ async fn mysql_unified_file_id_allocation_survives_mixed_paths() {
     assert_eq!(
         changes_made(&pool, compact_commit.snapshot_id).await,
         Some(format!("compacted_table:{}", setup.table_id))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_multi_table_write_commits_parquet_and_inline_rows() {
+    let container = Mysql::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(3306).await.unwrap();
+    let conn_str = format!("mysql://root@127.0.0.1:{port}/test");
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let writer = Arc::new(MySqlMetadataWriter::new_with_init(&conn_str).await.unwrap());
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let pool = sqlx::MySqlPool::connect(&conn_str).await.unwrap();
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let columns = vec![ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap()];
+    for table_name in ["data", "coverage"] {
+        let setup = writer
+            .begin_write_transaction("main", table_name, &columns, WriteMode::Append)
+            .unwrap();
+        writer
+            .publish_snapshot(
+                setup.table_id,
+                "main",
+                table_name,
+                setup.snapshot_id,
+                WriteMode::Append,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+            )
+            .unwrap();
+    }
+    let table_writer = DuckLakeTableWriter::new(writer, Arc::new(LocalFileSystem::new())).unwrap();
+    let mut transaction = table_writer.transaction();
+    transaction
+        .stage_write_with_options(
+            "main",
+            "data",
+            schema.as_ref(),
+            WriteMode::Append,
+            &[RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .unwrap()],
+            &DuckLakeWriteOptions::default().with_data_inlining_row_limit(0),
+        )
+        .await
+        .unwrap();
+    transaction
+        .stage_write_with_options(
+            "main",
+            "coverage",
+            schema.as_ref(),
+            WriteMode::Append,
+            &[RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])
+                .unwrap()],
+            &DuckLakeWriteOptions::default().with_data_inlining_row_limit(1),
+        )
+        .await
+        .unwrap();
+
+    let committed = transaction.commit().await.unwrap();
+
+    assert_eq!(committed.len(), 2);
+    assert_eq!(committed[0].snapshot_id, committed[1].snapshot_id);
+    assert_eq!(committed[0].files_written, 1);
+    assert_eq!(committed[1].files_written, 0);
+    let file_snapshot: i64 =
+        sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_data_file WHERE table_id = ?")
+            .bind(committed[0].table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let inline_table: String = sqlx::query_scalar(
+        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
+    )
+    .bind(committed[1].table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let inline_snapshot: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+        "SELECT begin_snapshot FROM `{}`",
+        inline_table.replace('`', "``")
+    )))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let changes: String = sqlx::query_scalar(
+        "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+    )
+    .bind(committed[0].snapshot_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(file_snapshot, committed[0].snapshot_id);
+    assert_eq!(inline_snapshot, committed[0].snapshot_id);
+    assert_eq!(
+        changes,
+        format!(
+            "inserted_into_table:{},inserted_into_table:{}",
+            committed[0].table_id, committed[1].table_id
+        )
     );
 }

--- a/tests/it/mysql_metadata_writer_test.rs
+++ b/tests/it/mysql_metadata_writer_test.rs
@@ -16,9 +16,9 @@ use datafusion_ducklake::maintenance::ExpireCriteria;
 use datafusion_ducklake::metadata_writer::InlinedRowRef;
 use datafusion_ducklake::{
     ColumnDef, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
-    DeleteFileEntry, DeleteFileInfo, DuckLakeTableWriter, DuckLakeWriteOptions, MetadataProvider,
-    MetadataWriter, MySqlMetadataProvider, MySqlMetadataWriter, SnapshotCommitMetadata,
-    SourceRetirement, WriteMode, WriteSetupResult,
+    DeleteFileEntry, DeleteFileInfo, DuckLakeTableWriter, MetadataProvider, MetadataWriter,
+    MySqlMetadataProvider, MySqlMetadataWriter, SnapshotCommitMetadata, SourceRetirement,
+    WriteMode, WriteSetupResult,
 };
 use object_store::local::LocalFileSystem;
 use sqlx::{AssertSqlSafe, Row};
@@ -974,7 +974,7 @@ async fn mysql_unified_file_id_allocation_survives_mixed_paths() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
-async fn mysql_multi_table_write_commits_parquet_and_inline_rows() {
+async fn mysql_multi_table_write_commits_two_tables() {
     let container = Mysql::default().start().await.unwrap();
     let port = container.get_host_port_ipv4(3306).await.unwrap();
     let conn_str = format!("mysql://root@127.0.0.1:{port}/test");
@@ -1006,7 +1006,7 @@ async fn mysql_multi_table_write_commits_parquet_and_inline_rows() {
     let table_writer = DuckLakeTableWriter::new(writer, Arc::new(LocalFileSystem::new())).unwrap();
     let mut transaction = table_writer.transaction();
     transaction
-        .stage_write_with_options(
+        .stage_write(
             "main",
             "data",
             schema.as_ref(),
@@ -1016,19 +1016,17 @@ async fn mysql_multi_table_write_commits_parquet_and_inline_rows() {
                 vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
             )
             .unwrap()],
-            &DuckLakeWriteOptions::default().with_data_inlining_row_limit(0),
         )
         .await
         .unwrap();
     transaction
-        .stage_write_with_options(
+        .stage_write(
             "main",
             "coverage",
             schema.as_ref(),
             WriteMode::Append,
             &[RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])
                 .unwrap()],
-            &DuckLakeWriteOptions::default().with_data_inlining_row_limit(1),
         )
         .await
         .unwrap();
@@ -1038,27 +1036,19 @@ async fn mysql_multi_table_write_commits_parquet_and_inline_rows() {
     assert_eq!(committed.len(), 2);
     assert_eq!(committed[0].snapshot_id, committed[1].snapshot_id);
     assert_eq!(committed[0].files_written, 1);
-    assert_eq!(committed[1].files_written, 0);
+    assert_eq!(committed[1].files_written, 1);
     let file_snapshot: i64 =
         sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_data_file WHERE table_id = ?")
             .bind(committed[0].table_id)
             .fetch_one(&pool)
             .await
             .unwrap();
-    let inline_table: String = sqlx::query_scalar(
-        "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?",
-    )
-    .bind(committed[1].table_id)
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    let inline_snapshot: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
-        "SELECT begin_snapshot FROM `{}`",
-        inline_table.replace('`', "``")
-    )))
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let second_snapshot: i64 =
+        sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_data_file WHERE table_id = ?")
+            .bind(committed[1].table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     let changes: String = sqlx::query_scalar(
         "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
     )
@@ -1067,7 +1057,7 @@ async fn mysql_multi_table_write_commits_parquet_and_inline_rows() {
     .await
     .unwrap();
     assert_eq!(file_snapshot, committed[0].snapshot_id);
-    assert_eq!(inline_snapshot, committed[0].snapshot_id);
+    assert_eq!(second_snapshot, committed[0].snapshot_id);
     assert_eq!(
         changes,
         format!(

--- a/tests/it/mysql_metadata_writer_test.rs
+++ b/tests/it/mysql_metadata_writer_test.rs
@@ -972,9 +972,12 @@ async fn mysql_unified_file_id_allocation_survives_mixed_paths() {
     );
 }
 
+#[rstest::rstest]
+#[case::existing_tables(true)]
+#[case::new_tables(false)]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
-async fn mysql_multi_table_write_commits_two_tables() {
+async fn mysql_multi_table_write_commits_two_tables(#[case] existing: bool) {
     let container = Mysql::default().start().await.unwrap();
     let port = container.get_host_port_ipv4(3306).await.unwrap();
     let conn_str = format!("mysql://root@127.0.0.1:{port}/test");
@@ -986,22 +989,24 @@ async fn mysql_multi_table_write_commits_two_tables() {
     let pool = sqlx::MySqlPool::connect(&conn_str).await.unwrap();
     let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
     let columns = vec![ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap()];
-    for table_name in ["data", "coverage"] {
-        let setup = writer
-            .begin_write_transaction("main", table_name, &columns, WriteMode::Append)
-            .unwrap();
-        writer
-            .publish_snapshot(
-                setup.table_id,
-                "main",
-                table_name,
-                setup.snapshot_id,
-                WriteMode::Append,
-                setup.base_snapshot_id,
-                &columns,
-                &setup.column_ids,
-            )
-            .unwrap();
+    if existing {
+        for table_name in ["data", "coverage"] {
+            let setup = writer
+                .begin_write_transaction("main", table_name, &columns, WriteMode::Append)
+                .unwrap();
+            writer
+                .publish_snapshot(
+                    setup.table_id,
+                    "main",
+                    table_name,
+                    setup.snapshot_id,
+                    WriteMode::Append,
+                    setup.base_snapshot_id,
+                    &columns,
+                    &setup.column_ids,
+                )
+                .unwrap();
+        }
     }
     let table_writer = DuckLakeTableWriter::new(writer, Arc::new(LocalFileSystem::new())).unwrap();
     let mut transaction = table_writer.transaction();
@@ -1058,11 +1063,16 @@ async fn mysql_multi_table_write_commits_two_tables() {
     .unwrap();
     assert_eq!(file_snapshot, committed[0].snapshot_id);
     assert_eq!(second_snapshot, committed[0].snapshot_id);
-    assert_eq!(
-        changes,
+    let expected = if existing {
         format!(
             "inserted_into_table:{},inserted_into_table:{}",
             committed[0].table_id, committed[1].table_id
         )
-    );
+    } else {
+        format!(
+            "created_schema:\"main\",created_table:\"main\".\"data\",inserted_into_table:{},created_table:\"main\".\"coverage\",inserted_into_table:{}",
+            committed[0].table_id, committed[1].table_id
+        )
+    };
+    assert_eq!(changes, expected);
 }

--- a/tests/it/write_tests.rs
+++ b/tests/it/write_tests.rs
@@ -25,8 +25,8 @@ use sqlx::Row;
 use tempfile::TempDir;
 
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeError, DuckLakeTableWriter, MetadataProvider, MetadataWriter,
-    SqliteMetadataProvider, SqliteMetadataWriter, TableWriteOptions, WriteMode,
+    DuckLakeCatalog, DuckLakeError, DuckLakeTableWriter, DuckLakeWriteOptions, MetadataProvider,
+    MetadataWriter, SqliteMetadataProvider, SqliteMetadataWriter, TableWriteOptions, WriteMode,
     register_ducklake_functions,
 };
 
@@ -2601,4 +2601,313 @@ async fn failed_multi_table_database_commit_preserves_staged_files() {
             .unwrap(),
         base.snapshot_id
     );
+}
+
+#[rstest::rstest]
+#[case::snapshot_columns(false)]
+#[case::snapshot_columns_with_deletes(true)]
+#[tokio::test(flavor = "multi_thread")]
+async fn rejected_snapshot_column_stage_leaves_no_objects(#[case] with_deletes: bool) {
+    let (metadata, temp) = create_test_env().await;
+    let store = create_object_store();
+    let prefix = ObjectPath::from(
+        temp.path()
+            .join("data")
+            .to_string_lossy()
+            .trim_start_matches('/'),
+    );
+    let writer = DuckLakeTableWriter::new(Arc::new(metadata), store.clone()).unwrap();
+    let batch = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![19])) as ArrayRef,
+    )])
+    .unwrap();
+    let options = DuckLakeWriteOptions::default();
+    let mut transaction = writer.transaction();
+    let result = if with_deletes {
+        transaction
+            .stage_write_with_deletes_and_snapshot_columns(
+                "main",
+                "events",
+                batch.schema().as_ref(),
+                WriteMode::Append,
+                from_ref(&batch),
+                &[],
+                &[],
+                &options,
+                &["value"],
+            )
+            .await
+    } else {
+        transaction
+            .stage_write_with_snapshot_columns(
+                "main",
+                "events",
+                batch.schema().as_ref(),
+                WriteMode::Append,
+                from_ref(&batch),
+                &options,
+                &["value"],
+            )
+            .await
+    };
+    transaction.abort().await.unwrap();
+    assert!(matches!(result, Err(DuckLakeError::InvalidConfig(_))));
+    assert_eq!(
+        store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+        Vec::new()
+    );
+}
+
+#[rstest::rstest]
+#[case::empty_transaction(0)]
+#[case::empty_rows(1)]
+#[case::empty_rows_with_options(2)]
+#[case::empty_snapshot_rows(3)]
+#[case::empty_deletes(4)]
+#[case::empty_rows_with_deletes(5)]
+#[case::empty_snapshot_rows_with_deletes(6)]
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_transaction_stages_do_not_publish(#[case] stage: u8) {
+    let (metadata, temp) = create_test_env().await;
+    let store = create_object_store();
+    let prefix = ObjectPath::from(
+        temp.path()
+            .join("data")
+            .to_string_lossy()
+            .trim_start_matches('/'),
+    );
+    let writer = DuckLakeTableWriter::new(Arc::new(metadata), store.clone()).unwrap();
+    let schema = Schema::new(vec![Field::new("value", DataType::Int64, false)]);
+    let batch = RecordBatch::new_empty(Arc::new(schema.clone()));
+    let options = DuckLakeWriteOptions::default();
+    let mut transaction = writer.transaction();
+    match stage {
+        0 => {},
+        1 => transaction
+            .stage_write(
+                "main",
+                "events",
+                &schema,
+                WriteMode::Append,
+                from_ref(&batch),
+            )
+            .await
+            .unwrap(),
+        2 => transaction
+            .stage_write_with_options(
+                "main",
+                "events",
+                &schema,
+                WriteMode::Append,
+                from_ref(&batch),
+                &options,
+            )
+            .await
+            .unwrap(),
+        3 => transaction
+            .stage_write_with_snapshot_columns(
+                "main",
+                "events",
+                &schema,
+                WriteMode::Append,
+                from_ref(&batch),
+                &options,
+                &["value"],
+            )
+            .await
+            .unwrap(),
+        4 => transaction
+            .stage_deletes("main", "events", &schema, &[], &[])
+            .unwrap(),
+        5 => transaction
+            .stage_write_with_deletes(
+                "main",
+                "events",
+                &schema,
+                WriteMode::Append,
+                from_ref(&batch),
+                &[],
+                &[],
+            )
+            .await
+            .unwrap(),
+        6 => transaction
+            .stage_write_with_deletes_and_snapshot_columns(
+                "main",
+                "events",
+                &schema,
+                WriteMode::Append,
+                from_ref(&batch),
+                &[],
+                &[],
+                &options,
+                &["value"],
+            )
+            .await
+            .unwrap(),
+        _ => unreachable!(),
+    }
+    let results = transaction.commit().await.unwrap();
+    let pool =
+        sqlx::SqlitePool::connect(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap();
+    let state: (i64, i64, i64) = sqlx::query_as("SELECT (SELECT COUNT(*) FROM ducklake_snapshot), (SELECT COUNT(*) FROM ducklake_table), (SELECT COUNT(*) FROM ducklake_column)").fetch_one(&pool).await.unwrap();
+    assert_eq!(results.len(), 0);
+    assert_eq!(state, (0, 0, 0));
+    assert_eq!(
+        store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+        Vec::new()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_append_stages_commute_without_a_fence() {
+    let (metadata, temp) = create_test_env().await;
+    let writer = DuckLakeTableWriter::new(Arc::new(metadata), create_object_store()).unwrap();
+    let rows = [11, 23, 37].map(|value| {
+        RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![value])) as ArrayRef,
+        )])
+        .unwrap()
+    });
+    writer
+        .append_table("main", "events", from_ref(&rows[0]))
+        .await
+        .unwrap();
+    let mut first = writer.transaction();
+    let mut second = writer.transaction();
+    first
+        .stage_write(
+            "main",
+            "events",
+            rows[1].schema().as_ref(),
+            WriteMode::Append,
+            from_ref(&rows[1]),
+        )
+        .await
+        .unwrap();
+    second
+        .stage_write(
+            "main",
+            "events",
+            rows[2].schema().as_ref(),
+            WriteMode::Append,
+            from_ref(&rows[2]),
+        )
+        .await
+        .unwrap();
+    let first = first.commit().await.unwrap();
+    let second = second.commit().await.unwrap();
+    let ctx = create_read_context(&temp).await;
+    let actual = ctx
+        .sql("SELECT value FROM test.main.events ORDER BY value")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let values: Vec<i64> = actual
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    assert_eq!(second[0].snapshot_id, first[0].snapshot_id + 1);
+    assert_eq!(values, vec![11, 23, 37]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn staged_schema_change_rejects_without_reverting_columns() {
+    let (metadata, temp) = create_test_env().await;
+    let writer = DuckLakeTableWriter::new(Arc::new(metadata), create_object_store()).unwrap();
+    let batch = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![11])) as ArrayRef,
+    )])
+    .unwrap();
+    writer
+        .append_table("main", "events", from_ref(&batch))
+        .await
+        .unwrap();
+    let mut transaction = writer.transaction();
+    transaction
+        .stage_write(
+            "main",
+            "events",
+            batch.schema().as_ref(),
+            WriteMode::Append,
+            from_ref(&batch),
+        )
+        .await
+        .unwrap();
+    let changed = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Int64, false),
+            Field::new("extra", DataType::Utf8, true),
+        ])),
+        vec![Arc::new(Int64Array::from(vec![23])), Arc::new(StringArray::from(vec!["added"]))],
+    )
+    .unwrap();
+    let committed = writer
+        .append_table("main", "events", &[changed])
+        .await
+        .unwrap();
+    let error = transaction.commit().await.unwrap_err();
+    let provider =
+        SqliteMetadataProvider::new(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap();
+    let columns = provider
+        .get_table_structure(committed.table_id, committed.snapshot_id)
+        .unwrap();
+    assert!(matches!(error, DuckLakeError::Conflict(_)), "{error}");
+    assert_eq!(
+        provider.get_current_snapshot().unwrap(),
+        committed.snapshot_id
+    );
+    assert_eq!(
+        columns
+            .iter()
+            .map(|column| column.column_name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["value", "extra"]
+    );
+    let ctx = create_read_context(&temp).await;
+    let actual = ctx
+        .sql("SELECT value FROM test.main.events ORDER BY value")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let values: Vec<i64> = actual
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    assert_eq!(values, vec![11, 23]);
 }

--- a/tests/it/write_tests.rs
+++ b/tests/it/write_tests.rs
@@ -5,25 +5,29 @@
 
 #![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
 
+use std::slice::from_ref;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, BinaryViewArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
-    Int32Array, Int64Array, ListArray, ListBuilder, MapArray, StringArray, StringBuilder,
-    StringViewArray, StructArray, TimestampMicrosecondArray, TimestampNanosecondArray, UInt32Array,
-    UInt64Array,
+    Array, ArrayRef, BinaryViewArray, BooleanArray, Date32Array, Decimal128Array, Float32Array,
+    Float64Array, Int32Array, Int64Array, ListArray, ListBuilder, MapArray, StringArray,
+    StringBuilder, StringViewArray, StructArray, TimestampMicrosecondArray,
+    TimestampNanosecondArray, UInt32Array, UInt64Array,
 };
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{DataType, Field, Float32Type, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
+use futures::TryStreamExt;
 use object_store::local::LocalFileSystem;
+use object_store::path::Path as ObjectPath;
 use sqlx::Row;
 use tempfile::TempDir;
 
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
-    SqliteMetadataWriter, WriteMode, register_ducklake_functions,
+    DuckLakeCatalog, DuckLakeError, DuckLakeTableWriter, MetadataProvider, MetadataWriter,
+    SqliteMetadataProvider, SqliteMetadataWriter, TableWriteOptions, WriteMode,
+    register_ducklake_functions,
 };
 
 /// Create a local filesystem object store.
@@ -88,6 +92,7 @@ fn parquet_schema_fields(path: &std::path::Path) -> Vec<(String, Option<i32>)> {
     result
 }
 
+#[cfg(feature = "metadata-duckdb")]
 fn assert_duckdb_extension_reads_depths(catalog_path: &std::path::Path) {
     let conformance_path = catalog_path.with_file_name("duckdb-conformance.db");
     std::fs::copy(catalog_path, &conformance_path).unwrap();
@@ -515,6 +520,7 @@ async fn test_write_and_read_list_struct_column_roundtrip() {
         .await
         .unwrap();
 
+    #[cfg(feature = "metadata-duckdb")]
     assert_duckdb_extension_reads_depths(&temp_dir.path().join("test.db"));
 
     let ctx = create_read_context(&temp_dir).await;
@@ -2298,5 +2304,301 @@ async fn test_write_and_read_nanosecond_timestamptz() {
         col.values(),
         ns_values.as_slice(),
         "sub-microsecond fraction must survive the round-trip"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multi_table_commit_records_created_schema_once() {
+    let (metadata, temp) = create_test_env().await;
+    let writer = DuckLakeTableWriter::new(Arc::new(metadata), create_object_store()).unwrap();
+    let first = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![11, 23])) as ArrayRef,
+    )])
+    .unwrap();
+    let second = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![37])) as ArrayRef,
+    )])
+    .unwrap();
+    let mut transaction = writer.transaction();
+    for (name, batch) in [("first", &first), ("second", &second)] {
+        transaction
+            .stage_write(
+                "new_schema",
+                name,
+                batch.schema().as_ref(),
+                WriteMode::Append,
+                from_ref(batch),
+            )
+            .await
+            .unwrap();
+    }
+    let results = transaction.commit().await.unwrap();
+    let pool =
+        sqlx::SqlitePool::connect(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap();
+    let changes: String = sqlx::query_scalar(
+        "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+    )
+    .bind(results[0].snapshot_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let snapshots: Vec<i64> =
+        sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_data_file ORDER BY table_id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    let ctx = create_read_context(&temp).await;
+    let actual = ctx.sql("SELECT value FROM test.new_schema.first UNION ALL SELECT value FROM test.new_schema.second ORDER BY value")
+        .await.unwrap().collect().await.unwrap();
+    let values: Vec<i64> = actual
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].snapshot_id, results[1].snapshot_id);
+    assert_eq!(
+        (results[0].files_written, results[0].records_written),
+        (1, 2)
+    );
+    assert_eq!(
+        (results[1].files_written, results[1].records_written),
+        (1, 1)
+    );
+    assert_eq!(snapshots, vec![results[0].snapshot_id; 2]);
+    assert_eq!(values, vec![11, 23, 37]);
+    assert_eq!(
+        changes,
+        format!(
+            "created_schema:\"new_schema\",created_table:\"new_schema\".\"first\",created_table:\"new_schema\".\"second\",inserted_into_table:{},inserted_into_table:{}",
+            results[0].table_id, results[1].table_id
+        )
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conflicted_multi_table_commit_leaves_no_partial_state_and_no_staged_files() {
+    let (metadata, temp) = create_test_env().await;
+    let metadata = Arc::new(metadata);
+    let store = create_object_store();
+    let prefix = ObjectPath::from(
+        temp.path()
+            .join("data")
+            .to_string_lossy()
+            .trim_start_matches('/'),
+    );
+    let writer = DuckLakeTableWriter::new(metadata.clone(), store.clone()).unwrap();
+    let batch = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![11])) as ArrayRef,
+    )])
+    .unwrap();
+    writer
+        .append_table("main", "first", from_ref(&batch))
+        .await
+        .unwrap();
+    let base = writer
+        .append_table("main", "second", from_ref(&batch))
+        .await
+        .unwrap();
+    let mut transaction = writer
+        .transaction()
+        .with_options(&TableWriteOptions::new().with_expected_base_snapshot_id(base.snapshot_id));
+    for name in ["first", "second"] {
+        transaction
+            .stage_write(
+                "main",
+                name,
+                batch.schema().as_ref(),
+                WriteMode::Append,
+                from_ref(&batch),
+            )
+            .await
+            .unwrap();
+    }
+    let concurrent = writer
+        .append_table("main", "second", &[batch])
+        .await
+        .unwrap();
+    let provider =
+        SqliteMetadataProvider::new(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap();
+    let snapshots = provider.list_snapshots().unwrap().len();
+    let error = transaction.commit().await.unwrap_err();
+    let files = store
+        .list(Some(&prefix))
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let ctx = create_read_context(&temp).await;
+    let actual = ctx.sql("SELECT (SELECT COUNT(*) FROM test.main.first) AS first, (SELECT COUNT(*) FROM test.main.second) AS second")
+        .await.unwrap().collect().await.unwrap();
+    assert!(matches!(error, DuckLakeError::Conflict(_)), "{error}");
+    assert_eq!(
+        provider.get_current_snapshot().unwrap(),
+        concurrent.snapshot_id
+    );
+    assert_eq!(provider.list_snapshots().unwrap().len(), snapshots);
+    assert_eq!(files.len(), 3);
+    assert_eq!(
+        actual[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values(),
+        &[1]
+    );
+    assert_eq!(
+        actual[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values(),
+        &[2]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn abort_multi_table_write_removes_staged_files() {
+    let (metadata, temp) = create_test_env().await;
+    let metadata = Arc::new(metadata);
+    let store = create_object_store();
+    let prefix = ObjectPath::from(
+        temp.path()
+            .join("data")
+            .to_string_lossy()
+            .trim_start_matches('/'),
+    );
+    let writer = DuckLakeTableWriter::new(metadata.clone(), store.clone()).unwrap();
+    let batch = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![17])) as ArrayRef,
+    )])
+    .unwrap();
+    let base = writer
+        .append_table("main", "events", from_ref(&batch))
+        .await
+        .unwrap();
+    let before = store
+        .list(Some(&prefix))
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let mut transaction = writer.transaction();
+    transaction
+        .stage_write(
+            "main",
+            "events",
+            batch.schema().as_ref(),
+            WriteMode::Append,
+            &[batch],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    transaction.abort().await.unwrap();
+    assert_eq!(
+        store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+        before
+    );
+    assert_eq!(
+        SqliteMetadataProvider::new(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap()
+            .get_current_snapshot()
+            .unwrap(),
+        base.snapshot_id
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failed_multi_table_database_commit_preserves_staged_files() {
+    let (metadata, temp) = create_test_env().await;
+    let metadata = Arc::new(metadata);
+    let store = create_object_store();
+    let prefix = ObjectPath::from(
+        temp.path()
+            .join("data")
+            .to_string_lossy()
+            .trim_start_matches('/'),
+    );
+    let writer = DuckLakeTableWriter::new(metadata.clone(), store.clone()).unwrap();
+    let batch = RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(Int64Array::from(vec![19])) as ArrayRef,
+    )])
+    .unwrap();
+    let base = writer
+        .append_table("main", "events", from_ref(&batch))
+        .await
+        .unwrap();
+    let mut transaction = writer.transaction();
+    transaction
+        .stage_write(
+            "main",
+            "events",
+            batch.schema().as_ref(),
+            WriteMode::Append,
+            &[batch],
+        )
+        .await
+        .unwrap();
+    let before = store
+        .list(Some(&prefix))
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let pool =
+        sqlx::SqlitePool::connect(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap();
+    sqlx::query("DROP TABLE ducklake_snapshot_changes")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let error = transaction.commit().await.unwrap_err();
+    assert!(matches!(error, DuckLakeError::Sqlx(_)), "{error}");
+    assert_eq!(before.len(), 2);
+    assert_eq!(
+        store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+        before
+    );
+    assert_eq!(
+        SqliteMetadataProvider::new(&format!("sqlite:{}", temp.path().join("test.db").display()))
+            .await
+            .unwrap()
+            .get_current_snapshot()
+            .unwrap(),
+        base.snapshot_id
     );
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary

Add `DuckLakeWriteTransaction` to commit changes across new or existing tables in one snapshot. Each stage can
carry uploaded Parquet files, metadata-backed rows, positional deletes, or inline-row deletes.
The metadata implementations support both storage forms; high-level row staging currently writes
Parquet. Automatic small-write routing remains in #272, and the stored inlining limit is not parsed here.

Nonempty stages return one `WriteResult` each with the same snapshot ID. Empty staging calls add no result, and an empty transaction publishes no snapshot. A definite rejection
rolls back the metadata and removes transaction-owned objects. Database and transport errors retain
those objects for guarded vacuum because a failed COMMIT acknowledgement can hide a committed write.
Explicit `abort()` removes staged objects without attempting a metadata commit.

This overlaps the PostgreSQL metadata batch proposal in #235 and provides a shared writer contract. It also adds
snapshot-change reads, opaque commit metadata lookup, table-scoped settings, and commit coordination.

### Commit flow

```mermaid
flowchart TD
    Stage[Validate inputs and stage changes] --> Empty{Any stages?}
    Empty -->|No| Noop[Return no results or snapshot]
    Empty -->|Yes| Begin[Open metadata transaction]
    Begin --> Prepare[Acquire serialization lock and validate tables]
    Prepare --> Apply[Apply all stages under one snapshot]
    Apply --> Commit[Commit once]
    Prepare --> Reject[Definite rejection]
    Apply --> Reject
    Reject --> Cleanup[Roll back and remove staged objects]
    Commit --> Success[Return all table results]
    Commit --> Unknown[Ambiguous error: retain objects for vacuum]
```

SQLite uses `BEGIN IMMEDIATE` before reading fenced state. MySQL allocates the snapshot before its
fence and liveness reads: the counter update takes the serializing row lock before InnoDB creates
its read view. MySQL resolves the inline schema version under that lock and creates physical tables through
a separate connection. DDL cannot commit the metadata transaction, and the version remains stable
through preparation. A regression exercises this with a one-connection writer pool.

Every stage retains the schema and field IDs observed during staging. Ordinary append stages
commute. An explicitly requested expected-base snapshot applies to every target, including appends. Duplicate table stages fail before metadata mutation.
Per-table statistics, partition fences, and snapshot visibility stay within the shared transaction.

### Backend support

| Backend                   | New/existing table stages | Snapshot-change reads | Table settings and commit lock |
| ------------------------- | ------------------------- | --------------------- | ------------------------------ |
| DuckDB                    | Yes                       | Yes                   | Yes                            |
| SQLite                    | Yes                       | Yes                   | Yes                            |
| Multicatalog PostgreSQL   | Yes                       | Yes                   | Yes                            |
| Single-catalog PostgreSQL | Yes                       | Yes                   | Yes                            |
| MySQL                     | Yes                       | Yes                   | Yes                            |

Both PostgreSQL writers share staged storage operations and metadata coordination code. DuckDB
and MySQL reuse their existing column finalization at a caller-supplied commit snapshot. New-table
commits record schema/table creation and data changes under that snapshot, deduplicating schema
entries. Write setup retains each backend's existing reservation behavior.

### Metadata compatibility

- `SnapshotChangeMetadata::changes_made` is optional. Readers retain snapshots with NULL changes
  or no change-ledger row, and preserve author, message, and extra metadata.
- Opening an existing SQLite or multicatalog PostgreSQL writer creates the inline-table registry
  without requiring `initialize_schema()`. SQLite also upgrades legacy non-null change ledgers.
- Inline inserts, deletes, and flushes use `inlined_insert`, `inlined_delete`, and `inline_flush`.
  Parquet changes retain their existing token family, including replacements involving both stores.
- `find_snapshot_by_commit_extra_info` treats the caller's needle as opaque and searches commits
  with live Parquet files. It does not provide general idempotency for inline-only, delete-only,
  or retired commits. MySQL uses case-sensitive matching for the opaque commit text.
- Coordination locks serialize the catalog file on SQLite and DuckDB, and the requested identity
  on PostgreSQL and MySQL. Table settings reject unknown options and dropped tables.

Staged inline deletes use one update per physical table. Missing row IDs are no-ops, duplicates
collapse to one identity, and rows inserted in the same snapshot remain live. Separate checks
reject conflicting commits. The new delete paths preserve gross metadata counts; query tests
verify the exact visible count independently. Snapshot-column staging rejects unsupported input
before reserving metadata or uploading files.

The token reference is DuckLake
[`d8a1881e`](https://github.com/duckdb/ducklake/blob/d8a1881e/src/storage/ducklake_transaction_state.cpp#L380-L389),
the extension revision used with the pinned DuckDB 1.5.5 engine. The transaction boundary follows
[DuckLake transactions](https://ducklake.select/docs/stable/duckdb/advanced_features/transactions)
and the [snapshot changes table](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot_changes).

### Scope

`DuckLakeWriteOptions::data_inlining_row_limit` reserves the automatic routing setting for #272.
Nested inline encodings, automatic routing, and broader inline maintenance coverage remain there.
The options struct and staged storage enum are non-exhaustive. MySQL's pre-existing global-setting
setter remains unsupported; the new table-scoped setter is implemented.

The explicit expected-base API remains a caller-selected precondition. Applying it only to
`Replace` would silently discard a requested condition on an append. The regression suite verifies
both ordinary appends that commute and conditional appends that reject a stale base.

### Validation

All Rust commands use Rust 1.94.0 and `CARGO_BUILD_JOBS=8`. Integration checks use
`--all-features --test it` with `-- --include-ignored --test-threads=4`; the MySQL module uses
two test threads. Docker-backed tests run on local disposable containers.

| Check                                            | Result                                       |
| ------------------------------------------------ | -------------------------------------------- |
| Rustfmt                                          | Pass                                         |
| All-target, all-feature Clippy, `-D warnings`    | Pass                                         |
| Tests compile with `write-sqlite,write-postgres` | Pass; existing dead-code warnings            |
| Metadata writer unit tests                       | 89 passed                                    |
| Table writer unit tests                          | 17 passed                                    |
| Rejected-stage leak regressions                  | 2 passed                                     |
| Empty-operation regressions                      | 7 passed                                     |
| Ordinary append concurrency and schema drift     | 2 passed                                     |
| All-feature doctests                             | 8 passed                                     |
| Summary Markdown and Mermaid                     | Pass                                         |
| `metadata_contract_tests::`                      | 15 passed                                    |
| `multi_table`                                    | 12 passed                                    |
| `append_with_deletes_postgres_tests::`           | 5 passed                                     |
| `mysql_metadata_writer_test::`                   | 10 passed                                    |
| `multicatalog_postgres_tests::`                  | 69 passed; 3 existing ignored cases excluded |
| `postgres_single_catalog_write_tests::`          | 34 passed; 3 pre-existing failures           |

The single-catalog PostgreSQL failures reproduce with the same test names and errors on the
`main` base, `9a56a65`, which also reports 34 passed and 3 failed. They are tracked in
[#275](https://github.com/datafusion-contrib/datafusion-ducklake/issues/275). The new staged
PostgreSQL tests pass. Broader backend CI wiring remains a separate follow-up.

The selections overlap. Regressions cover shared snapshots, read-back values, schema drift,
conditional and ordinary appends, empty operations, rejected-stage leaks, rollback, abort cleanup,
and ambiguous-error object retention. Backend contracts cover nullable ledgers, registry upgrades,
option validation, lock release, and case-sensitive commit lookup.

### Key files

- [`src/table_writer.rs`](https://github.com/faysou/datafusion-ducklake/blob/ducklake-atomic-multi-table-writes-pr/src/table_writer.rs): staged transaction, cleanup, and flush lifecycle.
- [`src/metadata_writer.rs`](https://github.com/faysou/datafusion-ducklake/blob/ducklake-atomic-multi-table-writes-pr/src/metadata_writer.rs): staged state, accessors, and storage-specific change tokens.
- `src/metadata_writer_duckdb.rs`, `src/metadata_writer_mysql.rs`, `src/metadata_writer_postgres.rs`, and `src/metadata_writer_sqlite.rs`: publication, fencing, migration, and snapshot accounting.
- `src/metadata_writer_postgres_single.rs`: staged commits for standard PostgreSQL, sharing storage and coordination with the multicatalog writer.
- `src/metadata_provider.rs`, `src/metadata_provider_duckdb.rs`, `src/metadata_provider_mysql.rs`, `src/metadata_provider_postgres.rs`, `src/metadata_provider_sqlite.rs`, and `src/multicatalog_provider.rs`: nullable snapshot changes and explicit unsupported defaults.
- `tests/it/write_tests.rs` and `tests/it/metadata_contract_tests.rs`: transaction and metadata regressions, including SQLite tests enabled by the existing CI feature set.
- `tests/it/append_with_deletes_postgres_tests.rs` and `tests/it/mysql_metadata_writer_test.rs`: backend transaction boundaries.

- `tests/it/multicatalog_postgres_tests.rs`: seeds inline rows through the explicit metadata API.
- `CHANGELOG.md` and `COMPATIBILITY.md`: backend support, upgrade behavior, and API limits.
