### PR TITLE
fix(compaction): re-merge partial files instead of stranding them

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -10,7 +10,10 @@
 //!    row's original rowid AND a per-row `_ducklake_internal_snapshot_id` column,
 //!    and its catalog row records `partial_max` (the maximum origin snapshot id
 //!    among its rows), so time travel / change feeds can still attribute every
-//!    merged row to its origin snapshot.
+//!    merged row to its origin snapshot. A partial file is itself a merge
+//!    candidate: its scan projects that embedded column, so each row keeps its
+//!    own origin through a re-merge and a partition never accumulates a floor of
+//!    files it can no longer reduce.
 //! 2. [`DuckLakeTable::rewrite_data_files`] rewrites a data file whose deleted
 //!    fraction exceeds a threshold (DuckDB's default is 0.95): it reads only the
 //!    file's LIVE rows (delete-aware), writes them to a new file preserving each
@@ -34,8 +37,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
 
-use arrow::array::{ArrayRef, Int64Array, RecordBatch};
+use arrow::array::{Array, ArrayRef, Int64Array, RecordBatch};
 use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::Session;
@@ -61,7 +65,8 @@ use crate::partition::PartitionSpec;
 use crate::row_id::EMBEDDED_SNAPSHOT_ID_COLUMN_NAME;
 use crate::sort::{SortDirection, SortSpec};
 use crate::table::{
-    DuckLakeTable, RewrittenBatch, UpdateSourceScan, rewrite_output_schema, rewrite_scanned_batch,
+    DuckLakeTable, MergeSourceFacts, RewrittenBatch, UpdateSourceScan, rewrite_output_schema,
+    rewrite_scanned_batch,
 };
 use crate::table_writer::DuckLakeTableWriter;
 use crate::{DuckLakeError, Result};
@@ -145,25 +150,83 @@ impl CompactionResult {
     }
 }
 
-/// The Arrow field for the constant `_ducklake_internal_snapshot_id` column a
-/// merged partial file embeds. Field-id metadata is deliberately absent: only
+/// The Arrow field for the `_ducklake_internal_snapshot_id` column a merged
+/// partial file embeds. Field-id metadata is deliberately absent: only
 /// the column order matters here, and `write_compacted_file_stream` re-imposes
 /// the field-id-tagged parquet schema.
 fn snapshot_column_field() -> Field {
     Field::new(EMBEDDED_SNAPSHOT_ID_COLUMN_NAME, DataType::Int64, true)
 }
 
-/// Append a constant `_ducklake_internal_snapshot_id` column (every value =
-/// `origin`) to a `[data columns..., rowid]` batch, yielding the
+/// Where one merge source's per-row origin snapshots come from.
+///
+/// Decided from the PHYSICAL presence of the embedded column in the source's
+/// parquet footer, mirroring `DuckLakeMultiFileReader::GetVirtualColumnExpression`'s
+/// rule for `COLUMN_IDENTIFIER_SNAPSHOT_ID` (`ducklake_multi_file_reader.cpp`):
+/// a source carrying the column keeps its OWN per-row origins, and any other
+/// source contributes its single catalog `begin_snapshot` as a constant.
+#[derive(Debug, Clone, Copy)]
+enum OriginSource {
+    /// Every row of this source originates in one snapshot.
+    Constant(i64),
+    /// This source physically carries `_ducklake_internal_snapshot_id`: its
+    /// rows' origins are read from that column, row by row.
+    Embedded,
+}
+
+/// Resolve one rewritten batch's per-row origin snapshots into the column a
+/// merged partial file embeds.
+///
+/// For [`OriginSource::Embedded`] the origins come from the source's own
+/// embedded column, already filtered alongside its rows by
+/// [`rewrite_scanned_batch`]; for [`OriginSource::Constant`] every row of the
+/// source shares one origin.
+fn resolve_origin_column(
+    origin: OriginSource,
+    carried: Option<&ArrayRef>,
+    rows: usize,
+    source_path: &str,
+) -> DataFusionResult<ArrayRef> {
+    if let OriginSource::Constant(origin) = origin {
+        return Ok(Arc::new(Int64Array::from(vec![origin; rows])));
+    }
+    let carried = carried.ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "merge source \"{source_path}\" was planned with per-row origins but its scan did \
+             not project the embedded snapshot-id column"
+        ))
+    })?;
+    let origins = carried
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "embedded snapshot-id column of \"{source_path}\" is not Int64"
+            ))
+        })?;
+    // A NULL origin leaves the row's visibility undefined — the time-travel and
+    // change-feed comparisons on it disagree, so the same row can appear in one
+    // and not the other. Refuse rather than write it: this same commit removes
+    // the sources, so there would be nothing left to recover the origin from.
+    if origins.null_count() > 0 {
+        return Err(DataFusionError::Execution(format!(
+            "merge source \"{source_path}\" has NULL values in its embedded \
+             `_ducklake_internal_snapshot_id` column; refusing to merge rows whose origin \
+             snapshot is unknown"
+        )));
+    }
+    Ok(Arc::clone(carried))
+}
+
+/// Append `origins` to a `[data columns..., rowid]` batch, yielding the
 /// `[data columns..., rowid, snapshot_id]` `schema` of a merged partial file.
 fn append_snapshot_column(
     batch: &RecordBatch,
-    origin: i64,
+    origins: ArrayRef,
     schema: &SchemaRef,
 ) -> DataFusionResult<RecordBatch> {
-    let snap: ArrayRef = Arc::new(Int64Array::from(vec![origin; batch.num_rows()]));
     let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
-    cols.push(snap);
+    cols.push(origins);
     Ok(RecordBatch::try_new(Arc::clone(schema), cols)?)
 }
 
