### PR TITLE
chore: shorten CHANGELOG entries and document the convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,120 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `DuckLakeTableWriter::with_upload_concurrency` and
-  `DuckLakeWriteOptions::upload_concurrency` — how many finished data files a rolling
-  or partitioned write uploads at once, defaulting to `DEFAULT_UPLOAD_CONCURRENCY`
-  (4). Uploads are collected in write order, so `row_id_start`, per-file statistics
-  and partition labels are identical at any setting (#280).
-
-- Add read-only DuckLake views across metadata backends and writer-compatible view metadata (#264).
-- Add literal column defaults for schema evolution and omitted `INSERT` fields
-  across metadata backends (#259).
+- `DuckLakeTableWriter::with_upload_concurrency` and `DuckLakeWriteOptions::upload_concurrency`
+  set how many finished data files a rolling or partitioned write uploads at once, default 4.
+  Written output is identical at any setting (#280).
+- Read-only DuckLake views across metadata backends, with writer-compatible view metadata (#264).
+- Literal column defaults for schema evolution and omitted `INSERT` fields, across metadata
+  backends (#259).
 
 ### Changed
 
-- **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. It is a
-  plain `pub` struct, so an exhaustive struct literal — or a destructuring pattern
-  without `..` — stops compiling with "missing field `upload_concurrency`". Add
-  `..Default::default()` to the literal, or set `upload_concurrency: None` to keep the
-  writer default. No catalog or data migration is needed (#280).
-
-  Note this struct has now taken a breaking field addition more than once, and will
-  again for the next write option. Marking it `#[non_exhaustive]` does not fix that on
-  its own — for a struct it forbids struct expressions from other crates entirely,
-  including the `..Default::default()` form every caller currently uses — so a lasting
-  fix means pairing it with setter methods on the options type. That is a broader API
-  decision than this change should make, and is left to the maintainers.
-
-  ```rust
-  let options = DuckLakeWriteOptions {
-      target_file_size: Some(target_bytes),
-      ..Default::default()
-  };
-  ```
-
-- A write uploads up to 4 finished data files concurrently instead of one at a time,
-  raising peak **write memory roughly fourfold** on the paths that use it.
-  `object_store`'s `BufWriter` holds a 10 MiB buffer and keeps up to 8 multipart parts
-  in flight, so one upload of a large file peaks near 90 MiB and four near 360 MiB —
-  **per write session**, with no process-wide cap, so concurrent sessions multiply it.
-
-  Which paths are affected is narrower than it may appear, and worth checking against
-  your own usage rather than assuming. In-crate, the concurrent upload helper is
-  reached only from a streaming `begin_write` session (roll enabled) and from a
-  partitioned write's sink. SQL `INSERT`, compaction, and an unpartitioned SQL
-  `UPDATE` all still upload one file at a time and are unaffected. An embedder that
-  drives `begin_write` and streams batches — the shape a bulk load takes — gets both
-  the speedup and the memory cost.
-
-  Restore the previous behaviour with `DuckLakeTableWriter::with_upload_concurrency(1)`
-  on the writer you construct, or pin the previous release. Note that
-  `DuckLakeWriteOptions { upload_concurrency: Some(1), .. }` only takes effect if the
-  writer is built through `with_options`. The same multiplier applies to request rate —
-  up to 32 in-flight part uploads instead of 8 — worth checking against a rate-limited
-  store, gateway or proxy (#280).
-
-- A custom `ObjectStore` implementation now sees several `put_opts` /
-  `put_multipart_opts` calls from a single write overlapping in time. An
-  implementation that assumed this crate wrote one object at a time — a throttling or
-  ordering-sensitive wrapper, or a test double keyed on call sequence — must be made
-  concurrency-safe, or the writer set to `upload_concurrency: Some(1)` (#280).
-
-- A write whose uploads fail removes the objects from that batch, issuing `DELETE`
-  against the object store to do so. A writer role granted only put/list permissions
-  logs `failed to remove a data file after an aborted upload batch` and leaves the
-  orphans exactly as before; grant delete on the data prefix (`s3:DeleteObject`) to get
-  the cleanup. On a versioned bucket the removal leaves a delete marker rather than
-  reclaiming the bytes — including for files whose upload failed and which may never
-  have existed, since the cleanup covers every path in the batch. The cleanup covers a failure **within the upload batch** only —
-  objects from a write that uploaded everything and then failed to commit metadata are
-  still left behind (#280).
-
-- A failing write can surface its error later than before. Uploads already in flight
-  when the first error appears are awaited rather than dropped, because dropping a
-  future mid-multipart strands upload state that only a bucket lifecycle rule could
-  reclaim. Uploads that have not yet started are skipped, so the cost is bounded by
-  the concurrency setting rather than by the size of the batch. Cleanup of the objects
-  that did land is issued as a single batched delete rather than one request per file.
-  The first error in file order is the one returned; any others are logged (#280).
-
-- Staged-file uploads are wrapped in a new `ducklake.upload_staged_files` tracing span,
-  and the existing per-file `ducklake.upload_staged_file` spans now overlap in
-  wall-clock time. Summing their durations no longer approximates a write's upload
-  time (#280).
+- **BREAKING**: `DuckLakeWriteOptions` gained an `upload_concurrency` field. Add
+  `..Default::default()` to exhaustive struct literals; no catalog or data migration (#280).
+- Rolling and partitioned writes upload up to 4 files at once, raising peak write memory
+  roughly fourfold (~90 MiB to ~360 MiB per session) and in-flight upload parts from 8 to 32.
+  SQL `INSERT`, compaction and unpartitioned `UPDATE` are unaffected; `with_upload_concurrency(1)`
+  restores the previous behaviour (#280).
+- A custom `ObjectStore` now sees overlapping `put_opts` / `put_multipart_opts` calls from a
+  single write and must be concurrency-safe (#280).
+- A write whose uploads fail issues `DELETE` for that batch's objects; a writer without delete
+  permission logs and leaves them, and a versioned bucket keeps a delete marker (#280).
+- A failing write awaits in-flight uploads before returning, so its error can surface later.
+  The first error in file order is returned and the rest are logged (#280).
+- Staged-file uploads gained a `ducklake.upload_staged_files` span, and the per-file
+  `ducklake.upload_staged_file` spans now overlap in wall-clock time (#280).
 
 ### Fixed
 
-- Fix `NULL` sentinels, BLOB decoding, expression-default reads, and legacy
-  schema migration (#259).
-
-- An upload whose final flush failed panicked with "Already shut down" instead of
-  returning the error. `BufWriter::shutdown` leaves the writer shut down even when it
-  fails, and `BufWriter::abort` panics in that state, so the abort the writer ran on
-  every upload error turned a recoverable object-store failure — an expired credential,
-  a rejected `CompleteMultipartUpload` — into a panicking task. The abort decision now
-  lives inside the upload helper, which aborts a copy failure (where it releases the
-  multipart upload) and returns a flush failure as `DuckLakeError::Io`. No error type
-  or variant changed; code that observed this as a task panic now sees an ordinary
-  `Err`. The fix covers every upload the writer performs — data files, delete files and
-  the single-file write path — not only the concurrent one (#280).
-
-- `files_matching` prunes a data file that carries a delete file. Its recorded
-  bounds are marked inexact for readers that apply deletes, and the pruning view
-  uses only exact ones, so the first mutation to write a delete file stopped that
-  file contributing usable bounds to every later call — permanently, since
-  compaction skips delete-bearing files. Callers of `files_matching` read physical
-  rows without applying deletes, where the spec's lower/upper bounds still hold,
-  so they are restated as usable on that path alone; scan statistics are
-  unchanged. The live row count is withheld rather than restated, being the one
-  figure deletes change, and promoting it alongside a physical null count would
-  let a file be judged entirely null and dropped while still holding matching
-  rows (#276).
-
-- Table scans and `COUNT(*)` include scalar rows inlined in SQLite, DuckDB,
-  PostgreSQL, and MySQL metadata catalogs. DuckLake inlines inserts of up to 10
-  rows by default, so affected queries previously omitted them without warning;
-  unsupported non‑scalar inline values now report how to flush or disable
+- `NULL` sentinels, BLOB decoding, expression-default reads, and legacy schema migration (#259).
+- An upload whose final flush failed panicked with "Already shut down" instead of returning
+  the error (#280).
+- `files_matching` no longer stops pruning a data file once that file carries a delete
+  file (#276).
+- Table scans and `COUNT(*)` include scalar rows inlined in SQLite, DuckDB, PostgreSQL and
+  MySQL catalogs; unsupported non-scalar inline values report how to flush or disable
   inlining (#261).
 
 ## [0.7.0] - 2026-08-15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,3 +282,19 @@ cargo test concurrent         # Concurrency tests only
 cargo test --ignored          # Performance benchmarks
 cargo test --test it foo::     # One former test file, by module prefix
 ```
+
+### CHANGELOG entries
+
+Keep `CHANGELOG.md` short. One entry is one line — the user-visible change plus its issue
+refs, wrapping at the file's ~95-column width. Two lines is the ceiling.
+
+- No mechanism, no root-cause narrative, no "why this was quiet", no code blocks. That
+  belongs in the PR body and the commit message, which is where it is already written.
+- A **BREAKING** entry may add one sentence naming the migration (what to change, and
+  whether a catalog or data migration is needed) — not a rationale for the design.
+- Open questions and maintainer decisions do not go here. File an issue.
+- Group entries under `Added` / `Changed` / `Fixed` as now. Several entries from one PR are
+  fine when each is a distinct user-visible fact; don't restate the same fact per surface.
+
+A reader scans a changelog to find whether a release affects them. Anything they cannot act
+on makes that slower.


### PR DESCRIPTION
The `Unreleased` section had grown to 120 lines, most of it mechanism and root-cause narrative that is already written in the PR bodies and commit messages the entries reference. A reader scans a changelog to find whether a release affects them, so that material makes the file slower to use rather than more useful.

### CHANGELOG.md

`Unreleased` goes from 120 lines to 38; the file from 394 to 313. All 13 entries are kept — each is now one line of user-visible change plus its issue refs.

The six distinct `#280` entries stay separate rather than collapsing into one, since each is a different thing a user may need to act on: the new options field, the write-memory multiplier, custom `ObjectStore` concurrency, cleanup permissions, error timing, and the tracing spans.

Two things are dropped rather than shortened:

- the `DuckLakeWriteOptions` `#[non_exhaustive]` discussion, which is a maintainer decision and belongs in an issue
- the `..Default::default()` code block, replaced by naming the fix inline

Released sections (0.7.0 and older) are untouched — those notes are published.

### CLAUDE.md

A `CHANGELOG entries` subsection under Development Notes, so this does not regrow: one line per entry, two as the ceiling; no mechanism, root-cause narrative or code blocks; a **BREAKING** entry may add one sentence naming the migration; open questions go to issues.

No code, test or dependency changes.