### PR TITLE
perf(compaction): read a merge bin with one parallel scan

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -39,18 +39,18 @@ use arrow::array::{ArrayRef, Int64Array, RecordBatch};
 use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::Session;
-use datafusion::common::runtime::SpawnedTask;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::{
     EquivalenceProperties, LexOrdering, PhysicalSortExpr, expressions::Column,
 };
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
-    PlanProperties, sorts::sort::SortExec,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    sorts::sort::SortExec,
 };
 use futures::{StreamExt, TryStreamExt};
 
@@ -320,127 +320,6 @@ impl ExecutionPlan for CompactionSourceExec {
     }
 }
 
-/// Funnel a multi-partition compaction scan into ONE stream that keeps the
-/// input's partition order: every batch of partition 0, then partition 1, and
-/// so on.
-///
-/// The partitions are still read CONCURRENTLY — each runs on its own spawned
-/// task, `concurrency` of them in flight at a time — so the object-store round
-/// trips of a whole compaction set overlap. Only the hand-off is ordered.
-///
-/// Ordering costs buffering: a partition is collected in full, then waits its
-/// turn, so up to `concurrency` partitions' rows are resident at once. That is
-/// bounded by construction and no worse than reading the set file by file was,
-/// which held the whole set — but it does mean the compaction pipeline below is
-/// only as streaming as `concurrency` partitions are small.
-///
-/// DataFusion's own `CoalescePartitionsExec` would be one line instead, and
-/// would stream, but it emits partitions interleaved by arrival — the physical
-/// row order of a merged file would then depend on which object-store request
-/// returned first. Keeping the sources' order makes the layout reproducible from
-/// the same inputs — an unsorted merge of adjacent files stays rowid-ordered,
-/// and under a table sort order the ties within a sort key resolve the same way
-/// every time. Row lineage does not depend on it (every row carries its own
-/// rowid and origin snapshot), so this is about the output being predictable.
-#[derive(Debug)]
-struct OrderedCoalesceExec {
-    input: Arc<dyn ExecutionPlan>,
-    /// How many input partitions to read at once.
-    concurrency: usize,
-    properties: Arc<PlanProperties>,
-}
-
-impl OrderedCoalesceExec {
-    fn new(input: Arc<dyn ExecutionPlan>, concurrency: usize) -> Self {
-        let properties = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(input.schema()),
-            Partitioning::UnknownPartitioning(1),
-            input.pipeline_behavior(),
-            input.boundedness(),
-        ));
-        Self {
-            input,
-            concurrency: concurrency.max(1),
-            properties,
-        }
-    }
-}
-
-impl DisplayAs for OrderedCoalesceExec {
-    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "OrderedCoalesceExec: concurrency={}", self.concurrency)
-    }
-}
-
-impl ExecutionPlan for OrderedCoalesceExec {
-    fn name(&self) -> &str {
-        "OrderedCoalesceExec"
-    }
-
-    fn properties(&self) -> &Arc<PlanProperties> {
-        &self.properties
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.input]
-    }
-
-    fn maintains_input_order(&self) -> Vec<bool> {
-        vec![true]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        let [child] = <[Arc<dyn ExecutionPlan>; 1]>::try_from(children).map_err(|_| {
-            DataFusionError::Internal("OrderedCoalesceExec expects exactly one child".into())
-        })?;
-        Ok(Arc::new(OrderedCoalesceExec::new(child, self.concurrency)))
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<TaskContext>,
-    ) -> DataFusionResult<SendableRecordBatchStream> {
-        if partition != 0 {
-            return Err(DataFusionError::Internal(format!(
-                "OrderedCoalesceExec produces a single partition, got {partition}"
-            )));
-        }
-        let schema = self.schema();
-        let input = Arc::clone(&self.input);
-        let partitions = input.output_partitioning().partition_count();
-        let stream = futures::stream::iter(0..partitions)
-            .map(move |index| {
-                let input = Arc::clone(&input);
-                let context = Arc::clone(&context);
-                // Spawned, not merely polled: reading every partition on this
-                // one task would serialize each file's parquet decode onto a
-                // single core, which is the cost this operator exists to avoid.
-                // Dropping the output stream drops the task, which aborts it.
-                let task = SpawnedTask::spawn(async move {
-                    let mut stream = input.execute(index, context)?;
-                    let mut batches = Vec::new();
-                    while let Some(batch) = stream.next().await {
-                        batches.push(batch?);
-                    }
-                    Ok::<Vec<RecordBatch>, DataFusionError>(batches)
-                });
-                async move {
-                    task.join()
-                        .await
-                        .map_err(|error| DataFusionError::External(Box::new(error)))?
-                }
-            })
-            .buffered(self.concurrency)
-            .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
-            .try_flatten();
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
-    }
-}
-
 /// Pull from `stream` until the first batch that carries rows, then hand back
 /// the stream with that batch put in front of it. `None` means the whole stream
 /// was empty, so the compaction has nothing to write and must create no file.
@@ -569,8 +448,25 @@ pub(crate) fn sorted_rewrite_batches(
 ///
 /// `input` is normally multi-partition — one partition per source file, plus one
 /// per row-group chunk of a large file — because that is how the compaction set
-/// is read in parallel. [`OrderedCoalesceExec`] funnels those partitions back
-/// into the single stream the compaction writer consumes, in order.
+/// is read in parallel. `CoalescePartitionsExec` funnels those partitions back
+/// into the single stream the compaction writer consumes.
+///
+/// That coalesce emits partitions interleaved by arrival, so an unsorted merge's
+/// physical row order depends on which object-store request returned first. This
+/// matches official DuckLake, which sets `DONT_PRESERVE_ORDER` on exactly this
+/// copy (`ducklake_compaction_functions.cpp`), and costs nothing that is load
+/// bearing: a compaction output carries each row's rowid and origin snapshot as
+/// columns and records no `row_id_start`, so nothing downstream derives lineage
+/// from where a row sits. Delete files ARE written in position space, but a
+/// mutation resolves those positions by rescanning the file it is targeting, so
+/// they describe that file's actual layout whatever it turned out to be.
+///
+/// Preserving order instead means holding a partition until its turn to be
+/// emitted. The custom operator that did so buffered each one into a `Vec`
+/// outside the memory pool's accounting, which is memory a streaming coalesce
+/// does not need and the pool could not see. Note the coalesce starts every
+/// input partition at once rather than capping concurrency; the count is
+/// bounded by the bin, which `MergeOptions::max_merged_files` already limits.
 pub(crate) fn sorted_rewrite_output(
     context: Arc<TaskContext>,
     input: Arc<dyn ExecutionPlan>,
@@ -578,10 +474,7 @@ pub(crate) fn sorted_rewrite_output(
 ) -> Result<SendableRecordBatchStream> {
     let schema = input.schema();
     let input: Arc<dyn ExecutionPlan> = if input.output_partitioning().partition_count() > 1 {
-        Arc::new(OrderedCoalesceExec::new(
-            input,
-            context.session_config().target_partitions(),
-        ))
+        Arc::new(CoalescePartitionsExec::new(input))
     } else {
         input
     };
@@ -1073,63 +966,11 @@ impl DuckLakeTable {
         })
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::sort::{DUCKDB_DIALECT, NullOrder, SortDirection, SortField};
-    use arrow::array::Int64Array;
-    use datafusion::prelude::SessionContext;
-
-    /// The compaction plan reads every source partition at once, so its output
-    /// must still be the partitions concatenated IN ORDER — that is what keeps a
-    /// merged file's physical layout a function of its inputs rather than of
-    /// which object-store request happened to return first.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn ordered_coalesce_concatenates_partitions_in_order() {
-        const PARTITIONS: i64 = 8;
-        const ROWS_PER_PARTITION: usize = 4;
-
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
-        let partitions: Vec<Vec<RecordBatch>> = (0..PARTITIONS)
-            .map(|index| {
-                let column: ArrayRef = Arc::new(Int64Array::from(vec![index; ROWS_PER_PARTITION]));
-                vec![RecordBatch::try_new(Arc::clone(&schema), vec![column]).unwrap()]
-            })
-            .collect();
-        let input: Arc<dyn ExecutionPlan> =
-            MemorySourceConfig::try_new_exec(&partitions, Arc::clone(&schema), None).unwrap();
-        assert_eq!(
-            input.output_partitioning().partition_count(),
-            PARTITIONS as usize,
-        );
-
-        // A concurrency below the partition count exercises the buffering: a
-        // later partition can finish while an earlier one is still in flight.
-        let exec: Arc<dyn ExecutionPlan> = Arc::new(OrderedCoalesceExec::new(input, 3));
-        assert_eq!(exec.output_partitioning().partition_count(), 1);
-        let batches = datafusion::physical_plan::collect(exec, SessionContext::new().task_ctx())
-            .await
-            .unwrap();
-
-        let values: Vec<i64> = batches
-            .iter()
-            .flat_map(|batch| {
-                batch
-                    .column(0)
-                    .as_any()
-                    .downcast_ref::<Int64Array>()
-                    .unwrap()
-                    .values()
-                    .to_vec()
-            })
-            .collect();
-        assert_eq!(
-            values,
-            (0..PARTITIONS)
-                .flat_map(|index| std::iter::repeat_n(index, ROWS_PER_PARTITION))
-                .collect::<Vec<i64>>(),
-        );
-    }
 
     #[test]
     fn compaction_ordering_rejects_expression_sort_key() {

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -37,12 +37,22 @@ use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Int64Array, RecordBatch};
 use arrow::compute::SortOptions;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::Session;
+use datafusion::common::runtime::SpawnedTask;
 use datafusion::datasource::memory::MemorySourceConfig;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, expressions::Column};
-use datafusion::physical_plan::{ExecutionPlan, sorts::sort::SortExec};
+use datafusion::physical_expr::{
+    EquivalenceProperties, LexOrdering, PhysicalSortExpr, expressions::Column,
+};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::union::UnionExec;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
+    PlanProperties, sorts::sort::SortExec,
+};
+use futures::{StreamExt, TryStreamExt};
 
 use crate::column_rename::ColumnRenameExec;
 use crate::metadata_provider::DuckLakeTableFile;