@@ -172,8 +235,9 @@ fn append_snapshot_column(
 /// Wraps that file's positional read plan and rewrites each batch it produces
 /// into `[physical columns (catalog types)..., rowid]` — the same per-row
 /// transformation an `UPDATE` applies, via the shared [`rewrite_scanned_batch`]
-/// — appending the constant `_ducklake_internal_snapshot_id` column when
-/// `origin` is set (a merge whose bin spans more than one origin snapshot).
+/// — appending the `_ducklake_internal_snapshot_id` column when `origin` is set
+/// (a merge whose output is a partial file), resolved per row or as a per-file
+/// constant according to [`OriginSource`].
 ///
 /// Carrying provenance as columns OF THE SCAN is what lets a whole bin be read
 /// by one execution rather than one file at a time: nothing downstream needs to
@@ -195,14 +259,31 @@ struct CompactionSourceExec {
     /// This exec's output schema: [`Self::rewrite_schema`] plus the embedded
     /// snapshot-id column when [`Self::origin`] is set.
     schema: SchemaRef,
-    /// Origin snapshot to stamp on every row of this file, for a partial merge
+    /// Where this file's rows' origin snapshots come from, for a partial merge
     /// output; `None` leaves the batch at `[physical columns..., rowid]`.
-    origin: Option<i64>,
+    origin: Option<OriginSource>,
+    /// The greatest origin this exec has actually emitted, shared across every
+    /// leaf of one bin so the bin can record what it wrote.
+    ///
+    /// The catalog cannot answer this. A source may physically embed origins
+    /// above the `partial_max` its catalog row claims — providers substitute
+    /// NULL on catalogs predating the column, the MySQL provider hardcodes it,
+    /// and the migration that added it NULL-filled every existing row. Deriving
+    /// the output's bound from those rows would record a maximum below one the
+    /// merge physically wrote, and `needs_snapshot_filter` only filters below
+    /// `partial_max` — so rows would be served at snapshots before they
+    /// existed, with the sources retired in the same commit.
+    observed_max_origin: Arc<AtomicI64>,
     properties: Arc<PlanProperties>,
 }
 
 impl CompactionSourceExec {
-    fn new(scan: Arc<UpdateSourceScan>, physical_schema: SchemaRef, origin: Option<i64>) -> Self {
+    fn new(
+        scan: Arc<UpdateSourceScan>,
+        physical_schema: SchemaRef,
+        origin: Option<OriginSource>,
+        observed_max_origin: Arc<AtomicI64>,
+    ) -> Self {
         let rewrite_schema = rewrite_output_schema(&physical_schema);
         let schema = if origin.is_some() {
             let mut fields: Vec<Arc<Field>> = rewrite_schema.fields().iter().cloned().collect();
@@ -224,6 +305,7 @@ impl CompactionSourceExec {
             rewrite_schema,
             schema,
             origin,
+            observed_max_origin,
             properties,
         }
     }
@@ -235,8 +317,11 @@ impl DisplayAs for CompactionSourceExec {
             f,
             "CompactionSourceExec: file={}, origin={}",
             self.scan.source_path,
-            self.origin
-                .map_or_else(|| "none".to_string(), |origin| origin.to_string())
+            match self.origin {
+                None => "none".to_string(),
+                Some(OriginSource::Constant(origin)) => origin.to_string(),
+                Some(OriginSource::Embedded) => "embedded".to_string(),
+            }
         )
     }
 }
@@ -272,6 +357,7 @@ impl ExecutionPlan for CompactionSourceExec {
             Arc::new(scan),
             Arc::clone(&self.physical_schema),
             self.origin,
+            Arc::clone(&self.observed_max_origin),
         )))
     }
 
