### PR TITLE
perf(writer): upload staged data files concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `DuckLakeTableWriter::with_upload_concurrency` and
+  `DuckLakeWriteOptions::upload_concurrency` — how many finished data files a rolling
+  or partitioned write uploads at once, defaulting to `DEFAULT_UPLOAD_CONCURRENCY`
+  (4). Uploads are collected in write order, so `row_id_start`, per-file statistics
+  and partition labels are identical at any setting (#280).
+
 - Add read-only DuckLake views across metadata backends and writer-compatible view metadata (#264).
 
+### Changed
+
+- **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. It is a
+  plain `pub` struct, so an exhaustive struct literal — or a destructuring pattern
+  without `..` — stops compiling with "missing field `upload_concurrency`". Add
+  `..Default::default()` to the literal, or set `upload_concurrency: None` to keep the
+  writer default. No catalog or data migration is needed (#280).
+
+  Note this struct has now taken a breaking field addition more than once, and will
+  again for the next write option. Marking it `#[non_exhaustive]` does not fix that on
+  its own — for a struct it forbids struct expressions from other crates entirely,
+  including the `..Default::default()` form every caller currently uses — so a lasting
+  fix means pairing it with setter methods on the options type. That is a broader API
+  decision than this change should make, and is left to the maintainers.
+
+  ```rust
+  let options = DuckLakeWriteOptions {
+      target_file_size: Some(target_bytes),
+      ..Default::default()
+  };
+  ```
+
+- A write uploads up to 4 finished data files concurrently instead of one at a time,
+  raising peak **write memory roughly fourfold** on the paths that use it.
+  `object_store`'s `BufWriter` holds a 10 MiB buffer and keeps up to 8 multipart parts
+  in flight, so one upload of a large file peaks near 90 MiB and four near 360 MiB —
+  **per write session**, with no process-wide cap, so concurrent sessions multiply it.
+
+  Which paths are affected is narrower than it may appear, and worth checking against
+  your own usage rather than assuming. In-crate, the concurrent upload helper is
+  reached only from a streaming `begin_write` session (roll enabled) and from a
+  partitioned write's sink. SQL `INSERT`, compaction, and an unpartitioned SQL
+  `UPDATE` all still upload one file at a time and are unaffected. An embedder that
+  drives `begin_write` and streams batches — the shape a bulk load takes — gets both
+  the speedup and the memory cost.
+
+  Restore the previous behaviour with `DuckLakeTableWriter::with_upload_concurrency(1)`
+  on the writer you construct, or pin the previous release. Note that
+  `DuckLakeWriteOptions { upload_concurrency: Some(1), .. }` only takes effect if the
+  writer is built through `with_options`. The same multiplier applies to request rate —
+  up to 32 in-flight part uploads instead of 8 — worth checking against a rate-limited
+  store, gateway or proxy (#280).
+
+- A custom `ObjectStore` implementation now sees several `put_opts` /
+  `put_multipart_opts` calls from a single write overlapping in time. An
+  implementation that assumed this crate wrote one object at a time — a throttling or
+  ordering-sensitive wrapper, or a test double keyed on call sequence — must be made
+  concurrency-safe, or the writer set to `upload_concurrency: Some(1)` (#280).
+
+- A write whose uploads fail removes the objects from that batch, issuing `DELETE`
+  against the object store to do so. A writer role granted only put/list permissions
+  logs `failed to remove a data file after an aborted upload batch` and leaves the
+  orphans exactly as before; grant delete on the data prefix (`s3:DeleteObject`) to get
+  the cleanup. On a versioned bucket the removal leaves a delete marker rather than
+  reclaiming the bytes — including for files whose upload failed and which may never
+  have existed, since the cleanup covers every path in the batch. The cleanup covers a failure **within the upload batch** only —
+  objects from a write that uploaded everything and then failed to commit metadata are
+  still left behind (#280).
+
+- A failing write can surface its error later than before. Uploads already in flight
+  when the first error appears are awaited rather than dropped, because dropping a
+  future mid-multipart strands upload state that only a bucket lifecycle rule could
+  reclaim. Uploads that have not yet started are skipped, so the cost is bounded by
+  the concurrency setting rather than by the size of the batch. Cleanup of the objects
+  that did land is issued as a single batched delete rather than one request per file.
+  The first error in file order is the one returned; any others are logged (#280).
+
+- Staged-file uploads are wrapped in a new `ducklake.upload_staged_files` tracing span,
+  and the existing per-file `ducklake.upload_staged_file` spans now overlap in
+  wall-clock time. Summing their durations no longer approximates a write's upload
+  time (#280).
+
 ### Fixed
+
+- An upload whose final flush failed panicked with "Already shut down" instead of
+  returning the error. `BufWriter::shutdown` leaves the writer shut down even when it
+  fails, and `BufWriter::abort` panics in that state, so the abort the writer ran on
+  every upload error turned a recoverable object-store failure — an expired credential,
+  a rejected `CompleteMultipartUpload` — into a panicking task. The abort decision now
+  lives inside the upload helper, which aborts a copy failure (where it releases the
+  multipart upload) and returns a flush failure as `DuckLakeError::Io`. No error type
+  or variant changed; code that observed this as a task panic now sees an ordinary
+  `Err`. The fix covers every upload the writer performs — data files, delete files and
+  the single-file write path — not only the concurrent one (#280).
 
 - `files_matching` prunes a data file that carries a delete file. Its recorded
   bounds are marked inexact for readers that apply deletes, and the pruning view

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -41,6 +41,22 @@ pub use crate::partition::PartitionGroup;
 /// descriptors and memory.
 pub const DEFAULT_MAX_OPEN_PARTITIONS: usize = 100;
 
+/// How many finished data files a write uploads to object storage concurrently.
+///
+/// A rolling write finishes each file to local disk and uploads them all in
+/// `finish`, so the uploads are independent I/O with no ordering requirement
+/// between them — only the *resulting* `DataFileInfo` order matters, because
+/// `register_data_files` assigns `row_id_start` by walking that list in order.
+/// Uploading them one at a time leaves the link idle for the whole write.
+///
+/// Kept modest rather than core-count-scaled, because the real cost is memory and
+/// sockets rather than CPU — and it is larger than "one buffer per upload" suggests.
+/// `object_store`'s `BufWriter` holds a 10 MiB buffer AND keeps up to 8 multipart
+/// requests in flight on its own, so N concurrent uploads of large files peak near
+/// `N * 9 * 10 MiB`: roughly 360 MiB at the default of 4, not 40 MiB. Raise this
+/// only against a memory budget that accounts for that multiplier.
+pub const DEFAULT_UPLOAD_CONCURRENCY: usize = 4;
+
 /// Floor on the target data file size, matching official DuckLake's
 /// `MINIMUM_WRITE_FILE_SIZE` (`ducklake_insert.cpp`), which clamps with
 /// `MaxValue<idx_t>(target_file_size, 4096)`. A smaller request would roll a new file
@@ -72,6 +88,9 @@ pub struct DuckLakeWriteOptions {
     /// Max parquet files a partitioned streaming write keeps open at once; `None`
     /// leaves the writer default ([`DEFAULT_MAX_OPEN_PARTITIONS`]).
     pub max_open_partitions: Option<usize>,
+    /// How many finished data files to upload concurrently; `None` leaves the
+    /// writer default ([`DEFAULT_UPLOAD_CONCURRENCY`]). Clamped to at least 1.
+    pub upload_concurrency: Option<usize>,
 }
 
 /// Options shared by streaming and partitioned table writes.
@@ -131,6 +150,10 @@ pub struct DuckLakeTableWriter {
     /// once, so a byte cap bounds reader memory for wide schemas (e.g. large
     /// vector columns). Set via [`DuckLakeTableWriter::with_max_row_group_bytes`].
     max_row_group_bytes: Option<usize>,
+    /// How many finished data files `finish` uploads concurrently. Defaults to
+    /// [`DEFAULT_UPLOAD_CONCURRENCY`]; override via
+    /// [`DuckLakeTableWriter::with_upload_concurrency`].
+    upload_concurrency: usize,
     /// Target data file size in approximate encoded bytes. A write rolls over to a
     /// new file once the current file's estimated encoded size reaches this, so a
     /// large write produces several files instead of one. Paired with a sort order,
@@ -160,6 +183,7 @@ impl DuckLakeTableWriter {
             compression: Compression::UNCOMPRESSED,
             max_row_group_rows: None,
             max_row_group_bytes: None,
+            upload_concurrency: DEFAULT_UPLOAD_CONCURRENCY,
             target_file_size: DEFAULT_TARGET_FILE_SIZE,
             max_open_partitions: DEFAULT_MAX_OPEN_PARTITIONS,
         })
@@ -213,9 +237,18 @@ impl DuckLakeTableWriter {
         self
     }
 
+    /// Override how many finished data files `finish` uploads concurrently.
+    /// Defaults to [`DEFAULT_UPLOAD_CONCURRENCY`]. Values below 1 are clamped to 1
+    /// (a write must still upload its files).
+    #[must_use]
+    pub fn with_upload_concurrency(mut self, files: usize) -> Self {
+        self.upload_concurrency = files.max(1);
+        self
+    }
+
     /// Apply a [`DuckLakeWriteOptions`] set (compression, row-group caps, rollover
-    /// target, open-partition cap). Each field overrides the corresponding setting
-    /// only when present.
+    /// target, open-partition cap, upload concurrency). Each field overrides the
+    /// corresponding setting only when present.
     pub fn with_options(mut self, options: &DuckLakeWriteOptions) -> Self {
         if let Some(compression) = options.compression {
             self.compression = compression;
@@ -231,6 +264,9 @@ impl DuckLakeTableWriter {
         }
         if let Some(files) = options.max_open_partitions {
             self.max_open_partitions = files.max(1);
+        }
+        if let Some(files) = options.upload_concurrency {
+            self.upload_concurrency = files.max(1);
         }
         self
     }
@@ -531,6 +567,7 @@ impl DuckLakeTableWriter {
                             props: self.build_writer_props(),
                             target_file_size: self.target_file_size,
                             max_open: self.max_open_partitions,
+                            upload_concurrency: self.upload_concurrency,
                             open: Vec::new(),
                             staged: Vec::new(),
                         })
@@ -584,6 +621,7 @@ impl DuckLakeTableWriter {
             partition_sink,
             roller,
             rolled: Vec::new(),
+            upload_concurrency: self.upload_concurrency,
             commit_metadata: SnapshotCommitMetadata::default(),
         })
     }
@@ -712,10 +750,7 @@ impl DuckLakeTableWriter {
         let local = tokio::fs::File::open(temp.path()).await?;
         let mut reader = tokio::io::BufReader::new(local);
         let mut upload = ObjectBufWriter::new(Arc::clone(&self.object_store), object_path);
-        if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
-            let _ = upload.abort().await;
-            return Err(e.into());
-        }
+        stream_to_upload(&mut reader, &mut upload).await?;
 
         // Registered relative to the table path (like data files); the reader
         // resolves it against the same table data dir.
@@ -881,10 +916,7 @@ impl DuckLakeTableWriter {
         let local = tokio::fs::File::open(temp.path()).await?;
         let mut reader = tokio::io::BufReader::new(local);
         let mut upload = ObjectBufWriter::new(Arc::clone(&self.object_store), object_path);
-        if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
-            let _ = upload.abort().await;
-            return Err(e.into());
-        }
+        stream_to_upload(&mut reader, &mut upload).await?;
 
         // Collect stats for catalog columns only. Track NaN values while
         // consuming the stream because the Parquet footer omits that signal.
@@ -1569,7 +1601,13 @@ fn finalize_open_file(file: OpenFile) -> Result<StagedFile> {
 
 /// Upload a finished staging file and harvest its per-column stats, returning the
 /// [`DataFileInfo`] for the catalog commit (relative path; the caller stamps any
-/// partition). On failure the multipart upload is aborted so no partial object is left.
+/// partition).
+///
+/// On a COPY failure the multipart upload is aborted, so no partial object is left.
+/// On a FLUSH failure it deliberately is not — `BufWriter::abort` panics once the
+/// writer has been shut down — so a rejected or unacknowledged
+/// `CompleteMultipartUpload` can leave the upload dangling for a bucket lifecycle
+/// rule to reclaim. See [`stream_to_upload`].
 #[tracing::instrument(name = "ducklake.upload_staged_file", level = "info", skip_all)]
 async fn upload_staged_file(
     staged: StagedFile,
@@ -1584,10 +1622,7 @@ async fn upload_staged_file(
     let local = tokio::fs::File::open(&staged.temp).await?;
     let mut reader = tokio::io::BufReader::new(local);
     let mut upload = ObjectBufWriter::new(Arc::clone(object_store), staged.object_path.clone());
-    if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
-        let _ = upload.abort().await;
-        return Err(e.into());
-    }
+    stream_to_upload(&mut reader, &mut upload).await?;
 
     let column_stats = crate::stats_collect::collect_column_stats(
         &staged.temp,
@@ -1644,6 +1679,8 @@ struct PartitionSink {
     /// One roller per partition with a file in progress, oldest first (eviction takes
     /// from the front). Paired with the partition values its files carry.
     open: Vec<(Vec<Option<String>>, RollingFileWriter)>,
+    /// How many finished partition files are uploaded concurrently.
+    upload_concurrency: usize,
     /// Finished files awaiting upload at `finish`, with the partition each belongs to.
     staged: Vec<(Vec<Option<String>>, StagedFile)>,
 }
@@ -1728,18 +1765,166 @@ impl PartitionSink {
                 self.staged.push((values, staged));
             }
         }
-        let mut infos = Vec::with_capacity(self.staged.len());
-        for (values, staged) in std::mem::take(&mut self.staged) {
-            let partition_values: Vec<(i32, Option<String>)> = values
-                .iter()
-                .enumerate()
-                .map(|(i, v)| (i as i32, v.clone()))
-                .collect();
-            let info = upload_staged_file(staged, object_store, &self.column_ids).await?;
-            infos.push(info.with_partition(self.spec.partition_id, partition_values));
-        }
+        // Uploaded concurrently but collected in order: `register_data_files`
+        // assigns `row_id_start` by walking this list, so the order is part of the
+        // committed result even though the uploads themselves are independent.
+        let (values, staged): (Vec<_>, Vec<_>) =
+            std::mem::take(&mut self.staged).into_iter().unzip();
+        let uploaded = upload_staged_files_ordered(
+            staged,
+            object_store,
+            &self.column_ids,
+            self.upload_concurrency,
+        )
+        .await?;
+        // `zip` is positional and truncates silently; the helper asserts that it
+        // returns one info per input, which is what makes this pairing sound.
+        let infos = values
+            .into_iter()
+            .zip(uploaded)
+            .map(|(values, info)| {
+                let partition_values: Vec<(i32, Option<String>)> = values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, v)| (i as i32, v))
+                    .collect();
+                info.with_partition(self.spec.partition_id, partition_values)
+            })
+            .collect();
         Ok(infos)
     }
+}
+
+/// Upload several finished data files concurrently, returning their
+/// [`DataFileInfo`]s **in the original order**.
+///
+/// Order is load-bearing and this is the reason `buffered` is used rather than
+/// `buffer_unordered`: `register_data_files` walks the slice assigning
+/// `row_id_start` from a running counter, so reordering the results would
+/// renumber rows. Official DuckLake assigns row ids in collection order too, so
+/// preserving it here is what keeps the two equivalent.
+///
+/// `concurrency` bounds how many uploads are in flight; each holds its own
+/// object-store write buffer, so this is a memory bound rather than a CPU one.
+///
+/// On failure, uploads already IN FLIGHT are awaited — dropping a future
+/// mid-multipart strands upload state that only a bucket lifecycle rule could
+/// reclaim — while uploads that have not yet STARTED are skipped. That bounds the
+/// cost of a failing batch by the concurrency setting rather than by its size, which
+/// matters because each upload carries the object store's own retry budget (minutes
+/// per request): draining unconditionally turns a store outage into an hours-long
+/// hang. The objects that did land are then removed.
+///
+/// Scope, precisely: this covers a failure WITHIN the upload batch. It does not
+/// cover a metadata/catalog commit that fails after every upload succeeded — those
+/// objects are still left behind. Official DuckLake cleans up the files a write
+/// created in both cases, so that second case remains a divergence; it is
+/// pre-existing and not addressed here.
+#[tracing::instrument(
+    name = "ducklake.upload_staged_files",
+    level = "info",
+    skip_all,
+    fields(files = staged.len(), concurrency)
+)]
+async fn upload_staged_files_ordered(
+    staged: Vec<StagedFile>,
+    object_store: &Arc<dyn ObjectStore>,
+    column_ids: &[i64],
+    concurrency: usize,
+) -> Result<Vec<DataFileInfo>> {
+    // Paired with its destination so a failed batch can remove what it wrote: the
+    // returned `DataFileInfo` carries a catalog-relative path, not the object key.
+    let targets: Vec<ObjectPath> = staged.iter().map(|s| s.object_path.clone()).collect();
+    // Once the batch has failed, uploads that have not STARTED are skipped. Draining
+    // them unconditionally is what makes a store outage catastrophic rather than slow:
+    // each upload carries the object store's own retry budget (minutes per request),
+    // so a large batch against an unreachable store would hold the caller for hours.
+    // Uploads already in flight are still awaited — dropping those is what strands a
+    // multipart upload — so the anti-strand property is unchanged.
+    let failed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let results: Vec<Option<Result<DataFileInfo>>> =
+        futures::stream::iter(staged.into_iter().map(|s| {
+            let failed = Arc::clone(&failed);
+            async move {
+                if failed.load(std::sync::atomic::Ordering::Relaxed) {
+                    return None;
+                }
+                let outcome = upload_staged_file(s, object_store, column_ids).await;
+                if outcome.is_err() {
+                    failed.store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+                Some(outcome)
+            }
+        }))
+        .buffered(concurrency.max(1))
+        .collect()
+        .await;
+
+    let mut infos = Vec::with_capacity(results.len());
+    let mut failure = None;
+    for (index, result) in results.into_iter().enumerate() {
+        let Some(result) = result else {
+            continue;
+        }; // never started
+        match result {
+            Ok(info) => infos.push(info),
+            Err(e) => {
+                // Keep the FIRST error in file order as the one returned, but do not
+                // swallow the rest: a batch can produce several failures before the skip takes
+                // effect, so a systemic cause (an expired credential, a store that went away) shows
+                // up as several failures of which only one would otherwise be visible.
+                if failure.is_none() {
+                    failure = Some(e);
+                } else {
+                    tracing::warn!(
+                        error = %e,
+                        file_index = index,
+                        "additional upload failure in the same batch"
+                    );
+                }
+            },
+        }
+    }
+    if let Some(e) = failure {
+        // EVERY path in the batch, not only those that reported success. An upload
+        // that fails at flush — a rejected or unacknowledged `CompleteMultipartUpload`
+        // — returns an error while its object may well exist, and that is precisely
+        // the case most likely to strand. Paths whose upload was skipped were never
+        // created, and deleting a key that does not exist is a harmless no-op.
+        //
+        // Best effort: the write is already failing, so a delete that also fails must
+        // not mask the original error. Anything surviving is reclaimable as an orphan,
+        // since no snapshot references it.
+        // `delete_stream`, not a loop of `delete`: it is a required trait method whose
+        // S3 implementation batches into `DeleteObjects` and whose other backends run
+        // deletes concurrently. A sequential loop costs one full retry budget per file
+        // precisely when the store is unhealthy.
+        let to_delete = futures::stream::iter(targets.into_iter().map(Ok));
+        let mut deletions = object_store.delete_stream(to_delete.boxed());
+        while let Some(outcome) = deletions.next().await {
+            match outcome {
+                Ok(_)
+                | Err(object_store::Error::NotFound {
+                    ..
+                }) => {},
+                Err(cleanup) => tracing::warn!(
+                    error = %cleanup,
+                    "failed to remove a data file after an aborted upload batch"
+                ),
+            }
+        }
+        return Err(e);
+    }
+    // The load-bearing invariant of the skip: a `None` (never started) is only
+    // possible once some future has already errored, so on the success path every
+    // input must have produced an info. If this ever broke, the commit would register
+    // FEWER files than were written — rows lost with no error.
+    debug_assert_eq!(
+        infos.len(),
+        targets.len(),
+        "a skipped upload must imply a returned error"
+    );
+    Ok(infos)
 }
 
 /// Streaming write session. Batches stream to a local staging file; the
@@ -1804,6 +1989,8 @@ pub struct TableWriteSession {
     roller: Option<RollingFileWriter>,
     /// Files the roller has finished, awaiting upload at `finish`.
     rolled: Vec<StagedFile>,
+    /// How many of those files `finish` uploads concurrently.
+    upload_concurrency: usize,
     commit_metadata: SnapshotCommitMetadata,
 }
 
@@ -1980,11 +2167,13 @@ impl TableWriteSession {
             if let Some(staged) = roller.finish()? {
                 self.rolled.push(staged);
             }
-            let mut file_infos = Vec::with_capacity(self.rolled.len());
-            for staged in std::mem::take(&mut self.rolled) {
-                file_infos
-                    .push(upload_staged_file(staged, &self.object_store, &self.column_ids).await?);
-            }
+            let file_infos = upload_staged_files_ordered(
+                std::mem::take(&mut self.rolled),
+                &self.object_store,
+                &self.column_ids,
+                self.upload_concurrency,
+            )
+            .await?;
             if file_infos.is_empty() {
                 // No rows arrived. Fall through to the single-file path, which
                 // registers the 0-row marker a Replace needs to retire the prior
@@ -2125,13 +2314,13 @@ impl TableWriteSession {
                 // partition fence) — same behaviour as a non-rolling session.
                 vec![self.upload_staged().await?]
             } else {
-                let mut file_infos = Vec::with_capacity(self.rolled.len());
-                for staged in std::mem::take(&mut self.rolled) {
-                    file_infos.push(
-                        upload_staged_file(staged, &self.object_store, &self.column_ids).await?,
-                    );
-                }
-                file_infos
+                upload_staged_files_ordered(
+                    std::mem::take(&mut self.rolled),
+                    &self.object_store,
+                    &self.column_ids,
+                    self.upload_concurrency,
+                )
+                .await?
             }
         } else {
             vec![self.upload_staged().await?]
@@ -2213,10 +2402,7 @@ impl TableWriteSession {
         let mut reader = tokio::io::BufReader::new(local);
         let mut upload =
             ObjectBufWriter::new(Arc::clone(&self.object_store), self.object_path.clone());
-        if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
-            let _ = upload.abort().await;
-            return Err(e.into());
-        }
+        stream_to_upload(&mut reader, &mut upload).await?;
 
         // Harvest per-column statistics from the parquet footer we just wrote
         // (mirrors DuckLake reading its writer's WRITTEN_FILE_STATISTICS) and
@@ -2250,9 +2436,18 @@ async fn stream_to_upload<R>(reader: &mut R, upload: &mut ObjectBufWriter) -> st
 where
     R: tokio::io::AsyncRead + Unpin + ?Sized,
 {
-    tokio::io::copy(reader, upload).await?;
-    upload.shutdown().await?;
-    Ok(())
+    // The abort decision lives here rather than at each call site, because only ONE
+    // of the two failure modes may be aborted and getting it wrong is a panic, not a
+    // wrong result: `BufWriter::abort` panics if the writer has already been shut
+    // down, and a failing `shutdown` leaves it in exactly that state. So aborting
+    // after a flush failure turns a recoverable upload error into a panicking task.
+    // Aborting after a copy failure is both safe and necessary — it releases the
+    // multipart upload instead of stranding it.
+    if let Err(e) = tokio::io::copy(reader, upload).await {
+        let _ = upload.abort().await;
+        return Err(e);
+    }
+    upload.shutdown().await
 }
 
 /// Read the parquet footer length (thrift metadata + 8-byte trailer) from the

--- a/tests/it/concurrent_staged_upload_tests.rs
+++ b/tests/it/concurrent_staged_upload_tests.rs
@@ -1,0 +1,421 @@
+//! Ordered-concurrent staged-file upload.
+//!
+//! `TableWriteSession::finish` uploads the files a rolling write produced with
+//! several in flight, but must register them in WRITE ORDER: the commit assigns
+//! each file's `row_id_start` by walking the list and advancing a running counter
+//! (`register_data_files_with_commit_metadata`). Reordering the uploads would
+//! renumber rows silently — no error, no failed commit, just different lineage ids
+//! and different per-file value ranges.
+//!
+//! So these tests pin the ORDERING PROPERTY, not the concurrency: the same write
+//! must produce byte-identical catalog rows at `upload_concurrency` 1 and at 4.
+//! Official DuckLake assigns row ids in collection order too, which is why
+//! preserving it here is what keeps the two equivalent.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::Int32Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+
+use datafusion_ducklake::{DuckLakeTableWriter, MetadataWriter, SqliteMetadataWriter, WriteMode};
+use sqlx::sqlite::SqlitePool;
+
+/// One committed data file as the catalog records it: `(row_id_start, id min,
+/// id max, record_count)`. Everything an out-of-order registration could corrupt.
+type CommittedFile = (Option<i64>, Option<String>, Option<String>, i64);
+
+async fn create_writer(temp_dir: &TempDir) -> SqliteMetadataWriter {
+    let db_path = temp_dir.path().join("test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    writer
+}
+
+fn table_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+/// One rolling append of `batches` at the given upload concurrency. Returns
+/// `(files_written, per-file (row_id_start, min_id, max_id) ordered by data_file_id)`.
+async fn rolling_append(
+    upload_concurrency: usize,
+) -> (
+    usize,
+    Vec<(Option<i64>, Option<String>, Option<String>, i64)>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+    let schema = table_schema();
+
+    // Ascending, disjoint id ranges per batch, and a small target file size, so the
+    // write rolls into several files whose value ranges are checkable and whose
+    // correct order is unambiguous.
+    // Deliberately UNEVEN batch sizes. With uniform batches every file holds the
+    // same row count, so `row_id_start` comes out 0, N, 2N... under every possible
+    // permutation and cannot discriminate order at all.
+    let mut next_id = 0i32;
+    let batches: Vec<RecordBatch> = (0..24)
+        .map(|b: i32| {
+            let count = 40 + (b % 7) * 37;
+            let ids: Vec<i32> = (next_id..next_id + count).collect();
+            next_id += count;
+            let vals: Vec<i32> = ids.iter().map(|id| id * 10).collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    let mut session = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .with_target_file_size(4 * 1024)
+        .with_upload_concurrency(upload_concurrency)
+        .begin_write("main", "t", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    for batch in &batches {
+        session.write_batch(batch).unwrap();
+    }
+    let result = session.finish().await.unwrap();
+    assert!(
+        result.files_written > 1,
+        "the write must span several files or concurrency is untested, got {}",
+        result.files_written
+    );
+    assert_eq!(result.records_written, i64::from(next_id));
+
+    let db_path = temp_dir.path().join("test.db");
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    // `row_id_start` plus the id column's recorded bounds, in data_file_id order —
+    // which is the order the commit walked the uploaded list in.
+    let rows: Vec<CommittedFile> = sqlx::query_as(
+        "SELECT d.row_id_start, s.min_value, s.max_value, d.record_count
+           FROM ducklake_data_file d
+           JOIN ducklake_file_column_stats s ON s.data_file_id = d.data_file_id
+          WHERE d.end_snapshot IS NULL AND s.column_id = 1
+          ORDER BY d.data_file_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    (result.files_written, rows)
+}
+
+/// The property: concurrency changes nothing the catalog records.
+#[tokio::test(flavor = "multi_thread")]
+async fn staged_uploads_register_in_write_order_regardless_of_concurrency() {
+    let (serial_files, serial_rows) = rolling_append(1).await;
+    let (concurrent_files, concurrent_rows) = rolling_append(4).await;
+
+    assert_eq!(
+        serial_files, concurrent_files,
+        "same input must produce the same file count"
+    );
+    assert_eq!(
+        serial_rows, concurrent_rows,
+        "row_id_start and per-file id bounds must be identical at concurrency 1 and 4 — \
+         a difference means the uploads were registered out of write order"
+    );
+}
+
+/// `row_id_start` must be strictly ascending in data_file_id order and contiguous:
+/// each file starts exactly where the previous one ended. This is the invariant an
+/// out-of-order registration breaks, stated directly rather than only by comparison.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_staged_uploads_keep_row_ids_contiguous_and_ascending() {
+    let (files_written, rows) = rolling_append(4).await;
+    assert_eq!(rows.len(), files_written);
+
+    let starts: Vec<i64> = rows.iter().filter_map(|(s, _, _, _)| *s).collect();
+    assert_eq!(
+        starts.len(),
+        rows.len(),
+        "every file must carry a row_id_start"
+    );
+    // THIS test is the ordering guard, via the ascending per-file minima below. The
+    // sibling test that compares concurrency 1 against 4 is only a secondary
+    // consistency check: a reordering bug that is not concurrency-dependent applies
+    // to both of its runs and cancels out, so a total list inversion passes it.
+    //
+    // Contiguity itself is a commit invariant rather than an ordering guard — row ids
+    // stay contiguous however the list was ordered, since the counter walks whatever
+    // it is given. It is asserted because a gap or overlap corrupts lineage on its own.
+    let counts: Vec<i64> = rows.iter().map(|(_, _, _, c)| *c).collect();
+    let mut expected = starts[0];
+    for (i, (start, count)) in starts.iter().zip(&counts).enumerate() {
+        assert_eq!(
+            *start, expected,
+            "file {i}: row_id_start must continue the previous file's range; \
+             starts={starts:?} counts={counts:?}"
+        );
+        expected += count;
+    }
+
+    // Per-file id ranges must also ascend and not overlap: the source ids were
+    // written ascending, so a file covering a lower range than its predecessor is
+    // exactly the reordering symptom.
+    let mins: Vec<i32> = rows
+        .iter()
+        .filter_map(|(_, min, _, _)| min.as_ref().and_then(|m| m.parse::<i32>().ok()))
+        .collect();
+    assert_eq!(
+        mins.len(),
+        rows.len(),
+        "every file must record an id minimum"
+    );
+    assert!(
+        mins.windows(2).all(|w| w[0] < w[1]),
+        "per-file id minima must ascend with data_file_id, got {mins:?}"
+    );
+    // Ascending minima alone do not prove the ranges do not OVERLAP, and `max` is
+    // already selected — so assert the real property: each file's range ends before
+    // the next one begins.
+    let maxes: Vec<i32> = rows
+        .iter()
+        .filter_map(|(_, _, max, _)| max.as_ref().and_then(|m| m.parse::<i32>().ok()))
+        .collect();
+    assert_eq!(
+        maxes.len(),
+        rows.len(),
+        "every file must record an id maximum"
+    );
+    for i in 0..rows.len() - 1 {
+        assert!(
+            maxes[i] < mins[i + 1],
+            "file {i} must end before file {} begins: maxes={maxes:?} mins={mins:?}",
+            i + 1
+        );
+    }
+    // And the sequence must start at 0 and cover every row, which pins the ends that
+    // a purely relative check leaves free.
+    assert_eq!(starts[0], 0, "row ids must start at 0, got {starts:?}");
+    // The fixture's premise: uniform file sizes make `row_id_start` identical under
+    // every permutation, so the checks above would prove nothing. Pin it, or a future
+    // change to rollover silently degrades this test to a tautology.
+    assert!(
+        counts
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            > 1,
+        "files must differ in row count or ordering cannot be detected: {counts:?}"
+    );
+    assert_eq!(
+        starts[starts.len() - 1] + counts[counts.len() - 1],
+        counts.iter().sum::<i64>(),
+        "the last file must end at the total row count"
+    );
+}
+
+/// A store that delegates to a real one but fails the Nth write.
+///
+/// Exists because the cleanup branch — delete what landed when a sibling upload
+/// fails — is the one part of this change that DELETES objects, and it is
+/// unreachable from a success-path test. An untested delete loop is exactly the
+/// thing that should not ship.
+#[derive(Debug)]
+struct FailNthWrite {
+    inner: Arc<dyn object_store::ObjectStore>,
+    writes: std::sync::atomic::AtomicUsize,
+    fail_on: usize,
+}
+
+impl std::fmt::Display for FailNthWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FailNthWrite({})", self.fail_on)
+    }
+}
+
+impl FailNthWrite {
+    fn should_fail(&self) -> bool {
+        use std::sync::atomic::Ordering;
+        self.writes.fetch_add(1, Ordering::SeqCst) + 1 == self.fail_on
+    }
+    fn injected() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "FailNthWrite",
+            source: "injected upload failure".into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl object_store::ObjectStore for FailNthWrite {
+    async fn put_opts(
+        &self,
+        location: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        opts: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult> {
+        if self.should_fail() {
+            return Err(Self::injected());
+        }
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &object_store::path::Path,
+        opts: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        if self.should_fail() {
+            return Err(Self::injected());
+        }
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: futures::stream::BoxStream<
+            'static,
+            object_store::Result<object_store::path::Path>,
+        >,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> object_store::Result<object_store::ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+        options: object_store::CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}
+
+/// When one upload in a concurrent batch fails, the files that DID land must be
+/// removed rather than left as orphans, and the original error must surface — not a
+/// cleanup error masking it.
+///
+/// This is the failure path official DuckLake covers by tracking the files a write
+/// created and removing them when it does not commit.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_upload_removes_the_files_that_already_landed() {
+    use futures::StreamExt;
+
+    const FAIL_ON: usize = 3;
+    const CONCURRENCY: usize = 4;
+    // Enough batches to roll into MANY files: the skip is only observable if the
+    // write would otherwise attempt far more uploads than the in-flight window.
+    const TOTAL_BATCHES: usize = 400;
+
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let data_dir = temp_dir.path().join("data");
+    let real: Arc<dyn object_store::ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(&data_dir).unwrap());
+    // Fail the 3rd write. Which FILE that is depends on scheduling, but the outcome
+    // does not: at least one file lands before it, and the assertions below are
+    // indifferent to which.
+    let failing = Arc::new(FailNthWrite {
+        inner: Arc::clone(&real),
+        writes: std::sync::atomic::AtomicUsize::new(0),
+        fail_on: FAIL_ON,
+    });
+    let store_writes = Arc::clone(&failing);
+    let store: Arc<dyn object_store::ObjectStore> = failing;
+    let schema = table_schema();
+
+    let mut session = DuckLakeTableWriter::new(writer.clone(), Arc::clone(&store))
+        .unwrap()
+        .with_target_file_size(4 * 1024)
+        .with_upload_concurrency(CONCURRENCY)
+        .begin_write("main", "t", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    for b in 0..TOTAL_BATCHES as i32 {
+        let ids: Vec<i32> = (b * 100..(b + 1) * 100).collect();
+        let vals: Vec<i32> = ids.iter().map(|id| id * 10).collect();
+        session
+            .write_batch(
+                &RecordBatch::try_new(
+                    schema.clone(),
+                    vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+    }
+    let err = session
+        .finish()
+        .await
+        .expect_err("the injected upload failure must fail the write");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("injected upload failure"),
+        "the original upload error must surface; got: {msg}"
+    );
+
+    // Nothing may be left behind: every object this batch landed before the failure
+    // must have been removed. A leak here is billable storage no snapshot references.
+    let leftovers: Vec<String> = real
+        .list(None)
+        .filter_map(|m| async move { m.ok().map(|m| m.location.to_string()) })
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .filter(|p| p.ends_with(".parquet"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "a failed concurrent upload batch must leave no data files behind, found: {leftovers:?}"
+    );
+
+    // The skip itself, which nothing else pins: once a batch has failed, uploads that
+    // have not started are abandoned rather than drained. Without it, EVERY file in
+    // the batch is uploaded before the error surfaces — which on a real store means
+    // one full retry budget each, turning an outage into an hours-long hang instead
+    // of a prompt failure. Removing the skip flag and reverting to an unconditional
+    // drain leaves every other assertion in this file passing, so assert the write
+    // count directly.
+    let attempted = store_writes
+        .writes
+        .load(std::sync::atomic::Ordering::SeqCst);
+    // The write rolls into far more files than this, so an unconditional drain would
+    // attempt all of them. Only the in-flight window may run past the first failure.
+    assert!(
+        attempted <= FAIL_ON + CONCURRENCY,
+        "a failed batch must abandon uploads it had not started: attempted \
+         {attempted}, expected <= {} (fail_on {FAIL_ON} + concurrency {CONCURRENCY})",
+        FAIL_ON + CONCURRENCY
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -24,6 +24,7 @@ mod column_stats_tests;
 mod common;
 mod compaction_postgres_tests;
 mod compaction_sqlite_tests;
+mod concurrent_staged_upload_tests;
 mod concurrent_tests;
 mod concurrent_write_tests;
 mod delete_filter_tests;

--- a/tests/it/partition_write_tests.rs
+++ b/tests/it/partition_write_tests.rs
@@ -1378,3 +1378,147 @@ async fn empty_overwrite_truncates_partitioned_table() {
         "empty INSERT OVERWRITE must truncate the partitioned table, not conflict"
     );
 }
+
+/// `PartitionSink::into_file_infos` zips each file's partition values onto the
+/// concurrent upload results positionally, so a desynchronisation mislabels which
+/// partition a file belongs to — no error, no change in row count.
+///
+/// SCOPE, stated precisely, because the previous version of this comment overstated
+/// it. This is a SMOKE TEST for the partitioned concurrent path, not a proven
+/// regression guard: flipping the shared helper to `buffer_unordered` does not
+/// reliably fail it, because on a local store these uploads complete in submission
+/// order however they are polled. The proven ordering guards are the two tests in
+/// `concurrent_staged_upload_tests`, which do fail under that mutation and exercise
+/// the same helper this path calls.
+///
+/// The single-run assertion below is a genuine but PARTIAL check: the fixture gives
+/// the `us` partition 3000-row files and the others 600-row files, so it catches a
+/// label that crossed between `us` and any other partition. A mislabel confined to
+/// `{eu, apac, latam}` is invisible to it, since those three are indistinguishable
+/// by row count.
+///
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_staged_uploads_are_order_stable_across_concurrency() {
+    use arrow::array::{ArrayRef, Int32Array, RecordBatch, TimestampMicrosecondArray};
+    use arrow::datatypes::{Field, Schema};
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    /// One streaming partitioned write at the given upload concurrency. Returns the
+    /// committed `(partition key index, partition value, row_id_start,
+    /// record_count)` in data_file_id order — everything the ordering could corrupt.
+    async fn write_at(concurrency: usize) -> Vec<(Option<i32>, Option<String>, Option<i64>, i64)> {
+        let env = setup().await; // partitioned by (region, year(ts))
+        let ts_type = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("region", DataType::Utf8, true),
+            Field::new("ts", ts_type, true),
+        ]));
+        let y2023: i64 = 1_673_776_800_000_000;
+        // Several partitions, each large enough to roll, so the sink finishes many
+        // staged files and the uploads genuinely overlap.
+        // Partition sizes are skewed so the uploads differ in duration, and so that
+        // `us` files are distinguishable from the rest by row count — which is what
+        // the assertion at the end relies on. The skew was NOT enough to make
+        // completion order diverge on a local store; see the scope note on this test.
+        let regions = ["us", "eu", "apac", "latam"];
+        let mut next_id = 0i32;
+        let batches: Vec<RecordBatch> = (0..40)
+            .map(|b: i32| {
+                let region = regions[(b as usize) % regions.len()];
+                let count = if region == "us" {
+                    3000
+                } else {
+                    60
+                };
+                let ids: Vec<i32> = (next_id..next_id + count).collect();
+                next_id += count;
+                let n = ids.len();
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from(ids)) as ArrayRef,
+                        Arc::new(arrow::array::StringArray::from(vec![region; n])) as ArrayRef,
+                        Arc::new(TimestampMicrosecondArray::from(vec![y2023; n])) as ArrayRef,
+                    ],
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let writer = SqliteMetadataWriter::new_with_init(&env.conn_str)
+            .await
+            .unwrap();
+        let object_store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new());
+        let mut session = DuckLakeTableWriter::new(Arc::new(writer), object_store)
+            .unwrap()
+            .with_target_file_size(8 * 1024)
+            .with_upload_concurrency(concurrency)
+            .begin_write("main", "events", schema.as_ref(), WriteMode::Append)
+            .unwrap();
+        for batch in &batches {
+            session.write_batch(batch).unwrap();
+        }
+        let result = session.finish().await.unwrap();
+        assert_eq!(result.records_written, i64::from(next_id));
+        assert!(
+            result.files_written > 4,
+            "the write must span several files per partition or concurrency is \
+             untested, got {}",
+            result.files_written
+        );
+
+        let pool = sqlx::sqlite::SqlitePool::connect(&env.conn_str)
+            .await
+            .unwrap();
+        sqlx::query_as(
+            // Both partition keys: the table is partitioned by (region, year(ts)),
+            // and a positional mix-up could corrupt either. Checking only index 0
+            // would miss a file whose year landed on the wrong row.
+            "SELECT p.partition_key_index, p.partition_value, d.row_id_start,
+                    d.record_count
+               FROM ducklake_data_file d
+               LEFT JOIN ducklake_file_partition_value p
+                      ON p.data_file_id = d.data_file_id
+              WHERE d.end_snapshot IS NULL
+              ORDER BY d.data_file_id, p.partition_key_index",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap()
+    }
+
+    let serial = write_at(1).await;
+    let concurrent = write_at(4).await;
+
+    // Absolute check within ONE run: a `us` file must hold 3000 rows and any other
+    // partition's file 600. This catches a label that crossed between `us` and the
+    // rest — which a 1-vs-4 comparison cannot, since a reordering applying to both
+    // runs cancels out. It does NOT distinguish eu/apac/latam from each other.
+    for rows in [&serial, &concurrent] {
+        for (key_index, value, _start, count) in rows.iter() {
+            if *key_index != Some(0) {
+                continue;
+            }
+            let expected = if value.as_deref() == Some("us") {
+                3000
+            } else {
+                600
+            };
+            assert_eq!(
+                *count, expected,
+                "partition {value:?} holds {expected}-row files by construction; a \
+                 different count means this file's partition label came from another \
+                 file's slot"
+            );
+        }
+    }
+
+    assert_eq!(
+        serial, concurrent,
+        "partition values, row_id_start and record_count must be identical at \
+         concurrency 1 and 4 — a difference means the sink registered its files out \
+         of order, so partition labels or row ids landed on the wrong file"
+    );
+}


### PR DESCRIPTION
## What

A rolling write finishes each data file to local disk and uploads them all in
`finish()`, one after another, strictly after every batch has been encoded. For a
write that rolls into many files that is a long tail of sequential object-store PUTs
with the encode side already done and idle. `PartitionSink` has the same shape per
partition.

Upload with a bounded number in flight instead.

## Order is preserved structurally

`buffered`, not `buffer_unordered`. `buffered` is backed by `FuturesOrdered`, so
completion order cannot reorder the returned vector — this is a property of the
combinator, not something the tests merely happen to observe.

It matters because the commit assigns each file's `row_id_start` by walking the
registered list and advancing a counter, so reordering would renumber rows silently:
no error, no failed commit, no change in row count.

This matches DuckLake rather than merely being cautious. `AddWrittenFiles` pushes
files in copy-output order (`ducklake_insert.cpp:119`), `Finalize` appends that
vector, the transaction-local append preserves it (`ducklake_transaction.cpp:182`),
and commit assigns `row_id_start = next_row_id` while walking `new_data_files`
(`ducklake_transaction_state.cpp:1116`). The metadata writers here do the same, e.g.
`metadata_writer_sqlite.rs:2569`.

Nothing else about a successful write changes: same `ducklake_data_file` rows, same
snapshot shape, same `ducklake_file_column_stats`, same partition-value attachment,
same parquet bytes and names.

## Also fixes a panic on upload failure

Found while writing the cleanup test below, and worth flagging separately because it
is independent of the concurrency work: **any upload failure at flush time panicked
the task instead of returning an error.**

`stream_to_upload` does `copy` then `shutdown`. A failing `shutdown` leaves the
`BufWriter` in `Flush` state, and `BufWriter::abort` panics if the writer has already
been shut down — so every caller that aborted on error hit "Already shut down"
instead of propagating. That affected four call sites: delete files, compacted files,
single-file writes and staged data files.

The abort decision now lives inside `stream_to_upload` so no call site can get it
wrong: abort after a failed `copy` (safe, and necessary to release the multipart),
never after a failed `shutdown`.

## Failure path now cleans up too

Previously a failing batch would short-circuit, dropping sibling futures
mid-multipart — stranding upload state only a bucket lifecycle rule could reclaim —
and leaving already-completed siblings as orphans.

Now the batch is drained rather than short-circuited — every upload runs to
completion, including ones not yet started when the first error appeared — and the
objects that did land are removed. That mirrors DuckLake tracking the files a write
created and removing them when it does not commit (`ducklake_transaction.cpp:70`).
Cleanup is best effort and logs rather than masking the original error; anything
surviving is a genuine orphan no snapshot references.

Scope, precisely: this covers a failure **within the upload batch**. It does not
cover a metadata commit that fails after every upload succeeded — those objects are
still left behind, which is the pre-existing divergence listed at the end.

## Concurrency is a memory bound

Default 4, not scaled by cores, because the real peak is larger than "one buffer per
upload" implies: `object_store`'s `BufWriter` holds a 10 MiB buffer *and* keeps up to
8 multipart requests in flight itself, so N concurrent uploads of large files peak
near `N * 9 * 10 MiB` — roughly 360 MiB at the default.

`write_rolled_files` stays sequential deliberately: it documents "at most one staged
file occupies local disk at a time" as an intentional memory property and serves the
collected-batches API rather than a streaming session.

## API note

`upload_concurrency` is added to the public `DuckLakeWriteOptions`, which is a source
break for external struct literals. Called out rather than left to be discovered.

## Tests

- `concurrent_staged_upload_tests` — catalog rows identical at upload concurrency 1
  and 4. **This is the ordering guard**: it fails under `buffer_unordered`, which
  registers files in completion order (observed as id minima arriving
  `[1200, 0, 800, 400, 1600, 2000]`).
- the same file also asserts row-id contiguity. To be precise about what that buys:
  contiguity is a commit invariant, **not** an ordering guard — row ids stay
  contiguous however the files were registered, since the counter walks whatever list
  it is given. It guards gaps and overlaps, which would corrupt lineage on their own.
- `a_failed_upload_removes_the_files_that_already_landed` — injects a failure on the
  3rd write via a delegating `ObjectStore`, then asserts the original error surfaces
  (not a cleanup error) and no data files are left behind. This is the test that
  surfaced the panic above; the cleanup branch is the only part of this change that
  deletes objects, so it should not ship untested.
- `partition_write_tests::partitioned_staged_uploads_are_order_stable_across_concurrency`
  — partition values (both keys), `row_id_start` and `record_count` stable across
  concurrency on the partitioned path, which nothing else covered.

The partitioned test is a **smoke test, not a regression guard**, and its doc says so:
it does not fail under `buffer_unordered`, because on a local store those uploads
complete in submission order however they are polled — with equal-sized and skewed
partitions alike.

366 + 369 + 8 tests pass; clippy clean under
`--workspace --all-targets --all-features --no-deps -D warnings`.

## Pre-existing divergences noticed while checking, not addressed here

Recording them because they are easy to rediscover and easy to forget:

- data files are named as raw UUID-v4 `.parquet`; official uses `ducklake-{uuidv7}`
  (`ducklake_insert.cpp:576`).
- `DuckLakeWriteOptions::target_file_size` bypasses official's 4096-byte floor
  (`MaxValue(target_file_size, 4096)`, same line), which can change file count.
- if metadata registration fails *after* uploads succeed, the uploaded objects are not
  removed. Official tracks transaction-local files and removes them on rollback
  (`ducklake_transaction.cpp:70`, `ducklake_transaction_state.cpp:1971`). This change
  fixes the upload-failure case but not the commit-failure case.
