### PR TITLE
fix(compaction): write with the table's configured parquet options

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -381,7 +381,22 @@ impl DuckLakeTable {
         let object_store = state
             .runtime_env()
             .object_store(self.object_store_url().as_ref())?;
-        let table_writer = DuckLakeTableWriter::new(Arc::clone(writer), object_store)?;
+        // Inherit the table's write options, exactly as the insert path does
+        // (`insert_exec.rs`). Compaction re-encodes data that already exists, so
+        // writing with the format defaults does not merely fail to optimise — it
+        // *undoes* the settings the data was written with. A table written LZ4
+        // with a bounded row group comes back uncompressed and, below a million
+        // rows, as a single row group nothing can prune into.
+        //
+        // Official DuckLake has no such gap: its compaction builds its copy
+        // options through the same `DuckLakeInsert::GetCopyOptions` inserts use,
+        // so a merged file inherits the catalog's configured
+        // `parquet_compression` / `parquet_compression_level`
+        // (`ducklake_compaction_functions.cpp:655`, `ducklake_insert.cpp:511`).
+        // Taking them from the table rather than from a per-call option keeps
+        // that single source of truth: one catalog setting, both paths.
+        let table_writer = DuckLakeTableWriter::new(Arc::clone(writer), object_store)?
+            .with_options(&self.write_options);
         let column_ids = self.column_ids();
         let top_level_column_ids = self.top_level_column_ids();
         let physical_schema = self.physical_schema();
@@ -565,7 +580,12 @@ impl DuckLakeTable {
         let object_store = state
             .runtime_env()
             .object_store(self.object_store_url().as_ref())?;
-        let table_writer = DuckLakeTableWriter::new(Arc::clone(writer), object_store)?;
+        // Inherit the table's write options, for the reasons given in
+        // `merge_adjacent_files`. A rewrite re-encodes just as a merge does, so
+        // it has to carry them too — the two writer constructions are the only
+        // places in this crate that could silently disagree about it.
+        let table_writer = DuckLakeTableWriter::new(Arc::clone(writer), object_store)?
+            .with_options(&self.write_options);
         let column_ids = self.column_ids();
         let top_level_column_ids = self.top_level_column_ids();
         let physical_schema = self.physical_schema();

--- a/src/table.rs
+++ b/src/table.rs
@@ -899,7 +899,7 @@ pub struct DuckLakeTable {
     /// Write-layout options (compression, row-group caps, file-rollover target)
     /// applied to the writer built for an INSERT into this table.
     #[cfg(feature = "write")]
-    write_options: crate::table_writer::DuckLakeWriteOptions,
+    pub(crate) write_options: crate::table_writer::DuckLakeWriteOptions,
 }
 
 impl std::fmt::Debug for DuckLakeTable {

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -243,6 +243,64 @@ async fn run_merge(temp: &TempDir, opts: MergeOptions) -> CompactionResult {
     .await
 }
 
+/// Run a merge with explicit table write options, as a catalog configured for a
+/// codec would produce.
+async fn run_merge_with_write_options(
+    temp: &TempDir,
+    write_options: datafusion_ducklake::DuckLakeWriteOptions,
+    opts: MergeOptions,
+) -> CompactionResult {
+    with_writable_table(temp, |table, state| async move {
+        table
+            .with_write_options(write_options)
+            .merge_adjacent_files(&state, opts)
+            .await
+            .unwrap()
+    })
+    .await
+}
+
+/// The same for a rewrite, so both writer sites are covered.
+async fn run_rewrite_with_write_options(
+    temp: &TempDir,
+    write_options: datafusion_ducklake::DuckLakeWriteOptions,
+    opts: RewriteOptions,
+) -> CompactionResult {
+    with_writable_table(temp, |table, state| async move {
+        table
+            .with_write_options(write_options)
+            .rewrite_data_files(&state, opts)
+            .await
+            .unwrap()
+    })
+    .await
+}
+
+/// Every column chunk's codec, and the row group count, of the single live file.
+fn live_file_parquet_facts(
+    temp: &TempDir,
+    pool_path: &str,
+) -> (Vec<parquet::basic::Compression>, usize) {
+    let file = std::fs::File::open(
+        temp.path()
+            .join("data")
+            .join("main")
+            .join("t")
+            .join(pool_path),
+    )
+    .unwrap();
+    let meta = ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .metadata()
+        .clone();
+    let codecs = meta
+        .row_groups()
+        .iter()
+        .flat_map(|rg| rg.columns().iter().map(|c| c.compression()))
+        .collect();
+    (codecs, meta.num_row_groups())
+}
+
 async fn run_rewrite(temp: &TempDir, opts: RewriteOptions) -> CompactionResult {
     with_writable_table(temp, |table, state| async move {
         table.rewrite_data_files(&state, opts).await.unwrap()
@@ -1640,5 +1698,109 @@ async fn cdc_attributes_merged_rows_to_origin_snapshots() {
         changes(s3 + 1, s3 + 1).await,
         vec![],
         "merge emits no CDC events"
+    );
+}
+
+/// Compaction writes with the table's configured parquet settings, not the
+/// format defaults.
+///
+/// Compaction re-encodes data that already exists, so leaving the writer at its
+/// defaults does not merely fail to optimise — it *undoes* what the data was
+/// written with. A table written LZ4 with a bounded row group comes back
+/// uncompressed and, below a million rows, as one row group nothing can prune
+/// into.
+///
+/// Official DuckLake has no such gap: its compaction builds copy options through
+/// the same `DuckLakeInsert::GetCopyOptions` inserts use, so a merged file
+/// inherits the catalog's configured `parquet_compression`.
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_inherits_the_tables_write_options() {
+    use datafusion_ducklake::DuckLakeWriteOptions;
+    use parquet::basic::Compression;
+
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2, 3], vec![10, 20, 30]).await;
+    append(&temp, vec![4, 5, 6], vec![40, 50, 60]).await;
+
+    let result = run_merge_with_write_options(
+        &temp,
+        DuckLakeWriteOptions {
+            compression: Some(Compression::LZ4),
+            // Two rows per group over six: enough that a single group is
+            // unmistakably the writer default rather than a coincidence.
+            max_row_group_rows: Some(2),
+            ..Default::default()
+        },
+        MergeOptions::default(),
+    )
+    .await;
+    assert_eq!(result.files_processed, 2);
+    assert_eq!(result.files_created, 1);
+
+    let p = pool(&temp).await;
+    let live_path: String =
+        sqlx::query_scalar("SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL")
+            .fetch_one(&p)
+            .await
+            .unwrap();
+    let (codecs, row_groups) = live_file_parquet_facts(&temp, &live_path);
+    assert!(
+        row_groups > 1,
+        "row group cap ignored: {row_groups} group(s) for 6 rows at 2 per group"
+    );
+    assert!(
+        codecs.iter().all(|c| *c == Compression::LZ4),
+        "merged file written {codecs:?}, not the table's configured codec"
+    );
+}
+
+/// The same for `rewrite_data_files`, which is a second writer construction and
+/// would otherwise be free to drift from the merge one.
+#[tokio::test(flavor = "multi_thread")]
+async fn rewrite_inherits_the_tables_write_options() {
+    use datafusion_ducklake::DuckLakeWriteOptions;
+    use parquet::basic::Compression;
+
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2, 3, 4, 5, 6], vec![10, 20, 30, 40, 50, 60]).await;
+
+    let p = pool(&temp).await;
+    let file_id: i64 = sqlx::query_scalar(
+        "SELECT data_file_id FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .fetch_one(&p)
+    .await
+    .unwrap();
+
+    // Naming the file rewrites it regardless of its delete fraction, which is
+    // what makes this a rewrite rather than a merge.
+    let result = run_rewrite_with_write_options(
+        &temp,
+        DuckLakeWriteOptions {
+            compression: Some(Compression::LZ4),
+            max_row_group_rows: Some(2),
+            ..Default::default()
+        },
+        RewriteOptions {
+            data_file_ids: Some(vec![file_id]),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_eq!(result.files_created, 1, "the named file is rewritten");
+
+    let live_path: String =
+        sqlx::query_scalar("SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL")
+            .fetch_one(&p)
+            .await
+            .unwrap();
+    let (codecs, row_groups) = live_file_parquet_facts(&temp, &live_path);
+    assert!(
+        row_groups > 1,
+        "row group cap ignored on rewrite: {row_groups} group(s) for 6 rows"
+    );
+    assert!(
+        codecs.iter().all(|c| *c == Compression::LZ4),
+        "rewritten file written {codecs:?}, not the table's configured codec"
     );
 }


### PR DESCRIPTION
## The problem

`merge_adjacent_files` and `rewrite_data_files` construct their parquet writer with `DuckLakeTableWriter::new(..)` and never apply the table's `DuckLakeWriteOptions`. Both therefore write with the writer defaults — `Compression::UNCOMPRESSED`, and no row group cap, which means a single row group for any file under a million rows.

Because compaction re-encodes data that already exists, this does not merely fail to optimise. It *undoes* the settings the data was written with: a table configured for LZ4 with a bounded row group size comes back uncompressed and with one row group that no row-group pruning can skip into, purely for having been compacted.

Nor could a caller work around it. The settings live on the table (`DuckLakeCatalog::with_write_options` / `DuckLakeTable::with_write_options`) and are applied on the insert path, but compaction never read them and neither `MergeOptions` nor `RewriteOptions` exposed an equivalent.

## Comparison with official DuckLake

Official DuckLake does not have this gap. Its compaction builds copy options through the same `DuckLakeInsert::GetCopyOptions` the insert path uses (`src/functions/ducklake_compaction_functions.cpp`), and that function reads the catalog's `parquet_compression` / `parquet_compression_level` (`src/storage/ducklake_insert.cpp`). A compacted file there inherits the configured codec exactly as an inserted one does.

So the current behaviour is the divergence, and this restores parity.

Row group sizing is less clear-cut upstream and this PR does not claim parity for it: official computes a configured batch size but only one of its two branches uses it, the other taking `DEFAULT_ROW_GROUP_SIZE`. What this PR does is stop compaction *discarding* a row group cap the table already had.

## The change

Apply `self.write_options` at both writer constructions, the same way `insert_exec` does.

Deliberately not a new field on `MergeOptions` / `RewriteOptions`. That would have worked, but it duplicates a setting the table already owns and makes correctness depend on every caller remembering to pass it — the same shape as the bug. Reading from the table keeps one source of truth, and matches how official derives both paths from one catalog setting.

`DuckLakeTable::write_options` becomes `pub(crate)` so the compaction module can read it. No public API change.

## Tests

Two, one per writer construction, asserting the *written file's parquet metadata* rather than its size — size alone cannot distinguish a codec change from merging away per-file overhead:

- `merge_inherits_the_tables_write_options` — merges two files with LZ4 and a two-row group cap over six rows, then asserts every column chunk's codec is LZ4 and there is more than one row group.
- `rewrite_inherits_the_tables_write_options` — the same through `rewrite_data_files`, naming the file explicitly so it rewrites regardless of delete fraction.

The second matters because the two writer constructions are the only places in the crate that could silently disagree about this; without it, removing the rewrite-side application would leave the suite green.

Full suite green, `cargo clippy --all-targets --all-features -- -D warnings` clean.