@@ -286,6 +372,7 @@ impl ExecutionPlan for CompactionSourceExec {
         let rewrite_schema = Arc::clone(&self.rewrite_schema);
         let schema = Arc::clone(&self.schema);
         let origin = self.origin;
+        let observed_max_origin = Arc::clone(&self.observed_max_origin);
         let stream = input
             .map(move |batch| -> DataFusionResult<Option<RecordBatch>> {
                 let batch = batch?;
@@ -293,6 +380,7 @@ impl ExecutionPlan for CompactionSourceExec {
                 // to select with, no assignments to apply.
                 let Some(RewrittenBatch {
                     batch,
+                    origin_snapshots,
                     ..
                 }) = rewrite_scanned_batch(
                     &physical_schema,
@@ -308,7 +396,24 @@ impl ExecutionPlan for CompactionSourceExec {
                     return Ok(None);
                 };
                 Ok(Some(match origin {
-                    Some(origin) => append_snapshot_column(&batch, origin, &schema)?,
+                    Some(origin) => {
+                        let origins = resolve_origin_column(
+                            origin,
+                            origin_snapshots.as_ref(),
+                            batch.num_rows(),
+                            &scan.source_path,
+                        )?;
+                        // What the output records has to be what it wrote, not
+                        // what the catalog said the sources held.
+                        if let Some(batch_max) = origins
+                            .as_any()
+                            .downcast_ref::<arrow::array::Int64Array>()
+                            .and_then(arrow::compute::max)
+                        {
+                            observed_max_origin.fetch_max(batch_max, Ordering::Relaxed);
+                        }
+                        append_snapshot_column(&batch, origins, &schema)?
+                    },
                     None => batch,
                 }))
             })
@@ -546,10 +651,21 @@ impl DuckLakeTable {
     /// preserving it keeps them prunable exactly as before.
     ///
     /// Each source file's live rows are read with their original rowids
-    /// preserved; a merged file that spans more than one origin snapshot is
+    /// preserved; a merged file whose rows span more than one origin snapshot is
     /// written as a partial file (embedding the per-row
     /// `_ducklake_internal_snapshot_id` column and recording `partial_max`). The
     /// sources are retired and scheduled for deletion in the same commit.
+    ///
+    /// A source may itself be a partial file. Whether its rows carry their own
+    /// origins is decided by the PHYSICAL presence of the embedded column in its
+    /// parquet footer — never by the catalog's `partial_max`, which providers may
+    /// leave NULL on a file that has the column — so those origins are copied
+    /// into the output instead of being replaced by one file-level
+    /// `begin_snapshot`. Merging a partial source requires this table to be
+    /// opened at a snapshot at or above its `partial_max` (all its rows must be
+    /// visible to the handle doing the merge); that is an error, while a bin
+    /// whose catalog calls a source partial that carries no such column is
+    /// skipped.
     ///
     /// Returns no-op metrics (and commits no snapshot) when nothing qualifies.
     /// Errors if the table is read-only (open the catalog with a writer) or if a
@@ -572,17 +688,19 @@ impl DuckLakeTable {
         // Candidates: live, delete-free, below-target files with a known origin
         // snapshot + schema version, ordered so adjacency and same-version
         // grouping fall out of the sort.
+        //
+        // A partial file IS a candidate: its scan projects the embedded
+        // `_ducklake_internal_snapshot_id` column, so each of its rows keeps its
+        // own origin through the merge. Official DuckLake likewise applies no
+        // `partial_max` filter to its compaction candidates
+        // (`GetFilesForCompaction`). Excluding them instead strands every merge
+        // output on a table taking appends between merge passes, leaving each
+        // partition a floor of files nothing can reduce.
         let table_files = self.files()?;
         let mut candidates: Vec<&DuckLakeTableFile> = table_files
             .iter()
             .filter(|f| {
                 f.delete_file_id.is_none()
-                    // Never re-merge an existing partial file: its rows carry
-                    // per-row origins in the embedded `_ducklake_internal_snapshot_id`
-                    // column, which the read path used to reconstruct them does NOT
-                    // surface — re-merging would collapse every row onto the file's
-                    // single begin_snapshot and corrupt time travel.
-                    && f.partial_max.is_none()
                     && f.begin_snapshot.is_some()
                     && f.schema_version.is_some()
                     && (f.file.file_size_bytes as u64) >= opts.min_file_size
@@ -631,23 +749,71 @@ impl DuckLakeTable {
             return Ok(CompactionResult::empty());
         }
 
-        // Safety: the merged output is written at the table's CURRENT schema, so
-        // a source carrying a column dropped since it was written would lose
-        // that column's data (and its source is then removed). Drop any such bin
-        // entirely — those files are left uncompacted rather than silently
-        // losing data. (The common case — files at the current schema, or an
-        // older schema that only ADDED columns — is unaffected.) Settled before
-        // anything else, so a table with only such bins stays a pure no-op.
+        // A partial source's rows are ALL visible only at a snapshot at or above
+        // its `partial_max`, and a merge reads every live row of its sources. A
+        // handle pinned below that would fold rows the handle itself cannot see
+        // into a new output, and commit them against a base snapshot that never
+        // contained them. Refuse loudly rather than compact from a historical
+        // handle: the caller wants a head handle.
+        for bin in &bins {
+            for tf in bin {
+                if let Some(partial_max) = tf.partial_max
+                    && self.base_snapshot() < partial_max
+                {
+                    return Err(DuckLakeError::InvalidConfig(format!(
+                        "merge_adjacent_files: source \"{}\" is a partial file whose rows reach \
+                         snapshot {partial_max}, but this table is opened at snapshot {}; \
+                         re-open the catalog at the current snapshot to merge it",
+                        tf.file.path,
+                        self.base_snapshot()
+                    )));
+                }
+            }
+        }
+
+        // Safety, from each source's parquet footer:
+        //
+        // - The merged output is written at the table's CURRENT schema, so a
+        //   source carrying a column dropped since it was written would lose that
+        //   column's data (and its source is then removed).
+        // - A source the catalog calls partial must physically carry the
+        //   `_ducklake_internal_snapshot_id` column its rows' origins live in.
+        //   Without it the catalog and the file disagree about the file's own
+        //   history, and the read path already refuses such a file below
+        //   `partial_max` (`build_exec_for_partial_file`); merging it would carry
+        //   that disagreement into a new file and remove the evidence.
+        //
+        // Either way the bin is dropped entirely — those files are left
+        // uncompacted rather than silently losing data or lineage. (The common
+        // case — files at the current schema, or an older schema that only ADDED
+        // columns — is unaffected.) Settled before anything else, so a table with
+        // only such bins stays a pure no-op.
+        //
+        // The facts are kept because the per-bin planning below needs
+        // `has_embedded_snapshot` again, and re-asking would re-walk the footers.
+        let mut source_facts: HashMap<i64, MergeSourceFacts> = HashMap::new();
         let mut viable: Vec<Vec<&DuckLakeTableFile>> = Vec::with_capacity(bins.len());
         for bin in bins {
-            let mut drops_columns = false;
+            let mut mergeable = true;
             for tf in &bin {
-                if self.file_drops_current_columns(state, &tf.file).await? {
-                    drops_columns = true;
+                let facts = self.merge_source_facts(state, &tf.file).await?;
+                source_facts.insert(tf.data_file_id, facts);
+                if facts.drops_current_columns {
+                    mergeable = false;
+                } else if tf.partial_max.is_some() && !facts.has_embedded_snapshot {
+                    tracing::warn!(
+                        file = %tf.file.path,
+                        partial_max = ?tf.partial_max,
+                        "skipping merge bin: the catalog records this file as partial but it \
+                         carries no embedded snapshot-id column"
+                    );
+                    mergeable = false;
+                }
+                if !mergeable {
                     break;
                 }
             }
-            if !drops_columns {
+            if mergeable {
                 viable.push(bin);
             }
         }
@@ -696,30 +862,46 @@ impl DuckLakeTable {
         let mut rows_written = 0i64;
 
         for bin in &bins {
-            // Every source's origin snapshot is catalog metadata, so the shape
+            // Every source's snapshot bounds are catalog metadata, so the shape
             // of the output is settled before a single row is read.
             //
-            // A group spanning >1 origin snapshot is a partial file: embed the
-            // per-row snapshot column, record the max origin as partial_max, and
-            // set begin_snapshot to the MIN origin so historical reads back to
-            // that point see it (row-filtered by origin). The sources are then
-            // redundant for every snapshot, so the commit removes + schedules
-            // them. A single-origin group needs no per-row column (all rows share
-            // one origin), and begins at that origin.
-            let mut file_origins: Vec<i64> = Vec::with_capacity(bin.len());
+            // A source spans the snapshot RANGE `[begin_snapshot, partial_max]` —
+            // a point for an ordinary file, a genuine interval for a partial one
+            // — so the output spans the union of those ranges: it begins at the
+            // MINIMUM origin (so historical reads back to that point see it,
+            // row-filtered by origin) and its `partial_max` is the maximum origin
+            // any of its rows carries. `GetCompactionChanges`
+            // (`ducklake_transaction_state.cpp`) derives the same two values the
+            // same way. The sources are then redundant for every snapshot, so the
+            // commit removes + schedules them.
+            //
+            // The output is partial whenever its rows do not all share one
+            // origin, and ALSO whenever any source physically carries the
+            // embedded column. That second disjunct is what keeps a re-merge
+            // lossless when the catalog understates a source: writing a
+            // non-partial output would drop the snapshot column AND record
+            // `partial_max` NULL, so no reader would look for those origins
+            // again — and this same commit removes the sources.
+            let mut range_mins: Vec<i64> = Vec::with_capacity(bin.len());
+            let mut range_maxes: Vec<i64> = Vec::with_capacity(bin.len());
             for tf in bin {
-                file_origins.push(tf.begin_snapshot.ok_or_else(|| {
+                let begin = tf.begin_snapshot.ok_or_else(|| {
                     DuckLakeError::Internal("merge candidate missing begin_snapshot".to_string())
-                })?);
+                })?;
+                range_mins.push(begin);
+                range_maxes.push(tf.partial_max.unwrap_or(begin));
             }
-            let origins: HashSet<i64> = file_origins.iter().copied().collect();
-            let partial = origins.len() > 1;
-            let min_origin = origins.iter().copied().min();
-            let partial_max = if partial {
-                origins.iter().copied().max()
-            } else {
-                None
+            let min_origin = range_mins.iter().copied().min();
+            let max_origin = range_maxes.iter().copied().max();
+            let embeds_origins = |tf: &DuckLakeTableFile| {
+                source_facts
+                    .get(&tf.data_file_id)
+                    .is_some_and(|facts| facts.has_embedded_snapshot)
             };
+            let partial = min_origin != max_origin || bin.iter().any(|tf| embeds_origins(tf));
+            // Seeded from the catalog so a bin that embeds nothing still reports
+            // its range; every leaf raises it to what it actually emitted.
+            let observed_max_origin = Arc::new(AtomicI64::new(max_origin.unwrap_or(i64::MIN)));
 
             // ONE execution over the whole bin, so DataFusion reads every source
             // concurrently instead of one object-store round trip at a time.
@@ -728,12 +910,27 @@ impl DuckLakeTable {
             // is what makes the single scan possible — the same shape official
             // DuckLake compaction uses.
             let mut leaves: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(bin.len());
-            for (tf, origin) in bin.iter().zip(&file_origins) {
-                let scan = self.build_update_scan(state, tf).await?;
+            for (tf, begin) in bin.iter().zip(&range_mins) {
+                // One fact — does this file physically carry the embedded column
+                // — decides both the scan's projection and where the exec reads
+                // origins from, so the two can never disagree and stamp a
+                // per-row-origin source with a single `begin_snapshot`. A source
+                // that carries it forces `partial`, so the column always has
+                // somewhere to go.
+                let source_embeds_origins = embeds_origins(tf);
+                let origin = partial.then_some(if source_embeds_origins {
+                    OriginSource::Embedded
+                } else {
+                    OriginSource::Constant(*begin)
+                });
+                let scan = self
+                    .build_update_scan_with_snapshot(state, tf, source_embeds_origins)
+                    .await?;
                 leaves.push(Arc::new(CompactionSourceExec::new(
                     Arc::new(scan),
                     Arc::clone(&physical_schema),
-                    partial.then_some(*origin),
+                    origin,
+                    Arc::clone(&observed_max_origin),
                 )));
                 sources.push(CompactionSourceFile {
                     data_file_id: tf.data_file_id,
@@ -781,6 +978,9 @@ impl DuckLakeTable {
                 Some(pid) => file.with_partition(pid, partition_value_pairs(&partition_values)),
                 None => file,
             };
+            // Read after the write has drained the stream: the bound the
+            // catalog claimed, raised to whatever the merge actually emitted.
+            let partial_max = partial.then(|| observed_max_origin.load(Ordering::Relaxed));
             outputs.push(CompactionOutputFile {
                 file,
                 partial_max,
@@ -901,7 +1101,10 @@ impl DuckLakeTable {
                 Arc::new(CompactionSourceExec::new(
                     Arc::new(scan),
                     Arc::clone(&physical_schema),
+                    // A delete-rewrite emits no origin column, so nothing raises
+                    // this and nothing reads it.
                     None,
+                    Arc::new(AtomicI64::new(i64::MIN)),
                 )),
                 ordering.as_ref(),
             )?;

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -405,11 +405,21 @@ impl ExecutionPlan for CompactionSourceExec {
                         )?;
                         // What the output records has to be what it wrote, not
                         // what the catalog said the sources held.
-                        if let Some(batch_max) = origins
+                        let typed = origins
                             .as_any()
                             .downcast_ref::<arrow::array::Int64Array>()
-                            .and_then(arrow::compute::max)
-                        {
+                            .ok_or_else(|| {
+                                // Understating the bound is the defect this
+                                // whole path exists to prevent, so a type the
+                                // max cannot be taken from is an error rather
+                                // than a skipped update.
+                                DataFusionError::Internal(format!(
+                                    "compaction origin column for \"{}\" is {:?}, not Int64",
+                                    scan.source_path,
+                                    origins.data_type()
+                                ))
+                            })?;
+                        if let Some(batch_max) = arrow::compute::max(typed) {
                             observed_max_origin.fetch_max(batch_max, Ordering::Relaxed);
                         }
                         append_snapshot_column(&batch, origins, &schema)?
@@ -755,21 +765,6 @@ impl DuckLakeTable {
         // into a new output, and commit them against a base snapshot that never
         // contained them. Refuse loudly rather than compact from a historical
         // handle: the caller wants a head handle.
-        for bin in &bins {
-            for tf in bin {
-                if let Some(partial_max) = tf.partial_max
-                    && self.base_snapshot() < partial_max
-                {
-                    return Err(DuckLakeError::InvalidConfig(format!(
-                        "merge_adjacent_files: source \"{}\" is a partial file whose rows reach \
-                         snapshot {partial_max}, but this table is opened at snapshot {}; \
-                         re-open the catalog at the current snapshot to merge it",
-                        tf.file.path,
-                        self.base_snapshot()
-                    )));
-                }
-            }
-        }
 
         // Safety, from each source's parquet footer:
         //
@@ -806,6 +801,21 @@ impl DuckLakeTable {
                         partial_max = ?tf.partial_max,
                         "skipping merge bin: the catalog records this file as partial but it \
                          carries no embedded snapshot-id column"
+                    );
+                    mergeable = false;
+                } else if tf.partial_max.is_some_and(|pm| self.base_snapshot() < pm) {
+                    // A handle opened below the file's reach would fold rows it
+                    // cannot see into the output and commit them against a base
+                    // that never held them. Cost the bin rather than the sweep:
+                    // a compactor on a slightly stale handle should still make
+                    // progress on everything else, which is the failure this
+                    // branch exists to end.
+                    tracing::warn!(
+                        file = %tf.file.path,
+                        partial_max = ?tf.partial_max,
+                        base_snapshot = self.base_snapshot(),
+                        "skipping merge bin: this table is opened below the snapshot the \
+                         source's rows reach; re-open at the current snapshot to merge it"
                     );
                     mergeable = false;
                 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -2553,21 +2553,20 @@ impl DuckLakeTable {
         self.columns.iter().map(|column| column.column_id).collect()
     }
 
-    /// Whether `file` carries a data column that is no longer in the table's
-    /// current schema (dropped since it was written). `merge_adjacent_files`
-    /// refuses to compact such a file — merged output is written at the current
-    /// schema, which would drop that column's data. Reads the parquet footer
-    /// (memoized in the per-file read-config cache).
+    /// What `merge_adjacent_files` needs from one candidate's PARQUET FOOTER.
+    /// Both facts come from the same footer read (memoized in the per-file
+    /// read-config cache), so asking for them together costs one lookup.
     #[cfg(feature = "write")]
-    pub(crate) async fn file_drops_current_columns(
+    pub(crate) async fn merge_source_facts(
         &self,
         state: &dyn Session,
         file: &DuckLakeFileData,
-    ) -> DataFusionResult<bool> {
-        Ok(self
-            .build_file_read_config(state, file)
-            .await?
-            .drops_current_columns)
+    ) -> DataFusionResult<MergeSourceFacts> {
+        let cfg = self.build_file_read_config(state, file).await?;
+        Ok(MergeSourceFacts {
+            drops_current_columns: cfg.drops_current_columns,
+            has_embedded_snapshot: cfg.embedded_snapshot_parquet_name.is_some(),
+        })
     }
 
     /// Build the positional read plan (and the metadata needed to interpret it)
@@ -2589,6 +2588,30 @@ impl DuckLakeTable {
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
     ) -> DataFusionResult<UpdateSourceScan> {
+        self.build_update_scan_with_snapshot(state, table_file, false)
+            .await
+    }
+
+    /// [`Self::build_update_scan`], additionally projecting the file's embedded
+    /// per-row `_ducklake_internal_snapshot_id` column when `want_snapshot_id`.
+    ///
+    /// Only a merge re-reading a source that PHYSICALLY carries that column sets
+    /// it: such a source's rows each hold their own origin snapshot, so the
+    /// merged output must copy the column through rather than stamp one origin
+    /// on every row. Errors when the file carries no such column — the caller
+    /// decides from the footer, so asking for a column that is not there is a
+    /// bug, and inventing origins would silently re-attribute history.
+    ///
+    /// The column is appended to a LOCAL read schema rather than to the cached
+    /// [`FileReadConfig::read_schema`], which ends with the embedded rowid that
+    /// the other read paths index from the end.
+    #[cfg(feature = "write")]
+    pub(crate) async fn build_update_scan_with_snapshot(
+        &self,
+        state: &dyn Session,
+        table_file: &DuckLakeTableFile,
+        want_snapshot_id: bool,
+    ) -> DataFusionResult<UpdateSourceScan> {
         let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
         let has_embedded = file_cfg.embedded_rowid_parquet_name.is_some();
 
@@ -2608,6 +2631,29 @@ impl DuckLakeTable {
             HashSet::new()
         };
 
+        // The scan schema is the cached per-file one, plus the embedded
+        // snapshot-id column when this caller asked for it. Appending here (and
+        // not in `build_file_read_config`) keeps the cached schema's invariant
+        // that the embedded rowid, when present, is its LAST field.
+        let read_schema = if want_snapshot_id {
+            let snap_name = file_cfg
+                .embedded_snapshot_parquet_name
+                .clone()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "File \"{}\" carries no embedded `_ducklake_internal_snapshot_id` \
+                         column, so its rows' origin snapshots cannot be read",
+                        table_file.file.path
+                    ))
+                })?;
+            let mut fields: Vec<Arc<Field>> =
+                file_cfg.read_schema.fields().iter().cloned().collect();
+            fields.push(Arc::new(Field::new(&snap_name, DataType::Int64, true)));
+            Arc::new(Schema::new(fields))
+        } else {
+            Arc::clone(&file_cfg.read_schema)
+        };
+
         // Positional scan: row-group-aligned partitions + a non-repartition,
         // non-pruning source so `FileRowNumberExec` yields true physical
         // positions. Project the physical columns (logical order) and, for an
@@ -2616,16 +2662,21 @@ impl DuckLakeTable {
         let target_partitions = state.config().target_partitions();
         let (file_groups, partition_starts) =
             self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?;
-        let source = PositionalFileSource::wrap(Arc::new(
-            self.create_parquet_source(file_cfg.read_schema.clone()),
-        ));
+        let source =
+            PositionalFileSource::wrap(Arc::new(self.create_parquet_source(read_schema.clone())));
+        // Built by pushing, so each appended column records the index it actually
+        // landed at. Arithmetic off `physical_len` would silently misalign the two
+        // appended columns for a file that has one but not the other, and both are
+        // Int64 — nothing downstream would fail to downcast.
         let mut proj: Vec<usize> = (0..physical_len).collect();
-        let embedded_batch_idx = if has_embedded {
+        let embedded_batch_idx = has_embedded.then(|| {
             proj.push(file_cfg.read_schema.fields().len() - 1);
-            Some(physical_len)
-        } else {
-            None
-        };
+            proj.len() - 1
+        });
+        let embedded_snapshot_batch_idx = want_snapshot_id.then(|| {
+            proj.push(read_schema.fields().len() - 1);
+            proj.len() - 1
+        });
         let scan = DataSourceExec::from_data_source(
             FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
                 .with_file_groups(file_groups)
@@ -2648,6 +2699,7 @@ impl DuckLakeTable {
             scan: plan,
             physical_len,
             embedded_batch_idx,
+            embedded_snapshot_batch_idx,
             pos_index,
             row_id_start: table_file.row_id_start,
             existing_deleted,
@@ -2717,6 +2769,26 @@ impl DuckLakeTable {
     }
 }
 
+/// What one merge candidate's parquet footer says about it, from
+/// [`DuckLakeTable::merge_source_facts`].
+#[cfg(feature = "write")]
+#[derive(Clone, Copy)]
+pub(crate) struct MergeSourceFacts {
+    /// The file carries a data column that is no longer in the table's current
+    /// schema (dropped since it was written). Merged output is written at the
+    /// current schema, so merging such a file would lose that column's data —
+    /// and remove the file that still holds it.
+    pub(crate) drops_current_columns: bool,
+    /// The file physically embeds the per-row `_ducklake_internal_snapshot_id`
+    /// column, so its rows' origin snapshots are read from it rather than taken
+    /// as the file's single catalog `begin_snapshot`. This is the ONLY thing
+    /// that decides where a merge source's origins come from — the catalog's
+    /// `partial_max` can be NULL on a file that carries the column (providers
+    /// that do not read the field, catalogs predating it), and keying off it
+    /// would re-stamp every row with one origin and drop the column.
+    pub(crate) has_embedded_snapshot: bool,
+}
+
 /// Output schema of a rewritten source file: the table's physical columns (in
 /// catalog types) followed by the preserved `rowid`. `UPDATE` and compaction
 /// share it so both emit exactly the same shape.
@@ -2735,6 +2807,11 @@ pub(crate) struct RewrittenBatch {
     /// Physical positions of the matched rows within the source file, in batch
     /// order — the positions the source file's new cumulative delete must mask.
     pub(crate) positions: Vec<i64>,
+    /// The matched rows' embedded per-row origin snapshots, present exactly when
+    /// the scan projected them ([`UpdateSourceScan::embedded_snapshot_batch_idx`]).
+    /// Filtered with the same mask as the data columns, so each value still
+    /// travels with its own row.
+    pub(crate) origin_snapshots: Option<ArrayRef>,
 }
 
 /// Rewrite ONE batch read from an [`UpdateSourceScan`] into its
@@ -2856,9 +2933,21 @@ pub(crate) fn rewrite_scanned_batch(
     };
     out_cols.push(rowid_col);
 
+    // Carried through under the SAME mask as the data columns: taking it from
+    // the unfiltered batch would hand each surviving row a different row's
+    // origin whenever a predicate selected a subset.
+    let origin_snapshots = match scan.embedded_snapshot_batch_idx {
+        Some(idx) => Some(
+            arrow::compute::filter(batch.column(idx).as_ref(), &mask)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+        ),
+        None => None,
+    };
+
     Ok(Some(RewrittenBatch {
         batch: RecordBatch::try_new(Arc::clone(out_schema), out_cols)?,
         positions: matched_pos.values().to_vec(),
+        origin_snapshots,
     }))
 }
 
@@ -2878,6 +2967,11 @@ pub(crate) struct UpdateSourceScan {
     /// the file has no embedded rowid (rowids are synthesized from
     /// `row_id_start + position`).
     pub(crate) embedded_batch_idx: Option<usize>,
+    /// Column index of the embedded per-row `_ducklake_internal_snapshot_id` in
+    /// each scanned batch, or `None` when the scan did not project it. Set only
+    /// by [`DuckLakeTable::build_update_scan_with_snapshot`], for a merge source
+    /// whose per-row origins must survive into the merged output.
+    pub(crate) embedded_snapshot_batch_idx: Option<usize>,
     /// Column index of the internal physical-position column in each batch.
     pub(crate) pos_index: usize,
     /// The source file's catalog `row_id_start` (used to synthesize rowids for a

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -1636,13 +1636,12 @@ async fn merge_respects_schema_version_boundary() {
     );
 }
 
-/// A partial file must NEVER be re-merged: the read path that reconstructs a
-/// source's rows does not surface the embedded per-row origin column, so
-/// re-merging would collapse every row onto the file's single begin_snapshot and
-/// corrupt time travel. `merge_adjacent_files` therefore excludes partial files
-/// from its candidates.
+/// A partial file IS a merge candidate, and a re-merge must carry every row's
+/// OWN origin snapshot through: its scan projects the embedded
+/// `_ducklake_internal_snapshot_id` column, so the output keeps the distinct
+/// origins rather than collapsing them onto one `begin_snapshot`.
 #[tokio::test(flavor = "multi_thread")]
-async fn merge_never_remerges_a_partial_file() {
+async fn merge_remerges_a_partial_file_preserving_per_row_origins() {
     let temp = TempDir::new().unwrap();
     seed(&temp, vec![1], vec![10]).await; // snapshot 1
     append(&temp, vec![2], vec![20]).await; // snapshot 2
@@ -1662,29 +1661,190 @@ async fn merge_never_remerges_a_partial_file() {
         "merge produced a partial file"
     );
 
-    append(&temp, vec![4], vec![40]).await; // snapshot 5 (one more small file, D)
+    append(&temp, vec![4], vec![40]).await; // one more small file, D
+    let s_d = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
 
-    // Merge #2: P is excluded (partial), leaving only D — a single file, so no
-    // group of >= 2 forms and nothing is merged. Crucially, P is not re-merged.
+    // Merge #2 re-merges P together with D into one file.
     let r2 = run_merge(&temp, MergeOptions::default()).await;
+    assert_eq!(r2.files_processed, 2, "P and D merge together");
+    assert_eq!(r2.files_created, 1);
     assert_eq!(
-        r2.files_processed, 0,
-        "the partial file P is not a candidate; D alone cannot merge"
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
+        )
+        .await,
+        1,
+        "the re-merge leaves exactly one live file"
     );
 
-    // Time travel to snapshot 2 must still return exactly rows from origins <= 2.
-    // If P had been re-merged, its rows would all carry origin 1 and (3,30) would
-    // wrongly reappear here.
+    // The output spans [MIN begin_snapshot, MAX(partial_max ?? begin_snapshot)]
+    // of its sources — P's interval [1, 3] unioned with D's point — matching
+    // official DuckLake's `GetCompactionChanges`.
+    let merged_path: String = sqlx::query(AssertSqlSafe(
+        "SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    ))
+    .fetch_one(&p)
+    .await
+    .unwrap()
+    .try_get::<String, _>(0)
+    .unwrap();
     assert_eq!(
-        read_rows_at(&temp, 2).await,
-        vec![(1, 10), (2, 20)],
-        "time travel intact: no origins collapsed by a re-merge"
+        opt_i64(
+            &p,
+            "SELECT begin_snapshot FROM ducklake_data_file WHERE end_snapshot IS NULL"
+        )
+        .await,
+        Some(1),
+        "output begins at the minimum origin of its sources"
     );
-    // Current snapshot sees everything.
+    assert_eq!(
+        opt_i64(
+            &p,
+            "SELECT partial_max FROM ducklake_data_file WHERE end_snapshot IS NULL"
+        )
+        .await,
+        Some(s_d),
+        "output partial_max is the maximum origin any of its rows carries"
+    );
+
+    // On disk, P's four rows keep their four DISTINCT origins. Keying the
+    // decision on the catalog instead would have stamped P's rows with its
+    // single begin_snapshot and left only {1, s_d} here.
+    let mut origins: Vec<i64> = file_lineage(&temp, &merged_path)
+        .into_iter()
+        .map(|(_, origin)| origin.expect("a re-merged output embeds per-row origins"))
+        .collect();
+    origins.sort_unstable();
+    assert_eq!(origins, vec![1, 2, 3, s_d]);
+
+    // Time travel therefore still attributes each row to its own origin.
+    assert_eq!(read_rows_at(&temp, 1).await, vec![(1, 10)]);
+    assert_eq!(read_rows_at(&temp, 2).await, vec![(1, 10), (2, 20)]);
+    assert_eq!(
+        read_rows_at(&temp, 3).await,
+        vec![(1, 10), (2, 20), (3, 30)]
+    );
     assert_eq!(
         read_rows(&temp).await,
         vec![(1, 10), (2, 20), (3, 30), (4, 40)]
     );
+}
+
+/// The convergence property, in the shape that actually occurs: appends
+/// INTERLEAVED with merge passes. Every merge whose sources span more than one
+/// origin snapshot writes a partial file, so on a table taking frequent appends
+/// nearly every output is partial. If partial files were excluded from the
+/// candidates, each pass would strand its own output and the live file count
+/// would climb by one per pass (1, 2, 3, …) with no bound — the partition would
+/// accumulate a floor of files nothing can reduce.
+///
+/// Merging repeatedly on a STATIC table does not exercise this: the first pass
+/// consumes everything and later passes have nothing to do.
+#[tokio::test(flavor = "multi_thread")]
+async fn interleaved_appends_and_merges_keep_the_live_file_count_flat() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![0], vec![0]).await;
+    let p = pool(&temp).await;
+
+    // Each pass appends one small file and then merges, so every pass after the
+    // first has a partial file among its sources.
+    let mut origins: Vec<(i64, i32)> = Vec::new();
+    for id in 1..=6i32 {
+        append(&temp, vec![id], vec![id * 10]).await;
+        origins.push((
+            scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await,
+            id,
+        ));
+        let result = run_merge(&temp, MergeOptions::default()).await;
+        assert_eq!(
+            scalar_i64(
+                &p,
+                "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
+            )
+            .await,
+            1,
+            "pass {id}: the live file count must not climb"
+        );
+        assert_eq!(
+            result.files_processed, 2,
+            "pass {id}: the previous output and the new append merged together"
+        );
+    }
+
+    // Every row is still attributed to the snapshot that appended it.
+    for (snapshot, id) in &origins {
+        let expected: Vec<(i32, i32)> = std::iter::once((0, 0))
+            .chain((1..=*id).map(|i| (i, i * 10)))
+            .collect();
+        assert_eq!(
+            read_rows_at(&temp, *snapshot).await,
+            expected,
+            "time travel to snapshot {snapshot} sees exactly the rows appended by then"
+        );
+    }
+}
+
+/// Whether a merge source carries per-row origins is decided by the PHYSICAL
+/// presence of the embedded column, never by the catalog's `partial_max`. The
+/// two can disagree: a provider that does not read the column substitutes NULL,
+/// as does a catalog predating it. Keying off the catalog would re-stamp every
+/// row of such a file with one origin and drop the embedded column — history
+/// lost irreversibly, since the same commit removes the sources.
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_reads_per_row_origins_from_the_file_not_the_catalog() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1], vec![10]).await; // snapshot 1
+    append(&temp, vec![2], vec![20]).await; // snapshot 2
+
+    // Merge #1 -> partial file P (origins {1, 2}).
+    assert_eq!(
+        run_merge(&temp, MergeOptions::default())
+            .await
+            .files_created,
+        1
+    );
+
+    // Simulate a catalog that lost the field: P still physically embeds its
+    // per-row origins, but its catalog row now says it is not partial.
+    let writable = SqlitePool::connect(&db_url(&temp)).await.unwrap();
+    sqlx::query(AssertSqlSafe(
+        "UPDATE ducklake_data_file SET partial_max = NULL WHERE end_snapshot IS NULL",
+    ))
+    .execute(&writable)
+    .await
+    .unwrap();
+
+    append(&temp, vec![3], vec![30]).await;
+    let p = pool(&temp).await;
+    let s3 = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+
+    let result = run_merge(&temp, MergeOptions::default()).await;
+    assert_eq!(result.files_processed, 2, "P is still a candidate");
+
+    // P's rows kept their own origins, so the output holds three distinct ones.
+    let merged_path: String = sqlx::query(AssertSqlSafe(
+        "SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    ))
+    .fetch_one(&p)
+    .await
+    .unwrap()
+    .try_get::<String, _>(0)
+    .unwrap();
+    let mut origins: Vec<i64> = file_lineage(&temp, &merged_path)
+        .into_iter()
+        .map(|(_, origin)| origin.expect("the output embeds per-row origins"))
+        .collect();
+    origins.sort_unstable();
+    assert_eq!(
+        origins,
+        vec![1, 2, s3],
+        "origins came from P's embedded column, not from its catalog begin_snapshot"
+    );
+
+    assert_eq!(read_rows_at(&temp, 1).await, vec![(1, 10)]);
+    assert_eq!(read_rows_at(&temp, 2).await, vec![(1, 10), (2, 20)]);
+    assert_eq!(read_rows(&temp).await, vec![(1, 10), (2, 20), (3, 30)]);
 }
 
 /// Merge must not silently drop a column's data. When a column has been dropped
@@ -2033,5 +2193,104 @@ async fn rewrite_inherits_the_tables_write_options() {
     assert!(
         codecs.iter().all(|c| *c == Compression::LZ4),
         "rewritten file written {codecs:?}, not the table's configured codec"
+    );
+}
+
+/// The recorded `partial_max` must be what the merge WROTE, not what the catalog
+/// claimed its sources held.
+///
+/// A source can physically embed origins above the `partial_max` its catalog row
+/// reports: providers substitute NULL on catalogs predating the column, the MySQL
+/// provider hardcodes it, and the migration that added it NULL-filled every
+/// existing row. Deriving the output's bound from those rows records a maximum
+/// below one the output physically contains — and `needs_snapshot_filter` only
+/// installs the row filter below `partial_max`, so the unfiltered rows are served
+/// at snapshots before they existed. The sources are retired in the same commit,
+/// so the true bound is gone with them.
+///
+/// The shape needs the understating source to hold the highest origin of the bin,
+/// which is why the first merge deliberately leaves the seed file alone.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_merge_records_the_origin_it_wrote_not_the_one_the_catalog_claimed() {
+    let temp = TempDir::new().unwrap();
+    // A big seed so it can be held out of the first merge by size alone.
+    let ids: Vec<i32> = (0..4000).collect();
+    let vals: Vec<i32> = (0..4000).map(|i| i * 2).collect();
+    seed(&temp, ids, vals).await; // snapshot 1, file A
+    append(&temp, vec![9001], vec![1]).await; // snapshot 2, file B
+    append(&temp, vec![9002], vec![2]).await; // snapshot 3, file C
+
+    let p = pool(&temp).await;
+    let small = scalar_i64(
+        &p,
+        "SELECT MIN(file_size_bytes) FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .await;
+    let big = scalar_i64(
+        &p,
+        "SELECT MAX(file_size_bytes) FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .await;
+    assert!(big > small * 2, "the seed must be separable by size");
+
+    // Merge B+C only: A is at or above the target, so it is left alone.
+    run_merge(
+        &temp,
+        MergeOptions {
+            target_file_size: big as u64,
+            max_merged_files: 1024,
+            min_file_size: 0,
+        },
+    )
+    .await;
+
+    // P now embeds origins {2, 3}. Make its catalog row understate that, the way
+    // a NULL-filling migration or a provider that cannot read the column does.
+    let writable = SqlitePool::connect(&db_url(&temp)).await.unwrap();
+    sqlx::query(AssertSqlSafe(
+        "UPDATE ducklake_data_file SET partial_max = NULL          WHERE end_snapshot IS NULL AND partial_max IS NOT NULL",
+    ))
+    .execute(&writable)
+    .await
+    .unwrap();
+
+    // A (begin 1) + P (begin 2, catalog says not partial, really holds 3).
+    let result = run_merge(
+        &temp,
+        MergeOptions {
+            target_file_size: 1 << 30,
+            max_merged_files: 1024,
+            min_file_size: 0,
+        },
+    )
+    .await;
+    assert_eq!(result.files_processed, 2, "A and P merge together");
+
+    let recorded = opt_i64(
+        &p,
+        "SELECT partial_max FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .await
+    .expect("the output is partial: it embeds per-row origins");
+
+    let merged_path: String = sqlx::query(AssertSqlSafe(
+        "SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    ))
+    .fetch_one(&p)
+    .await
+    .unwrap()
+    .try_get::<String, _>(0)
+    .unwrap();
+    let written_max = file_lineage(&temp, &merged_path)
+        .into_iter()
+        .filter_map(|(_, origin)| origin)
+        .max()
+        .expect("the output embeds per-row origins");
+
+    assert_eq!(
+        recorded, written_max,
+        "the catalog understated P (partial_max NULL, begin 2) while it physically \
+         held origin {written_max}; the output must record what it wrote, or a read \
+         below {written_max} skips the row filter and serves rows that did not exist yet"
     );
 }

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -2293,4 +2293,18 @@ async fn a_merge_records_the_origin_it_wrote_not_the_one_the_catalog_claimed() {
          held origin {written_max}; the output must record what it wrote, or a read \
          below {written_max} skips the row filter and serves rows that did not exist yet"
     );
+
+    // The bookkeeping is only a proxy. What the bound protects is the read: at a
+    // snapshot inside the gap the catalog claimed, the row that arrived later
+    // must not be visible. `needs_snapshot_filter` is `snapshot_id < partial_max`,
+    // so an understated bound is exactly the case where no filter is installed.
+    let at_two = read_rows_at(&temp, 2).await;
+    assert!(
+        !at_two.iter().any(|(id, _)| *id == 9002),
+        "the row appended at snapshot 3 must not be visible at snapshot 2: {at_two:?}"
+    );
+    assert!(
+        at_two.iter().any(|(id, _)| *id == 9001),
+        "the row appended at snapshot 2 must still be visible at snapshot 2: {at_two:?}"
+    );
 }


### PR DESCRIPTION
## The problem

A merge whose sources span more than one origin snapshot is written as a **partial file**: it embeds a per-row `_ducklake_internal_snapshot_id` column and records `partial_max`, so time travel can still attribute every merged row. `merge_adjacent_files` then excluded those files from every later merge:

```rust
&& f.partial_max.is_none()
```

On a table taking frequent appends nearly every merge spans snapshots, so nearly every output is born unmergeable. Each pass strands one more file and the partition accumulates a floor nothing can reduce — compaction consuming its own output.

Reproduced by interleaving appends with merge passes, which is the shape a continuous ingest plus a periodic sweep produces. Live file count after each pass, before this change:

```
1, 2, 3, 4, 5, 6
```

Merging repeatedly on a *static* table does not reproduce it: the first pass consumes everything and later passes have nothing to do. That is why the existing suite could not see this — every compaction test merges once and asserts the output.

## Following official DuckLake

Official applies no such filter. `GetFilesForCompaction` (`ducklake_metadata_manager.cpp`) selects on size, liveness and optional `newer_than` only; `partial_max` never appears in a predicate. It can do that because its reader resolves the origin **per source, from the physical presence of the column** — `GetVirtualColumnExpression` (`ducklake_multi_file_reader.cpp:625-639`) binds the embedded column when `TryFindColumnByFieldId` finds it, and a per-file constant otherwise.

This change adopts that rule. Whether a source carries per-row origins is read from the parquet footer, never from catalog `partial_max`, and the same fact drives both the scan's projection and the exec's origin resolution, so the two cannot disagree.

## The output's bound

`partial_max` on the output is the greatest origin the merge **actually wrote**, observed as the origin arrays stream past and seeded from the catalog's range.

Deriving it from the sources' catalog rows is unsafe precisely where this change matters. A provider that cannot read the column reports NULL — the MySQL provider hardcodes it, older catalogs substitute it, and the migration that added the column NULL-filled existing rows — so a source can physically embed origins above what its catalog row claims. The output would then record a maximum below one it physically contains, and `needs_snapshot_filter` only installs the row filter *below* `partial_max`: rows would be served at snapshots before they existed, with the sources retired in the same commit.

`begin_snapshot` remains the minimum of the sources' catalog values; understating it is not reachable the same way, since a partial file's `begin_snapshot` is its minimum origin by construction.

## Tests

Four, each verified to fail without the code it covers:

- `interleaved_appends_and_merges_keep_the_live_file_count_flat` — the shape above; fails at pass 2 with the exclusion restored (`left: 2, right: 1`).
- `merge_remerges_a_partial_file_preserving_per_row_origins` — a re-merge keeps distinct per-row origins on disk, with time travel checked at each snapshot.
- `merge_reads_per_row_origins_from_the_file_not_the_catalog` — a file that still embeds origins after its catalog row is NULLed. Keying the decision on the catalog instead yields origins `[1, 1, 4]` where `[1, 2, 4]` is correct: silent misattribution.
- `a_merge_records_the_origin_it_wrote_not_the_one_the_catalog_claimed` — a source whose physical origins exceed every source's catalog value. Asserts both the recorded bound and the read it protects: the row appended at snapshot 3 must not be visible at snapshot 2.

## Guards

A bin is skipped, with a warning, when the catalog calls a source partial while the file carries no such column, and when a source's rows reach past the handle's snapshot. Both cost the bin rather than the sweep, so a compactor on a stale handle keeps making progress on everything else.

## Deliberately not here

Two further divergences from official were found alongside this and are left for separate PRs, since neither is needed to fix the stranding:

- **Cross-schema-version merging.** Official merges across a DDL boundary when the fields survive into the latest schema (`can_merge_into_latest` / `FieldsPreservedInLatest`); this crate merges only within a schema version. Doing it safely first needs `initial_default` on the read path — the crate never reads that field, so merging a pre-`ADD COLUMN` file into an output at the current schema would materialize NULL over the column's defined default. I will file that separately.
- **`row_id_start` preservation.** Official keeps a compact `row_id_start` when sources are row-id contiguous and skips writing per-row rowids; this crate always writes them.

`cargo test --features write-sqlite,metadata-sqlite`: 373 passed. `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.