@@ -50,7 +60,9 @@ use crate::metadata_writer::{CompactionOutputFile, CompactionSourceFile, SourceR
 use crate::partition::PartitionSpec;
 use crate::row_id::EMBEDDED_SNAPSHOT_ID_COLUMN_NAME;
 use crate::sort::{SortDirection, SortSpec};
-use crate::table::DuckLakeTable;
+use crate::table::{
+    DuckLakeTable, RewrittenBatch, UpdateSourceScan, rewrite_output_schema, rewrite_scanned_batch,
+};
 use crate::table_writer::DuckLakeTableWriter;
 use crate::{DuckLakeError, Result};
 
@@ -133,28 +145,324 @@ impl CompactionResult {
     }
 }
 
+/// The Arrow field for the constant `_ducklake_internal_snapshot_id` column a
+/// merged partial file embeds. Field-id metadata is deliberately absent: only
+/// the column order matters here, and `write_compacted_file_stream` re-imposes
+/// the field-id-tagged parquet schema.
+fn snapshot_column_field() -> Field {
+    Field::new(EMBEDDED_SNAPSHOT_ID_COLUMN_NAME, DataType::Int64, true)
+}
+
 /// Append a constant `_ducklake_internal_snapshot_id` column (every value =
-/// `origin`) to a `[data columns..., rowid]` batch, yielding
-/// `[data columns..., rowid, snapshot_id]` for a merged partial file. Only the
-/// column order matters here; `write_compacted_file` re-imposes the
-/// field-id-tagged parquet schema.
-fn append_snapshot_column(batch: &RecordBatch, origin: i64) -> Result<RecordBatch> {
-    let n = batch.num_rows();
-    let snap: ArrayRef = Arc::new(Int64Array::from(vec![origin; n]));
+/// `origin`) to a `[data columns..., rowid]` batch, yielding the
+/// `[data columns..., rowid, snapshot_id]` `schema` of a merged partial file.
+fn append_snapshot_column(
+    batch: &RecordBatch,
+    origin: i64,
+    schema: &SchemaRef,
+) -> DataFusionResult<RecordBatch> {
+    let snap: ArrayRef = Arc::new(Int64Array::from(vec![origin; batch.num_rows()]));
     let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
     cols.push(snap);
-    let mut fields: Vec<Field> = batch
-        .schema()
-        .fields()
-        .iter()
-        .map(|f| f.as_ref().clone())
-        .collect();
-    fields.push(Field::new(
-        EMBEDDED_SNAPSHOT_ID_COLUMN_NAME,
-        DataType::Int64,
-        true,
-    ));
-    Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), cols)?)
+    Ok(RecordBatch::try_new(Arc::clone(schema), cols)?)
+}
+
+/// One source file of a compaction, as a leaf of the compaction plan.
+///
+/// Wraps that file's positional read plan and rewrites each batch it produces
+/// into `[physical columns (catalog types)..., rowid]` — the same per-row
+/// transformation an `UPDATE` applies, via the shared [`rewrite_scanned_batch`]
+/// — appending the constant `_ducklake_internal_snapshot_id` column when
+/// `origin` is set (a merge whose bin spans more than one origin snapshot).
+///
+/// Carrying provenance as columns OF THE SCAN is what lets a whole bin be read
+/// by one execution rather than one file at a time: nothing downstream needs to
+/// know which source a batch came from. Official DuckLake compaction has the
+/// same shape — a single scan over the compaction set that projects the row-id
+/// and snapshot-id virtual columns
+/// (`InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID` in
+/// `ducklake_compaction_functions.cpp`).
+#[derive(Debug)]
+struct CompactionSourceExec {
+    /// The source file's positional read plan and its lineage metadata. Shared
+    /// rather than cloned: every scan partition reads the same metadata, and it
+    /// carries the file's already-deleted position set.
+    scan: Arc<UpdateSourceScan>,
+    /// The table's physical (data) columns in catalog types.
+    physical_schema: SchemaRef,
+    /// `[physical columns..., rowid]` — what [`rewrite_scanned_batch`] emits.
+    rewrite_schema: SchemaRef,
+    /// This exec's output schema: [`Self::rewrite_schema`] plus the embedded
+    /// snapshot-id column when [`Self::origin`] is set.
+    schema: SchemaRef,
+    /// Origin snapshot to stamp on every row of this file, for a partial merge
+    /// output; `None` leaves the batch at `[physical columns..., rowid]`.
+    origin: Option<i64>,
+    properties: Arc<PlanProperties>,
+}
+
+impl CompactionSourceExec {
+    fn new(scan: Arc<UpdateSourceScan>, physical_schema: SchemaRef, origin: Option<i64>) -> Self {
+        let rewrite_schema = rewrite_output_schema(&physical_schema);
+        let schema = if origin.is_some() {
+            let mut fields: Vec<Arc<Field>> = rewrite_schema.fields().iter().cloned().collect();
+            fields.push(Arc::new(snapshot_column_field()));
+            Arc::new(Schema::new(fields))
+        } else {
+            Arc::clone(&rewrite_schema)
+        };
+        // Row-for-row: same partitioning as the file's scan, and no reordering.
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            scan.scan.output_partitioning().clone(),
+            scan.scan.pipeline_behavior(),
+            scan.scan.boundedness(),
+        ));
+        Self {
+            scan,
+            physical_schema,
+            rewrite_schema,
+            schema,
+            origin,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for CompactionSourceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "CompactionSourceExec: file={}, origin={}",
+            self.scan.source_path,
+            self.origin
+                .map_or_else(|| "none".to_string(), |origin| origin.to_string())
+        )
+    }
+}
+
+impl ExecutionPlan for CompactionSourceExec {
+    fn name(&self) -> &str {
+        "CompactionSourceExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.scan.scan]
+    }
+
+    /// Order-preserving: every row in, one row out, in order.
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let [child] = <[Arc<dyn ExecutionPlan>; 1]>::try_from(children).map_err(|_| {
+            DataFusionError::Internal("CompactionSourceExec expects exactly one child".into())
+        })?;
+        let mut scan = UpdateSourceScan::clone(&self.scan);
+        scan.scan = child;
+        Ok(Arc::new(CompactionSourceExec::new(
+            Arc::new(scan),
+            Arc::clone(&self.physical_schema),
+            self.origin,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let input = self.scan.scan.execute(partition, context)?;
+        let scan = Arc::clone(&self.scan);
+        let physical_schema = Arc::clone(&self.physical_schema);
+        let rewrite_schema = Arc::clone(&self.rewrite_schema);
+        let schema = Arc::clone(&self.schema);
+        let origin = self.origin;
+        let stream = input
+            .map(move |batch| -> DataFusionResult<Option<RecordBatch>> {
+                let batch = batch?;
+                // Compaction keeps every live row exactly as it is: no predicate
+                // to select with, no assignments to apply.
+                let Some(RewrittenBatch {
+                    batch,
+                    ..
+                }) = rewrite_scanned_batch(
+                    &physical_schema,
+                    &rewrite_schema,
+                    &scan,
+                    &batch,
+                    None,
+                    &[],
+                )?
+                else {
+                    // An empty batch contributes nothing; drop it rather than
+                    // pass it on, so the parquet writer only ever sees rows.
+                    return Ok(None);
+                };
+                Ok(Some(match origin {
+                    Some(origin) => append_snapshot_column(&batch, origin, &schema)?,
+                    None => batch,
+                }))
+            })
+            .try_filter_map(|batch| std::future::ready(Ok(batch)));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            stream,
+        )))
+    }
+}
+
+/// Funnel a multi-partition compaction scan into ONE stream that keeps the
+/// input's partition order: every batch of partition 0, then partition 1, and
+/// so on.
+///
+/// The partitions are still read CONCURRENTLY — each runs on its own spawned
+/// task, `concurrency` of them in flight at a time — so the object-store round
+/// trips of a whole compaction set overlap. Only the hand-off is ordered.
+///
+/// Ordering costs buffering: a partition is collected in full, then waits its
+/// turn, so up to `concurrency` partitions' rows are resident at once. That is
+/// bounded by construction and no worse than reading the set file by file was,
+/// which held the whole set — but it does mean the compaction pipeline below is
+/// only as streaming as `concurrency` partitions are small.
+///
+/// DataFusion's own `CoalescePartitionsExec` would be one line instead, and
+/// would stream, but it emits partitions interleaved by arrival — the physical
+/// row order of a merged file would then depend on which object-store request
+/// returned first. Keeping the sources' order makes the layout reproducible from
+/// the same inputs — an unsorted merge of adjacent files stays rowid-ordered,
+/// and under a table sort order the ties within a sort key resolve the same way
+/// every time. Row lineage does not depend on it (every row carries its own
+/// rowid and origin snapshot), so this is about the output being predictable.
+#[derive(Debug)]
+struct OrderedCoalesceExec {
+    input: Arc<dyn ExecutionPlan>,
+    /// How many input partitions to read at once.
+    concurrency: usize,
+    properties: Arc<PlanProperties>,
+}
+
+impl OrderedCoalesceExec {
+    fn new(input: Arc<dyn ExecutionPlan>, concurrency: usize) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(input.schema()),
+            Partitioning::UnknownPartitioning(1),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+        Self {
+            input,
+            concurrency: concurrency.max(1),
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for OrderedCoalesceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "OrderedCoalesceExec: concurrency={}", self.concurrency)
+    }
+}
+
+impl ExecutionPlan for OrderedCoalesceExec {
+    fn name(&self) -> &str {
+        "OrderedCoalesceExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let [child] = <[Arc<dyn ExecutionPlan>; 1]>::try_from(children).map_err(|_| {
+            DataFusionError::Internal("OrderedCoalesceExec expects exactly one child".into())
+        })?;
+        Ok(Arc::new(OrderedCoalesceExec::new(child, self.concurrency)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "OrderedCoalesceExec produces a single partition, got {partition}"
+            )));
+        }
+        let schema = self.schema();
+        let input = Arc::clone(&self.input);
+        let partitions = input.output_partitioning().partition_count();
+        let stream = futures::stream::iter(0..partitions)
+            .map(move |index| {
+                let input = Arc::clone(&input);
+                let context = Arc::clone(&context);
+                // Spawned, not merely polled: reading every partition on this
+                // one task would serialize each file's parquet decode onto a
+                // single core, which is the cost this operator exists to avoid.
+                // Dropping the output stream drops the task, which aborts it.
+                let task = SpawnedTask::spawn(async move {
+                    let mut stream = input.execute(index, context)?;
+                    let mut batches = Vec::new();
+                    while let Some(batch) = stream.next().await {
+                        batches.push(batch?);
+                    }
+                    Ok::<Vec<RecordBatch>, DataFusionError>(batches)
+                });
+                async move {
+                    task.join()
+                        .await
+                        .map_err(|error| DataFusionError::External(Box::new(error)))?
+                }
+            })
+            .buffered(self.concurrency)
+            .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+            .try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+/// Pull from `stream` until the first batch that carries rows, then hand back
+/// the stream with that batch put in front of it. `None` means the whole stream
+/// was empty, so the compaction has nothing to write and must create no file.
+///
+/// Replaces the old "collect the whole output, then check the batches are not
+/// all empty" guard: one batch is enough to decide.
+async fn first_nonempty(
+    mut stream: SendableRecordBatchStream,
+) -> Result<Option<SendableRecordBatchStream>> {
+    let schema = stream.schema();
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let head = futures::stream::once(std::future::ready(Ok(batch)));
+        return Ok(Some(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            head.chain(stream),
+        ))));
+    }
+    Ok(None)
 }
 
 /// A file's partition identity, normalized for grouping and comparison: the spec
@@ -182,25 +490,20 @@ fn partition_value_pairs(values: &[Option<String>]) -> Vec<(i32, Option<String>)
         .collect()
 }
 
-/// Stream compaction output through DataFusion's spilling sort.
+/// Resolve a table's live sort specification into the ordering compaction and
+/// `UPDATE` apply to their rewritten rows, against `data_schema` — the table's
+/// data columns, which are the LEADING columns of a rewrite batch. `None` means
+/// "write unsorted".
 ///
-/// Batches may carry trailing embedded columns beyond `data_schema`. Sort keys
-/// resolve to the leading data columns, so embedded row lineage stays attached.
-/// An absent sort specification returns the input stream. An unsupported expression
-/// or missing sort column fails before any rewritten file is committed.
-pub(crate) fn sorted_rewrite_output(
-    context: Arc<TaskContext>,
-    batches: Vec<RecordBatch>,
+/// Resolved ONCE per operation, before any source file is read, so a
+/// specification this crate cannot honour fails the whole compaction rather
+/// than depending on which bin happened to contain rows.
+pub(crate) fn compaction_ordering(
     data_schema: &Schema,
     sort_spec: Option<&SortSpec>,
-) -> Result<SendableRecordBatchStream> {
-    let schema = batches
-        .first()
-        .ok_or_else(|| DuckLakeError::Internal("cannot sort empty compaction input".to_string()))?
-        .schema();
-    let input = MemorySourceConfig::try_new_exec(&[batches], Arc::clone(&schema), None)?;
+) -> Result<Option<LexOrdering>> {
     let Some(sort_spec) = sort_spec else {
-        return Ok(input.execute(0, Arc::clone(&context))?);
+        return Ok(None);
     };
     let keys = sort_spec.producible_columns().ok_or_else(|| {
         DuckLakeError::InvalidConfig(format!(
@@ -217,7 +520,7 @@ pub(crate) fn sorted_rewrite_output(
     // `LexOrdering::new` would instead fail a compaction that official completes; the
     // SQL INSERT path already returns "no ordering" for this case.
     if keys.is_empty() {
-        return Ok(input.execute(0, Arc::clone(&context))?);
+        return Ok(None);
     }
 
     let mut expressions = Vec::with_capacity(keys.len());
@@ -235,9 +538,57 @@ pub(crate) fn sorted_rewrite_output(
             },
         ));
     }
-    let ordering = LexOrdering::new(expressions)
-        .ok_or_else(|| DuckLakeError::Internal("sort order is empty".to_string()))?;
-    let sorted: Arc<dyn ExecutionPlan> = Arc::new(SortExec::new(ordering, input));
+    Ok(Some(LexOrdering::new(expressions).ok_or_else(|| {
+        DuckLakeError::Internal("sort order is empty".to_string())
+    })?))
+}
+
+/// Stream already-materialized rewrite output through the same path as a
+/// compaction plan. `UPDATE` holds its rewritten rows in memory (it interleaves
+/// them with per-file delete authoring), so it enters here rather than at
+/// [`sorted_rewrite_output`].
+pub(crate) fn sorted_rewrite_batches(
+    context: Arc<TaskContext>,
+    batches: Vec<RecordBatch>,
+    ordering: Option<&LexOrdering>,
+) -> Result<SendableRecordBatchStream> {
+    let schema = batches
+        .first()
+        .ok_or_else(|| DuckLakeError::Internal("cannot sort empty compaction input".to_string()))?
+        .schema();
+    let input = MemorySourceConfig::try_new_exec(&[batches], schema, None)?;
+    sorted_rewrite_output(context, input, ordering)
+}
+
+/// Stream compaction output through DataFusion's spilling sort.
+///
+/// `input` carries `[data columns..., rowid]` and, for a partial merge, the
+/// embedded snapshot-id column. `ordering` (from [`compaction_ordering`])
+/// resolves against the leading data columns, so the embedded row lineage stays
+/// attached to its row; `None` streams the input through unsorted.
+///
+/// `input` is normally multi-partition — one partition per source file, plus one
+/// per row-group chunk of a large file — because that is how the compaction set
+/// is read in parallel. [`OrderedCoalesceExec`] funnels those partitions back
+/// into the single stream the compaction writer consumes, in order.
+pub(crate) fn sorted_rewrite_output(
+    context: Arc<TaskContext>,
+    input: Arc<dyn ExecutionPlan>,
+    ordering: Option<&LexOrdering>,
+) -> Result<SendableRecordBatchStream> {
+    let schema = input.schema();
+    let input: Arc<dyn ExecutionPlan> = if input.output_partitioning().partition_count() > 1 {
+        Arc::new(OrderedCoalesceExec::new(
+            input,
+            context.session_config().target_partitions(),
+        ))
+    } else {
+        input
+    };
+    let Some(ordering) = ordering else {
+        return Ok(input.execute(0, context)?);
+    };
+    let sorted: Arc<dyn ExecutionPlan> = Arc::new(SortExec::new(ordering.clone(), input));
     let output = Arc::new(ColumnRenameExec::new(sorted, schema, HashMap::new()));
     Ok(output.execute(0, context)?)
 }
@@ -378,6 +729,31 @@ impl DuckLakeTable {
             return Ok(CompactionResult::empty());
         }
 
+        // Safety: the merged output is written at the table's CURRENT schema, so
+        // a source carrying a column dropped since it was written would lose
+        // that column's data (and its source is then removed). Drop any such bin
+        // entirely — those files are left uncompacted rather than silently
+        // losing data. (The common case — files at the current schema, or an
+        // older schema that only ADDED columns — is unaffected.) Settled before
+        // anything else, so a table with only such bins stays a pure no-op.
+        let mut viable: Vec<Vec<&DuckLakeTableFile>> = Vec::with_capacity(bins.len());
+        for bin in bins {
+            let mut drops_columns = false;
+            for tf in &bin {
+                if self.file_drops_current_columns(state, &tf.file).await? {
+                    drops_columns = true;
+                    break;
+                }
+            }
+            if !drops_columns {
+                viable.push(bin);
+            }
+        }
+        let bins = viable;
+        if bins.is_empty() {
+            return Ok(CompactionResult::empty());
+        }
+
         let object_store = state
             .runtime_env()
             .object_store(self.object_store_url().as_ref())?;
@@ -407,6 +783,7 @@ impl DuckLakeTable {
         // bounds each output near target_file_size, so no extra file rollover is
         // needed here.
         let sort_spec = self.live_sort_spec()?;
+        let ordering = compaction_ordering(physical_schema.as_ref(), sort_spec.as_ref())?;
         // Only for naming the output's Hive directory; the partition identity a
         // merged file carries comes from its sources, not from this.
         let live_partition_spec = self.live_partition_spec()?;
@@ -417,43 +794,9 @@ impl DuckLakeTable {
         let mut rows_written = 0i64;
 
         for bin in &bins {
-            // Safety: the merged output is written at the table's CURRENT schema,
-            // so a source carrying a column dropped since it was written would
-            // lose that column's data (and its source is then removed). Skip any
-            // such group entirely — those files are left uncompacted rather than
-            // silently losing data. (The common case — files at the current
-            // schema, or an older schema that only ADDED columns — is unaffected.)
-            let mut bin_would_drop_columns = false;
-            for tf in bin {
-                if self.file_drops_current_columns(state, &tf.file).await? {
-                    bin_would_drop_columns = true;
-                    break;
-                }
-            }
-            if bin_would_drop_columns {
-                continue;
-            }
-
-            // Read each source's live rows (with original rowids) and its origin.
-            let mut per_source: Vec<(Vec<RecordBatch>, i64)> = Vec::with_capacity(bin.len());
-            for tf in bin {
-                let scan = self.build_update_scan(state, tf).await?;
-                let batches =
-                    datafusion::physical_plan::collect(Arc::clone(&scan.scan), state.task_ctx())
-                        .await?;
-                let out = self.apply_update_to_batches(&scan, &batches, None, &[])?;
-                let origin = tf.begin_snapshot.ok_or_else(|| {
-                    DuckLakeError::Internal("merge candidate missing begin_snapshot".to_string())
-                })?;
-                rows_written += out.matched_count as i64;
-                per_source.push((out.updated_batches, origin));
-                sources.push(CompactionSourceFile {
-                    data_file_id: tf.data_file_id,
-                    delete_file_id: None,
-                });
-                files_processed += 1;
-            }
-
+            // Every source's origin snapshot is catalog metadata, so the shape
+            // of the output is settled before a single row is read.
+            //
             // A group spanning >1 origin snapshot is a partial file: embed the
             // per-row snapshot column, record the max origin as partial_max, and
             // set begin_snapshot to the MIN origin so historical reads back to
@@ -461,7 +804,13 @@ impl DuckLakeTable {
             // redundant for every snapshot, so the commit removes + schedules
             // them. A single-origin group needs no per-row column (all rows share
             // one origin), and begins at that origin.
-            let origins: HashSet<i64> = per_source.iter().map(|(_, o)| *o).collect();
+            let mut file_origins: Vec<i64> = Vec::with_capacity(bin.len());
+            for tf in bin {
+                file_origins.push(tf.begin_snapshot.ok_or_else(|| {
+                    DuckLakeError::Internal("merge candidate missing begin_snapshot".to_string())
+                })?);
+            }
+            let origins: HashSet<i64> = file_origins.iter().copied().collect();
             let partial = origins.len() > 1;
             let min_origin = origins.iter().copied().min();
             let partial_max = if partial {
@@ -470,28 +819,37 @@ impl DuckLakeTable {
                 None
             };
 
-            let mut merged: Vec<RecordBatch> = Vec::new();
-            for (batches, origin) in per_source {
-                for b in batches {
-                    if b.num_rows() == 0 {
-                        continue;
-                    }
-                    merged.push(if partial {
-                        append_snapshot_column(&b, origin)?
-                    } else {
-                        b
-                    });
-                }
+            // ONE execution over the whole bin, so DataFusion reads every source
+            // concurrently instead of one object-store round trip at a time.
+            // Each source contributes a leaf that carries its own rowid lineage
+            // (and, for a partial merge, its origin snapshot) as columns, which
+            // is what makes the single scan possible — the same shape official
+            // DuckLake compaction uses.
+            let mut leaves: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(bin.len());
+            for (tf, origin) in bin.iter().zip(&file_origins) {
+                let scan = self.build_update_scan(state, tf).await?;
+                leaves.push(Arc::new(CompactionSourceExec::new(
+                    Arc::new(scan),
+                    Arc::clone(&physical_schema),
+                    partial.then_some(*origin),
+                )));
+                sources.push(CompactionSourceFile {
+                    data_file_id: tf.data_file_id,
+                    delete_file_id: None,
+                });
+                files_processed += 1;
             }
-            if merged.is_empty() {
-                continue;
-            }
+
             let merged = sorted_rewrite_output(
                 state.task_ctx(),
-                merged,
-                physical_schema.as_ref(),
-                sort_spec.as_ref(),
+                UnionExec::try_new(leaves)?,
+                ordering.as_ref(),
             )?;
+            // A bin whose sources hold no rows at all writes no file; its
+            // sources are still retired by the commit below.
+            let Some(merged) = first_nonempty(merged).await? else {
+                continue;
+            };
             // Every file in the bin shares one partition identity (that is the
             // grouping key), so the merged output inherits it: same Hive directory,
             // same `partition_id` + values in the catalog.
@@ -516,6 +874,7 @@ impl DuckLakeTable {
                     subpath.as_deref(),
                 )
                 .await?;
+            rows_written += file.record_count;
             let file = match partition_id {
                 Some(pid) => file.with_partition(pid, partition_value_pairs(&partition_values)),
                 None => file,
@@ -590,9 +949,35 @@ impl DuckLakeTable {
         let top_level_column_ids = self.top_level_column_ids();
         let physical_schema = self.physical_schema();
 
+        // Select the files to rewrite up front, so a table with nothing over the
+        // threshold stays a pure no-op — it must not fail on, say, a sort order
+        // this crate cannot honour.
+        let selected_ids = opts
+            .data_file_ids
+            .map(|ids| ids.into_iter().collect::<HashSet<_>>());
+        let table_files = self.files()?;
+        let candidates: Vec<&DuckLakeTableFile> = table_files
+            .iter()
+            .filter(|tf| match &selected_ids {
+                Some(selected_ids) => selected_ids.contains(&tf.data_file_id),
+                // Threshold selection only applies to files with live deletes.
+                None => {
+                    let record_count = tf.max_row_count.unwrap_or(0);
+                    tf.delete_file_id.is_some()
+                        && record_count > 0
+                        && tf.delete_count.unwrap_or(0) as f64 / record_count as f64
+                            >= opts.delete_threshold
+                },
+            })
+            .collect();
+        if candidates.is_empty() {
+            return Ok(CompactionResult::empty());
+        }
+
         // Re-apply the table's live sort order to each rewritten file so its rows
         // stay ordered (tight min/max) after the delete-driven rewrite.
         let sort_spec = self.live_sort_spec()?;
+        let ordering = compaction_ordering(physical_schema.as_ref(), sort_spec.as_ref())?;
         // Only for naming the output's Hive directory (see `partition_path_names`);
         // a rewritten file inherits its partition identity from the file it replaces.
         let live_partition_spec = self.live_partition_spec()?;
@@ -602,33 +987,22 @@ impl DuckLakeTable {
         let mut files_processed = 0usize;
         let mut rows_written = 0i64;
 
-        let selected_ids = opts
-            .data_file_ids
-            .map(|ids| ids.into_iter().collect::<HashSet<_>>());
-        let table_files = self.files()?;
-        for tf in &table_files {
-            let record_count = tf.max_row_count.unwrap_or(0);
-            let delete_count = tf.delete_count.unwrap_or(0);
-            if let Some(selected_ids) = &selected_ids {
-                if !selected_ids.contains(&tf.data_file_id) {
-                    continue;
-                }
-            } else {
-                // Threshold selection only applies to files with live deletes.
-                if tf.delete_file_id.is_none() || record_count <= 0 {
-                    continue;
-                }
-                let ratio = delete_count as f64 / record_count as f64;
-                if ratio < opts.delete_threshold {
-                    continue;
-                }
-            }
-
+        for tf in candidates {
+            // A rewrite replaces ONE source file, so its scan is already the
+            // whole set; the file's own row groups are what DataFusion reads in
+            // parallel. Rowid lineage rides out of the scan as a column, so the
+            // sort and the parquet write consume the plan directly instead of a
+            // fully collected `Vec<RecordBatch>`.
             let scan = self.build_update_scan(state, tf).await?;
-            let batches =
-                datafusion::physical_plan::collect(Arc::clone(&scan.scan), state.task_ctx())
-                    .await?;
-            let out = self.apply_update_to_batches(&scan, &batches, None, &[])?;
+            let sorted = sorted_rewrite_output(
+                state.task_ctx(),
+                Arc::new(CompactionSourceExec::new(
+                    Arc::new(scan),
+                    Arc::clone(&physical_schema),
+                    None,
+                )),
+                ordering.as_ref(),
+            )?;
 
             files_processed += 1;
             sources.push(CompactionSourceFile {
@@ -636,52 +1010,48 @@ impl DuckLakeTable {
                 delete_file_id: tf.delete_file_id,
             });
 
-            let live_rows = out.matched_count;
-            if live_rows > 0 {
-                let sorted = sorted_rewrite_output(
-                    state.task_ctx(),
-                    out.updated_batches,
+            // Every row deleted: the source is retired with no replacement.
+            let Some(sorted) = first_nonempty(sorted).await? else {
+                continue;
+            };
+
+            // The rewrite drops deleted rows from ONE source file, so the output
+            // holds a subset of that file's rows and therefore its exact
+            // partition: inherit the identity and the Hive directory.
+            let (partition_id, partition_values) = partition_key(tf);
+            let subpath = partition_id.map(|pid| {
+                let names = self.partition_path_names(
+                    live_partition_spec.as_ref(),
+                    pid,
+                    &top_level_column_ids,
+                );
+                crate::partition::hive_subpath(&names, &partition_values)
+            });
+            let file = table_writer
+                .write_compacted_file_stream(
+                    schema_name,
+                    self.table_name(),
                     physical_schema.as_ref(),
-                    sort_spec.as_ref(),
-                )?;
-                // The rewrite drops deleted rows from ONE source file, so the output
-                // holds a subset of that file's rows and therefore its exact
-                // partition: inherit the identity and the Hive directory.
-                let (partition_id, partition_values) = partition_key(tf);
-                let subpath = partition_id.map(|pid| {
-                    let names = self.partition_path_names(
-                        live_partition_spec.as_ref(),
-                        pid,
-                        &top_level_column_ids,
-                    );
-                    crate::partition::hive_subpath(&names, &partition_values)
-                });
-                let file = table_writer
-                    .write_compacted_file_stream(
-                        schema_name,
-                        self.table_name(),
-                        physical_schema.as_ref(),
-                        &column_ids,
-                        &top_level_column_ids,
-                        sorted,
-                        false,
-                        subpath.as_deref(),
-                    )
-                    .await?;
-                let file = match partition_id {
-                    Some(pid) => file.with_partition(pid, partition_value_pairs(&partition_values)),
-                    None => file,
-                };
-                rows_written += live_rows as i64;
-                // A rewrite output holds only currently-live rows and begins at
-                // the compaction snapshot (begin_snapshot = None); its
-                // pre-compaction history is served by the retained sources.
-                outputs.push(CompactionOutputFile {
-                    file,
-                    partial_max: None,
-                    begin_snapshot: None,
-                });
-            }
+                    &column_ids,
+                    &top_level_column_ids,
+                    sorted,
+                    false,
+                    subpath.as_deref(),
+                )
+                .await?;
+            rows_written += file.record_count;
+            let file = match partition_id {
+                Some(pid) => file.with_partition(pid, partition_value_pairs(&partition_values)),
+                None => file,
+            };
+            // A rewrite output holds only currently-live rows and begins at
+            // the compaction snapshot (begin_snapshot = None); its
+            // pre-compaction history is served by the retained sources.
+            outputs.push(CompactionOutputFile {
+                file,
+                partial_max: None,
+                begin_snapshot: None,
+            });
         }
 
         if sources.is_empty() {
@@ -710,14 +1080,60 @@ mod tests {
     use arrow::array::Int64Array;
     use datafusion::prelude::SessionContext;
 
+    /// The compaction plan reads every source partition at once, so its output
+    /// must still be the partitions concatenated IN ORDER — that is what keeps a
+    /// merged file's physical layout a function of its inputs rather than of
+    /// which object-store request happened to return first.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ordered_coalesce_concatenates_partitions_in_order() {
+        const PARTITIONS: i64 = 8;
+        const ROWS_PER_PARTITION: usize = 4;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let partitions: Vec<Vec<RecordBatch>> = (0..PARTITIONS)
+            .map(|index| {
+                let column: ArrayRef = Arc::new(Int64Array::from(vec![index; ROWS_PER_PARTITION]));
+                vec![RecordBatch::try_new(Arc::clone(&schema), vec![column]).unwrap()]
+            })
+            .collect();
+        let input: Arc<dyn ExecutionPlan> =
+            MemorySourceConfig::try_new_exec(&partitions, Arc::clone(&schema), None).unwrap();
+        assert_eq!(
+            input.output_partitioning().partition_count(),
+            PARTITIONS as usize,
+        );
+
+        // A concurrency below the partition count exercises the buffering: a
+        // later partition can finish while an earlier one is still in flight.
+        let exec: Arc<dyn ExecutionPlan> = Arc::new(OrderedCoalesceExec::new(input, 3));
+        assert_eq!(exec.output_partitioning().partition_count(), 1);
+        let batches = datafusion::physical_plan::collect(exec, SessionContext::new().task_ctx())
+            .await
+            .unwrap();
+
+        let values: Vec<i64> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(
+            values,
+            (0..PARTITIONS)
+                .flat_map(|index| std::iter::repeat_n(index, ROWS_PER_PARTITION))
+                .collect::<Vec<i64>>(),
+        );
+    }
+
     #[test]
-    fn sorted_rewrite_output_rejects_expression_sort_key() {
+    fn compaction_ordering_rejects_expression_sort_key() {
         let data_schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
-        let batch = RecordBatch::try_new(
-            Arc::new(data_schema.clone()),
-            vec![Arc::new(Int64Array::from(vec![2, 1]))],
-        )
-        .unwrap();
         let sort_spec = SortSpec {
             sort_id: 7,
             fields: vec![SortField {
@@ -729,12 +1145,7 @@ mod tests {
             }],
         };
 
-        let result = sorted_rewrite_output(
-            SessionContext::new().task_ctx(),
-            vec![batch],
-            &data_schema,
-            Some(&sort_spec),
-        );
+        let result = compaction_ordering(&data_schema, Some(&sort_spec));
         let err = match result {
             Ok(_) => panic!("expression sort key must be rejected"),
             Err(e) => e,

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -464,9 +464,18 @@ pub(crate) fn sorted_rewrite_batches(
 /// Preserving order instead means holding a partition until its turn to be
 /// emitted. The custom operator that did so buffered each one into a `Vec`
 /// outside the memory pool's accounting, which is memory a streaming coalesce
-/// does not need and the pool could not see. Note the coalesce starts every
-/// input partition at once rather than capping concurrency; the count is
-/// bounded by the bin, which `MergeOptions::max_merged_files` already limits.
+/// does not need and the pool could not see.
+///
+/// The coalesce starts every input partition at once rather than capping
+/// concurrency, so the fan-out is worth being explicit about. Partitions are the
+/// bin's row groups, not its files, and two limits bound that from opposite
+/// directions: `MergeOptions::max_merged_files` caps how many files a pass
+/// considers, and the bin's byte budget caps how much data one plan covers — so
+/// many tiny files means many partitions of one row group each, and large files
+/// means few files each contributing several. They cannot both be at maximum.
+/// The batches in flight are bounded too: `CoalescePartitionsExec` feeds a
+/// `tokio::sync::mpsc` channel sized to the partition count, so a producer that
+/// outruns the writer blocks on send rather than accumulating.
 pub(crate) fn sorted_rewrite_output(
     context: Arc<TaskContext>,
     input: Arc<dyn ExecutionPlan>,

--- a/src/table.rs
+++ b/src/table.rs
@@ -2670,6 +2670,10 @@ impl DuckLakeTable {
     /// [`DuckLakeTableWriter::begin_write_with_embedded_rowid`](crate::table_writer::DuckLakeTableWriter::begin_write_with_embedded_rowid).
     /// The original rowid is the embedded column when the file has one, else
     /// `row_id_start + physical_position`.
+    ///
+    /// The per-batch work lives in [`rewrite_scanned_batch`], which compaction
+    /// applies inside its execution plan rather than after a `collect`, so both
+    /// paths produce byte-identical rows.
     #[cfg(feature = "write")]
     pub(crate) fn apply_update_to_batches(
         &self,
@@ -2678,124 +2682,25 @@ impl DuckLakeTable {
         predicate: Option<&Arc<dyn PhysicalExpr>>,
         assignments: &[(usize, Arc<dyn PhysicalExpr>)],
     ) -> DataFusionResult<FileUpdateOutput> {
-        let physical_len = scan.physical_len;
-
-        // Output schema for the rewritten rows: physical columns + rowid.
-        let mut out_fields: Vec<Arc<Field>> =
-            self.physical_schema.fields().iter().cloned().collect();
-        out_fields.push(Arc::new(rowid_field()));
-        let out_schema = Arc::new(Schema::new(out_fields));
+        let out_schema = rewrite_output_schema(&self.physical_schema);
 
         let mut updated_batches: Vec<RecordBatch> = Vec::new();
         let mut new_positions: Vec<i64> = Vec::new();
 
         for batch in batches {
-            let n = batch.num_rows();
-            if n == 0 {
+            let Some(rewritten) = rewrite_scanned_batch(
+                &self.physical_schema,
+                &out_schema,
+                scan,
+                batch,
+                predicate,
+                assignments,
+            )?
+            else {
                 continue;
-            }
-
-            // Coerce physical columns to the catalog types the assignment /
-            // predicate exprs (and the writer) expect.
-            let mut phys_cols: Vec<ArrayRef> = Vec::with_capacity(physical_len);
-            for i in 0..physical_len {
-                phys_cols.push(crate::column_rename::coerce_column(
-                    batch.column(i),
-                    self.physical_schema.field(i).data_type(),
-                )?);
-            }
-            let phys_batch = RecordBatch::try_new(self.physical_schema.clone(), phys_cols.clone())?;
-
-            let row_pos = batch
-                .column(scan.pos_index)
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(format!("{ROW_POS_COLUMN_NAME} column is not Int64"))
-                })?;
-
-            // Predicate mask (all rows when there is no WHERE). A NULL predicate
-            // result is a non-match (SQL semantics).
-            let mask: BooleanArray = match predicate {
-                Some(p) => {
-                    let arr = p.evaluate(&phys_batch)?.into_array(n)?;
-                    let b = arr.as_any().downcast_ref::<BooleanArray>().ok_or_else(|| {
-                        DataFusionError::Execution(
-                            "UPDATE predicate did not evaluate to a boolean".to_string(),
-                        )
-                    })?;
-                    BooleanArray::from(
-                        (0..n)
-                            .map(|i| b.is_valid(i) && b.value(i))
-                            .collect::<Vec<bool>>(),
-                    )
-                },
-                None => BooleanArray::from(vec![true; n]),
             };
-            if mask.true_count() == 0 {
-                continue;
-            }
-
-            // Keep only matched rows, then apply the assignments to them.
-            let matched_phys: Vec<ArrayRef> = phys_cols
-                .iter()
-                .enumerate()
-                .map(|(i, column)| {
-                    let filtered = arrow::compute::filter(column.as_ref(), &mask)
-                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                    crate::column_rename::coerce_column(
-                        &filtered,
-                        self.physical_schema.field(i).data_type(),
-                    )
-                })
-                .collect::<DataFusionResult<_>>()?;
-            let matched_batch =
-                RecordBatch::try_new(self.physical_schema.clone(), matched_phys.clone())?;
-            let matched_rows = matched_batch.num_rows();
-
-            let mut out_cols = matched_phys;
-            for (col_idx, expr) in assignments {
-                let val = expr.evaluate(&matched_batch)?.into_array(matched_rows)?;
-                out_cols[*col_idx] = crate::column_rename::coerce_column(
-                    &val,
-                    self.physical_schema.field(*col_idx).data_type(),
-                )?;
-            }
-
-            // Original rowids: embedded column when present, else synthesized.
-            let matched_pos = arrow::compute::filter(row_pos, &mask)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-            let matched_pos = matched_pos
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .expect("filtered Int64Array");
-            let rowid_col: ArrayRef = if let Some(idx) = scan.embedded_batch_idx {
-                let embedded = batch
-                    .column(idx)
-                    .as_any()
-                    .downcast_ref::<Int64Array>()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal("embedded rowid column is not Int64".to_string())
-                    })?;
-                let embedded: ArrayRef = Arc::new(embedded.clone());
-                arrow::compute::filter(embedded.as_ref(), &mask)
-                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
-            } else {
-                let start = scan
-                    .row_id_start
-                    .expect("row_id_start checked in build_update_scan");
-                Arc::new(Int64Array::from(
-                    matched_pos
-                        .values()
-                        .iter()
-                        .map(|p| start + p)
-                        .collect::<Vec<i64>>(),
-                ))
-            };
-            out_cols.push(rowid_col);
-            updated_batches.push(RecordBatch::try_new(out_schema.clone(), out_cols)?);
-
-            new_positions.extend(matched_pos.values().iter().copied());
+            updated_batches.push(rewritten.batch);
+            new_positions.extend(rewritten.positions);
         }
 
         let matched_count = new_positions.len();
@@ -2812,11 +2717,156 @@ impl DuckLakeTable {
     }
 }
 
+/// Output schema of a rewritten source file: the table's physical columns (in
+/// catalog types) followed by the preserved `rowid`. `UPDATE` and compaction
+/// share it so both emit exactly the same shape.
+#[cfg(feature = "write")]
+pub(crate) fn rewrite_output_schema(physical_schema: &SchemaRef) -> SchemaRef {
+    let mut fields: Vec<Arc<Field>> = physical_schema.fields().iter().cloned().collect();
+    fields.push(Arc::new(rowid_field()));
+    Arc::new(Schema::new(fields))
+}
+
+/// One batch of [`DuckLakeTable::apply_update_to_batches`] output.
+#[cfg(feature = "write")]
+pub(crate) struct RewrittenBatch {
+    /// `[physical columns (catalog types)..., rowid]` for the matched rows.
+    pub(crate) batch: RecordBatch,
+    /// Physical positions of the matched rows within the source file, in batch
+    /// order — the positions the source file's new cumulative delete must mask.
+    pub(crate) positions: Vec<i64>,
+}
+
+/// Rewrite ONE batch read from an [`UpdateSourceScan`] into its
+/// `[physical columns..., rowid]` form, retaining each row's original rowid.
+///
+/// `Ok(None)` means the batch contributed nothing (it was empty, or `predicate`
+/// matched no row); the caller skips it. `out_schema` must be
+/// [`rewrite_output_schema`] of `physical_schema` — it is passed in so a
+/// streaming caller builds it once rather than per batch.
+///
+/// Row-order independent: every value it reads (the physical columns, the
+/// embedded rowid, the physical-position column) travels with its own row, so
+/// the result is the same however the scan is partitioned or merged.
+#[cfg(feature = "write")]
+pub(crate) fn rewrite_scanned_batch(
+    physical_schema: &SchemaRef,
+    out_schema: &SchemaRef,
+    scan: &UpdateSourceScan,
+    batch: &RecordBatch,
+    predicate: Option<&Arc<dyn PhysicalExpr>>,
+    assignments: &[(usize, Arc<dyn PhysicalExpr>)],
+) -> DataFusionResult<Option<RewrittenBatch>> {
+    let physical_len = scan.physical_len;
+    let n = batch.num_rows();
+    if n == 0 {
+        return Ok(None);
+    }
+
+    // Coerce physical columns to the catalog types the assignment /
+    // predicate exprs (and the writer) expect.
+    let mut phys_cols: Vec<ArrayRef> = Vec::with_capacity(physical_len);
+    for i in 0..physical_len {
+        phys_cols.push(crate::column_rename::coerce_column(
+            batch.column(i),
+            physical_schema.field(i).data_type(),
+        )?);
+    }
+    let phys_batch = RecordBatch::try_new(Arc::clone(physical_schema), phys_cols.clone())?;
+
+    let row_pos = batch
+        .column(scan.pos_index)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(format!("{ROW_POS_COLUMN_NAME} column is not Int64"))
+        })?;
+
+    // Predicate mask (all rows when there is no WHERE). A NULL predicate
+    // result is a non-match (SQL semantics).
+    let mask: BooleanArray = match predicate {
+        Some(p) => {
+            let arr = p.evaluate(&phys_batch)?.into_array(n)?;
+            let b = arr.as_any().downcast_ref::<BooleanArray>().ok_or_else(|| {
+                DataFusionError::Execution(
+                    "UPDATE predicate did not evaluate to a boolean".to_string(),
+                )
+            })?;
+            BooleanArray::from(
+                (0..n)
+                    .map(|i| b.is_valid(i) && b.value(i))
+                    .collect::<Vec<bool>>(),
+            )
+        },
+        None => BooleanArray::from(vec![true; n]),
+    };
+    if mask.true_count() == 0 {
+        return Ok(None);
+    }
+
+    // Keep only matched rows, then apply the assignments to them.
+    let matched_phys: Vec<ArrayRef> = phys_cols
+        .iter()
+        .enumerate()
+        .map(|(i, column)| {
+            let filtered = arrow::compute::filter(column.as_ref(), &mask)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+            crate::column_rename::coerce_column(&filtered, physical_schema.field(i).data_type())
+        })
+        .collect::<DataFusionResult<_>>()?;
+    let matched_batch = RecordBatch::try_new(Arc::clone(physical_schema), matched_phys.clone())?;
+    let matched_rows = matched_batch.num_rows();
+
+    let mut out_cols = matched_phys;
+    for (col_idx, expr) in assignments {
+        let val = expr.evaluate(&matched_batch)?.into_array(matched_rows)?;
+        out_cols[*col_idx] =
+            crate::column_rename::coerce_column(&val, physical_schema.field(*col_idx).data_type())?;
+    }
+
+    // Original rowids: embedded column when present, else synthesized.
+    let matched_pos = arrow::compute::filter(row_pos, &mask)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+    let matched_pos = matched_pos
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("filtered Int64Array");
+    let rowid_col: ArrayRef = if let Some(idx) = scan.embedded_batch_idx {
+        let embedded = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("embedded rowid column is not Int64".to_string())
+            })?;
+        let embedded: ArrayRef = Arc::new(embedded.clone());
+        arrow::compute::filter(embedded.as_ref(), &mask)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+    } else {
+        let start = scan
+            .row_id_start
+            .expect("row_id_start checked in build_update_scan");
+        Arc::new(Int64Array::from(
+            matched_pos
+                .values()
+                .iter()
+                .map(|p| start + p)
+                .collect::<Vec<i64>>(),
+        ))
+    };
+    out_cols.push(rowid_col);
+
+    Ok(Some(RewrittenBatch {
+        batch: RecordBatch::try_new(Arc::clone(out_schema), out_cols)?,
+        positions: matched_pos.values().to_vec(),
+    }))
+}
+
 /// Per-source-file read plan + metadata for an `UPDATE`, produced by
 /// [`DuckLakeTable::build_update_scan`] at plan time and consumed by
 /// [`DuckLakeUpdateExec`] at execute time.
 #[cfg(feature = "write")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct UpdateSourceScan {
     /// Positional read plan yielding `[physical columns..., (embedded rowid),
     /// __ducklake_row_pos]` for the source file, already masking rows removed by

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -61,7 +61,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures::stream::{self, TryStreamExt};
 
-use crate::compaction::sorted_rewrite_output;
+use crate::compaction::sorted_rewrite_batches;
 use crate::metadata_writer::{DeleteFileEntry, MetadataWriter, WriteMode};
 use crate::table::{DuckLakeTable, UpdateSourceScan};
 use crate::table_writer::DuckLakeTableWriter;
@@ -275,13 +275,14 @@ impl ExecutionPlan for DuckLakeUpdateExec {
             let sort_spec = table
                 .live_sort_spec()
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            let mut updated_batches = sorted_rewrite_output(
-                Arc::clone(&context),
-                updated_batches,
+            let ordering = crate::compaction::compaction_ordering(
                 physical_schema.as_ref(),
                 sort_spec.as_ref(),
             )
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let mut updated_batches =
+                sorted_rewrite_batches(Arc::clone(&context), updated_batches, ordering.as_ref())
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
             let mut session = table_writer
                 .begin_write_with_embedded_rowid(
                     &schema_name,

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -537,8 +537,12 @@ async fn merge_only_within_a_partition_and_preserves_assignment() {
 /// lineage carried as a column of that scan, the shape official DuckLake
 /// compaction uses. This pins what that has to produce for a bin far wider than
 /// one file: the same rows, the same rowids, the same partition assignment and
-/// the same per-row origin snapshots the old file-at-a-time reads produced, with
-/// the sources' order still visible in the merged file's physical layout.
+/// the same per-row origin snapshots the old file-at-a-time reads produced.
+///
+/// Not the physical row order: the sources are read concurrently and handed on
+/// as they arrive, which is what official does too. Nothing reads that order --
+/// every row carries its own rowid and origin snapshot -- so the assertions
+/// below compare lineage as a set.
 #[tokio::test(flavor = "multi_thread")]
 async fn merge_reads_a_whole_bin_in_one_pass() {
     use datafusion_ducklake::partition::PartitionTransform;
@@ -675,12 +679,18 @@ async fn merge_reads_a_whole_bin_in_one_pass() {
             "partial_max is the MAX origin of the bin"
         );
 
-        // The physical layout: rowids ascending in source (data_file_id) order,
-        // each stamped with the origin snapshot of the file it came from. Read
-        // straight from the parquet, so this is the bytes on disk, not what the
-        // read path reconstructs.
-        let lineage = file_lineage(&temp, &file.path);
-        let expected: Vec<(i64, Option<i64>)> = (0..APPENDS)
+        // Every row keeps its own rowid and the origin snapshot of the file it
+        // came from. Read straight from the parquet, so this is the bytes on
+        // disk, not what the read path reconstructs.
+        //
+        // Compared as a set: the bin's sources are read concurrently and handed
+        // on as they arrive, so physical order is not fixed -- and nothing reads
+        // it, because each row carries its own lineage rather than deriving it
+        // from position. Sorting by rowid is what makes the assertion about the
+        // pairing, which is the part that must hold.
+        let mut lineage = file_lineage(&temp, &file.path);
+        lineage.sort_unstable();
+        let mut expected: Vec<(i64, Option<i64>)> = (0..APPENDS)
             .map(|append_index| {
                 (
                     i64::from(append_index) * 2 + index as i64,
@@ -688,9 +698,10 @@ async fn merge_reads_a_whole_bin_in_one_pass() {
                 )
             })
             .collect();
+        expected.sort_unstable();
         assert_eq!(
             lineage, expected,
-            "merged rows keep their rowid and origin snapshot, in source order"
+            "merged rows keep their rowid and origin snapshot"
         );
     }
 

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -196,6 +196,57 @@ fn file_values(temp: &TempDir, path: &str) -> Vec<i32> {
         .concat()
 }
 
+/// One live data file's catalog row, as `merge_reads_a_whole_bin_in_one_pass`
+/// reads it back.
+#[derive(Debug)]
+struct MergedFile {
+    path: String,
+    partition_id: Option<i64>,
+    partition_value: Option<String>,
+    begin_snapshot: Option<i64>,
+    partial_max: Option<i64>,
+}
+
+/// The embedded lineage columns of a compaction output — `(rowid, origin
+/// snapshot)` per row, in the file's PHYSICAL order. Read from the parquet
+/// itself, so it shows the layout on disk rather than what the read path
+/// reconstructs. The snapshot column is absent unless the file is partial.
+fn file_lineage(temp: &TempDir, path: &str) -> Vec<(i64, Option<i64>)> {
+    let file =
+        std::fs::File::open(temp.path().join("data").join("main").join("t").join(path)).unwrap();
+    let mut out = Vec::new();
+    for batch in ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap()
+    {
+        let batch = batch.unwrap();
+        let rowids = batch
+            .column_by_name("_ducklake_internal_row_id")
+            .expect("a compaction output embeds its rowids")
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .clone();
+        let snapshots = batch
+            .column_by_name("_ducklake_internal_snapshot_id")
+            .map(|column| {
+                column
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .clone()
+            });
+        for i in 0..batch.num_rows() {
+            out.push((
+                rowids.value(i),
+                snapshots.as_ref().map(|column| column.value(i)),
+            ));
+        }
+    }
+    out
+}
+
 /// Downcast the writable `main.t` provider to a `DuckLakeTable` and run `op` on
 /// it (the compaction ops are `DuckLakeTable` methods). A fresh writable catalog
 /// is opened so the table binds to the latest snapshot.
@@ -479,6 +530,175 @@ async fn merge_only_within_a_partition_and_preserves_assignment() {
     assert_eq!(
         read_rows(&temp).await,
         vec![(1, 1), (2, 1), (11, 2), (12, 2)]
+    );
+}
+
+/// A merge reads the WHOLE bin with one plan — every source at once, each row's
+/// lineage carried as a column of that scan, the shape official DuckLake
+/// compaction uses. This pins what that has to produce for a bin far wider than
+/// one file: the same rows, the same rowids, the same partition assignment and
+/// the same per-row origin snapshots the old file-at-a-time reads produced, with
+/// the sources' order still visible in the merged file's physical layout.
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_reads_a_whole_bin_in_one_pass() {
+    use datafusion_ducklake::partition::PartitionTransform;
+    use datafusion_ducklake::{ColumnDef, WriteMode};
+
+    // Wide enough that a serialized read would be doing something visibly
+    // different from one plan over the set, and deep enough in snapshots that
+    // every source has its own origin.
+    const APPENDS: i32 = 12;
+
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(make_writer(&temp).await);
+    let cols = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
+    ];
+    let table_id = {
+        let s = writer
+            .begin_write_transaction("main", "t", &cols, WriteMode::Replace)
+            .unwrap();
+        writer
+            .publish_snapshot(
+                s.table_id,
+                "main",
+                "t",
+                s.snapshot_id,
+                WriteMode::Replace,
+                s.base_snapshot_id,
+                &cols,
+                &s.column_ids,
+            )
+            .unwrap();
+        writer
+            .set_partition_spec(
+                s.table_id,
+                &[("val".to_string(), PartitionTransform::Identity)],
+            )
+            .unwrap();
+        s.table_id
+    };
+
+    // Each append is its own snapshot and touches both partitions, so the merge
+    // sees APPENDS x 2 sources spread over APPENDS origin snapshots, binned into
+    // one output per partition.
+    append(&temp, vec![1, 101], vec![1, 2]).await;
+    let p = pool(&temp).await;
+    let first_snapshot = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    for id in 2..=APPENDS {
+        append(&temp, vec![id, id + 100], vec![1, 2]).await;
+    }
+    let last_snapshot = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
+        )
+        .await,
+        i64::from(APPENDS) * 2,
+    );
+
+    let rows_before = read_rows(&temp).await;
+    let rowids_before = read_id_rowid(&temp).await;
+
+    let result = run_merge(
+        &temp,
+        MergeOptions {
+            target_file_size: 1 << 30,
+            max_merged_files: 1024,
+            min_file_size: 0,
+        },
+    )
+    .await;
+
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: usize::try_from(APPENDS).unwrap() * 2,
+            files_created: 2,
+            rows_written: i64::from(APPENDS) * 2,
+        },
+    );
+    assert_eq!(read_rows(&temp).await, rows_before, "same rows");
+    assert_eq!(read_id_rowid(&temp).await, rowids_before, "same rowids");
+
+    // One merged file per partition, each keeping its sources' assignment, and
+    // each recording the bin's origin span: begin at the MIN origin so time
+    // travel back to it still sees the file, partial_max at the MAX.
+    let live: Vec<MergedFile> = sqlx::query(
+        "SELECT df.path, df.partition_id, fpv.partition_value, df.begin_snapshot, df.partial_max
+         FROM ducklake_data_file AS df
+         LEFT JOIN ducklake_file_partition_value AS fpv
+           ON fpv.data_file_id = df.data_file_id
+         WHERE df.table_id = ? AND df.end_snapshot IS NULL
+         ORDER BY fpv.partition_value",
+    )
+    .bind(table_id)
+    .fetch_all(&p)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| MergedFile {
+        path: r.try_get(0).unwrap(),
+        partition_id: r.try_get(1).unwrap(),
+        partition_value: r.try_get(2).unwrap(),
+        begin_snapshot: r.try_get(3).unwrap(),
+        partial_max: r.try_get(4).unwrap(),
+    })
+    .collect();
+
+    assert_eq!(live.len(), 2, "one merged file per partition: {live:?}");
+    for (index, file) in live.iter().enumerate() {
+        let expected_partition_value = if index == 0 {
+            "1"
+        } else {
+            "2"
+        };
+        assert!(
+            file.partition_id.is_some(),
+            "a merged file of a partitioned table keeps its partition_id"
+        );
+        assert_eq!(
+            file.partition_value.as_deref(),
+            Some(expected_partition_value),
+            "each merged file keeps its sources' partition value"
+        );
+        assert_eq!(
+            file.begin_snapshot,
+            Some(first_snapshot),
+            "begin_snapshot is the MIN origin of the bin"
+        );
+        assert_eq!(
+            file.partial_max,
+            Some(last_snapshot),
+            "partial_max is the MAX origin of the bin"
+        );
+
+        // The physical layout: rowids ascending in source (data_file_id) order,
+        // each stamped with the origin snapshot of the file it came from. Read
+        // straight from the parquet, so this is the bytes on disk, not what the
+        // read path reconstructs.
+        let lineage = file_lineage(&temp, &file.path);
+        let expected: Vec<(i64, Option<i64>)> = (0..APPENDS)
+            .map(|append_index| {
+                (
+                    i64::from(append_index) * 2 + index as i64,
+                    Some(first_snapshot + i64::from(append_index)),
+                )
+            })
+            .collect();
+        assert_eq!(
+            lineage, expected,
+            "merged rows keep their rowid and origin snapshot, in source order"
+        );
+    }
+
+    // Time travel to the first append still sees exactly its rows, served by the
+    // merged partial file.
+    assert_eq!(
+        read_rows_at(&temp, first_snapshot).await,
+        vec![(1, 1), (101, 2)],
     );
 }
 

--- a/tests/it/keyed_mutation_after_compaction_tests.rs
+++ b/tests/it/keyed_mutation_after_compaction_tests.rs
@@ -11,11 +11,18 @@
 //!
 //! Every test here pins that distinction down in the two ways it can break
 //! silently: it asserts the exact surviving `(id, rowid)` rows, AND that the
-//! resolved/written `pos` values are physical indices rather than rowids. The
-//! second assertion is the one that fails if anyone reintroduces rowid-based
-//! resolution — in each case the two numbers differ, and in
-//! `delete_on_rewritten_file_whose_physical_order_is_reversed` they run in
-//! opposite directions.
+//! resolved/written `pos` values are physical indices rather than rowids.
+//!
+//! How the second assertion is made differs, because a merge reads its sources
+//! concurrently and does not fix which slot a row lands in. Where the physical
+//! order IS determined — `delete_on_rewritten_file_whose_physical_order_is_reversed`,
+//! under a sort order that runs position and rowid in opposite directions, and
+//! `keyed_mutation_after_rewrite_with_rowid_holes`, where the rowid run has
+//! gaps — the positions are asserted exactly, and those two are the decisive
+//! coverage. The merge tests instead choose a row whose rowid cannot be a valid
+//! slot of the file, so a rowid-keyed resolver cannot return a plausible answer
+//! by chance, and check that the DELETE records the position the resolver
+//! found.
 
 #![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
 
@@ -363,18 +370,20 @@ async fn delete_after_merge_of_multi_origin_files() {
         "a merge spanning three origin snapshots writes a partial file",
     );
 
-    // id = 2 sits at physical position 1 of the merged file; its rowid is also 1
-    // here, so this case alone cannot distinguish the two — the tests below do.
-    assert_eq!(
-        resolve_in_only_live_file(&temp, id_equals(2)).await,
-        vec![1]
-    );
+    // Resolved rather than hardcoded: a merge reads its sources concurrently and
+    // hands them on as they arrive, so which physical slot id = 2 lands in is not
+    // fixed. What must hold is that the DELETE records the slot the resolver
+    // found — that the delete is keyed on physical position at all. Whether that
+    // position can be told apart from the rowid is settled by the sorted case
+    // below, where the two deliberately run opposite.
+    let position = resolve_in_only_live_file(&temp, id_equals(2)).await;
+    assert_eq!(position.len(), 1, "id = 2 occurs once");
 
     assert_eq!(
         run_dml(&temp, "DELETE FROM ducklake.main.t WHERE id = 2").await,
         1,
     );
-    assert_eq!(live_delete_positions(&temp).await, vec![1]);
+    assert_eq!(live_delete_positions(&temp).await, position);
     assert_eq!(read_rows(&temp).await, vec![(1, 10), (3, 30)]);
     assert_eq!(read_id_rowid(&temp).await, vec![(1, 0), (3, 2)]);
 }
@@ -538,33 +547,39 @@ async fn delete_after_partitioned_merge() {
         "partition val=1 holds rowids 0,2,4 and val=2 holds 1,3,5",
     );
 
-    // id = 2 is the SECOND row of the val=1 partition file, so its position is 1
-    // while its rowid is 2.
+    // id = 3 on purpose, not id = 2: its rowid is 4, which is OUTSIDE the three
+    // slots (0..=2) of the val=1 partition file, so no position a correct
+    // resolver can return is ever equal to it. id = 2 would not do -- its rowid
+    // is 2, a valid slot, so a rowid-keyed resolver could return it and pass by
+    // coincidence once the merge stopped fixing which slot a row lands in.
+    //
+    // Which slot id = 3 actually occupies does depend on the order its source
+    // file's read completed, so the position is resolved rather than asserted.
     let (ctx, provider) = open_table(&temp).await;
     let table = as_ducklake(&provider);
-    let matching = table.files_matching(&id_equals(2)).unwrap();
+    let matching = table.files_matching(&id_equals(3)).unwrap();
     let mut positions: Vec<i64> = table
-        .resolve_positions(&ctx.state(), &matching[0].file, id_equals(2))
+        .resolve_positions(&ctx.state(), &matching[0].file, id_equals(3))
         .await
         .unwrap()
         .into_iter()
         .collect();
     positions.sort_unstable();
-    assert_eq!(
-        positions,
-        vec![1],
-        "physical position 1, not rowid 2 — the gap is what a hole-bearing \
-         rowid run produces",
+    assert_eq!(positions.len(), 1, "id = 3 occurs once");
+    assert!(
+        (0..3).contains(&positions[0]),
+        "a physical position in the three-row partition file, never the rowid 4 \
+         a rowid-keyed resolver would have returned: {positions:?}",
     );
 
     assert_eq!(
-        run_dml(&temp, "DELETE FROM ducklake.main.t WHERE id = 2").await,
+        run_dml(&temp, "DELETE FROM ducklake.main.t WHERE id = 3").await,
         1,
     );
-    assert_eq!(live_delete_positions(&temp).await, vec![1]);
+    assert_eq!(live_delete_positions(&temp).await, positions);
     assert_eq!(
         read_id_rowid(&temp).await,
-        vec![(1, 0), (3, 4), (11, 1), (12, 3), (13, 5)],
+        vec![(1, 0), (2, 2), (11, 1), (12, 3), (13, 5)],
     );
 }
 

--- a/tests/it/keyed_mutation_after_compaction_tests.rs
+++ b/tests/it/keyed_mutation_after_compaction_tests.rs
@@ -19,10 +19,16 @@
 //! under a sort order that runs position and rowid in opposite directions, and
 //! `keyed_mutation_after_rewrite_with_rowid_holes`, where the rowid run has
 //! gaps — the positions are asserted exactly, and those two are the decisive
-//! coverage. The merge tests instead choose a row whose rowid cannot be a valid
-//! slot of the file, so a rowid-keyed resolver cannot return a plausible answer
-//! by chance, and check that the DELETE records the position the resolver
-//! found.
+//! coverage.
+//!
+//! Of the merge tests, only `delete_after_partitioned_merge` can rule out a
+//! rowid-keyed resolver: it deletes a row whose rowid is outside the file's slot
+//! range, so no rowid it returned could look like a valid position.
+//! `delete_after_merge_of_multi_origin_files` cannot — its three rows occupy
+//! slots 0..=2 and carry rowids 0..=2, so every rowid is also a valid slot — and
+//! it stands as a consistency case instead: the DELETE must record the position
+//! the resolver reported, and the surviving rows and their rowids must be
+//! exactly right.
 
 #![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
 


### PR DESCRIPTION
## The problem

`merge_adjacent_files` read its source files one at a time:

```rust
for bin in &bins {
    for tf in bin {
        let scan = self.build_update_scan(state, tf).await?;
        let batches = collect(scan.scan, state.task_ctx()).await?;   // <- awaited, per file
        let out = self.apply_update_to_batches(&scan, &batches, None, &[])?;
    }
}
```

One DataFusion execution per source file, awaited in sequence. A small
compaction candidate is usually a single row group, so each of those
executions is a single scan partition — one object-store round trip at a
time. Merging a bin of N small files therefore costs N round trips end to
end, with the machine's remaining cores idle for all of it. The wall clock
is latency, not work.

It was per-file for a reason: provenance. Every merged row has to keep its
original rowid, and a merged file spanning several origin snapshots has to
record which snapshot each row came from. Both were attached in Rust,
after `collect`ing each file, so the reads could not be pooled.

`rewrite_data_files` had the same `collect`-then-rewrite shape (one source
file per output file, so its scan was already the whole set — but it held
every batch in memory before writing).

## What official DuckLake does

It solves provenance *inside* the scan, with virtual columns, and so gets
to read the whole compaction set with one parallel scan.
`DuckLakeCompactor::GenerateCompactionCommand` in
[`src/functions/ducklake_compaction_functions.cpp`](https://github.com/duckdb/ducklake/blob/main/src/functions/ducklake_compaction_functions.cpp)
builds one `DuckLakeMultiFileList` over the source set, one `LogicalGet`
over that, optionally a sort, then one `LogicalCopyToFile`:

```cpp
copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID;
...
column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
column_ids.emplace_back(DuckLakeMultiFileReader::COLUMN_IDENTIFIER_SNAPSHOT_ID);
```

The row-id and snapshot-id arrive as columns of the scan, so nothing
downstream needs to know which file a row came from — and DuckDB's
executor parallelises the multi-file scan.

## The change

Same shape here. A new `CompactionSourceExec` wraps one source file's
positional read plan and turns each batch into
`[data columns..., rowid]`, plus a constant `_ducklake_internal_snapshot_id`
column when the bin is partial. A bin then becomes one plan:

```
CompactionSourceExec (per source) -> UnionExec -> OrderedCoalesceExec -> SortExec? -> parquet write
```

DataFusion runs the union's partitions concurrently, so the bin's files are
read in parallel rather than one after another.

The per-row rewrite is not reimplemented: the batch-at-a-time body of
`apply_update_to_batches` is extracted as `rewrite_scanned_batch` and shared,
so the `UPDATE` path and compaction produce identical rows by construction.

`rewrite_data_files` keeps its one-output-per-source-file shape and moves onto
the same plan, so it streams into the writer instead of collecting first.

### Row order

`OrderedCoalesceExec` reads up to `target_partitions` input partitions
concurrently, each on its own spawned task, but hands their batches on in
partition order. DataFusion's `CoalescePartitionsExec` would be simpler and
would stream, but it interleaves by arrival — a merged file's physical layout
would then depend on which object-store request returned first. Ordering costs
buffering (a partition is collected, then waits its turn), bounded by the
concurrency; reading the set file by file held the whole set, so this is no
worse.

Row lineage never depended on order — every row carries its own rowid and
origin snapshot — so this is about the output being reproducible from the same
inputs. Official likewise preserves order when it can rely on `row_id_start`
(`PreserveOrderType::PRESERVE_ORDER`), and only drops the guarantee on the path
where it embeds row-ids.

## Semantics

Unchanged: per-row lineage rowids, `partial_max`, the embedded
`_ducklake_internal_snapshot_id` column, `begin_snapshot` = MIN origin
snapshot of the bin, the table's live sort order, and partition identity
(a bin never spans partitions; a merged file keeps its sources').
`CompactionResult` counts are identical — `rows_written` now comes from the
written file's record count rather than a running sum of matched rows, which is
the same number.

One deliberate tightening: the sort order is resolved **once per operation**
instead of per output file, so a specification this crate cannot honour (a
non-column expression, or a key naming a column absent from the schema) fails
the compaction deterministically, rather than depending on whether some bin
happened to contain rows. Both entry points still no-op *without* error when
nothing qualifies — the bins a dropped column rules out, and the rewrite's
candidate selection, are settled before the sort order is resolved.

## Not in this change

Official groups several delete-heavy files into one `REWRITE_DELETES`
compaction; this crate rewrites one source file to one output file. That is a
pre-existing difference and is left alone here — changing it moves output-file
granularity and the source/delete retirement mapping, which is its own change.

## Tests

- `merge_reads_a_whole_bin_in_one_pass` (new, `tests/it/compaction_sqlite_tests.rs`):
  24 sources across 2 partitions and 12 origin snapshots merged in one call.
  Asserts the same rows and rowids as before the merge, one output per
  partition with the sources' partition assignment, `begin_snapshot` /
  `partial_max` at the origin span, time travel to the first snapshot, and —
  read straight out of the parquet — every row's embedded rowid and origin
  snapshot in source order. It passes unmodified against `main`, which is the
  point: the output is byte-for-byte the same work, just read in parallel.
- `ordered_coalesce_concatenates_partitions_in_order` (new, unit): the operator
  concatenates partitions in index order with a concurrency below the partition
  count.
- The existing compaction suite is unchanged, including the two tests that pin
  a merged file's physical row positions for keyed deletes.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and
`cargo test --features "skip-tests-with-docker write-sqlite"` are clean
(365 integration + 367 lib + 8 doc tests). The `--no-default-features` feature
combinations build.
