### PR TITLE
feat(postgres): index ducklake_file_column_stats for the planning reads

### DIFF
--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -135,6 +135,46 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
         contains_nan BOOLEAN,
         extra_stats VARCHAR
     )"#,
+    // Postgres needs an index here that the DuckLake spec does not define. Every
+    // planning read of this table filters `table_id` for equality and then walks
+    // `data_file_id` as a range — the statistics page query and the column-size
+    // roll-up in `MulticatalogProvider`, and the per-commit recomputation in this
+    // writer — so without one a catalog pays a sequential scan of the whole table
+    // on the planning path of every query, growing with the number of data files
+    // ever written. The official extension leaves this to the operator on Postgres:
+    // duckdb/ducklake#1147 taught its filter pushdown to use such an index but
+    // deliberately does not create one. That is a reasonable default when a person
+    // owns the catalog and a trap when a library does, so this writer creates it.
+    //
+    // Column order follows the predicates rather than convention: `table_id` is the
+    // only equality, `data_file_id` is the only range (and the join key), and
+    // `column_id` costs 8 bytes and lets the planner satisfy the `ORDER BY` without
+    // a sort. `column_size_bytes` rides in INCLUDE so the roll-up query, which
+    // projects nothing else from this table, can be served index-only.
+    // `min_value` / `max_value` stay out on purpose: each is capped at
+    // `MAX_STRING_STAT_BYTES`, and an INCLUDE payload can be compressed but never
+    // moved out of line, so a wide pair would exceed the btree tuple limit and fail
+    // the INSERT — turning a read optimisation into a write outage.
+    //
+    // The guard runs first because a `CREATE INDEX CONCURRENTLY` that is interrupted
+    // leaves an invalid index behind, and `CREATE INDEX IF NOT EXISTS` then skips it
+    // forever — paying the maintenance cost on every write with none of the read
+    // benefit, and silently. Dropping the invalid one makes an interrupted
+    // concurrent build self-healing on the next initialization.
+    r#"DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indexrelid
+                WHERE c.relname = 'idx_file_column_stats_table_file_column'
+                  AND NOT i.indisvalid
+            ) THEN
+                DROP INDEX IF EXISTS idx_file_column_stats_table_file_column;
+            END IF;
+        END $$"#,
+    r#"CREATE INDEX IF NOT EXISTS idx_file_column_stats_table_file_column
+        ON ducklake_file_column_stats (table_id, data_file_id, column_id)
+        INCLUDE (column_size_bytes)"#,
     // Table-wide per-column roll-up (DuckLake spec) — feeds the optimizer.
     r#"CREATE TABLE IF NOT EXISTS ducklake_table_column_stats (
         table_id BIGINT NOT NULL,

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -5671,3 +5671,92 @@ async fn postgres_file_and_table_column_stats_round_trip_per_column() {
         );
     }
 }
+
+/// The `ducklake_file_column_stats` index is not in the DuckLake spec, so nothing
+/// upstream pins its shape. Assert the key columns *in order* plus the included
+/// column: an index that merely exists under the right name is worthless if the
+/// columns are reordered, because the leading-equality/trailing-range shape is the
+/// entire reason it serves the planning reads.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn file_column_stats_index_has_the_documented_shape() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+
+    let rows = sqlx::query(
+        "SELECT a.attname AS col, (k.ord <= i.indnkeyatts) AS is_key
+         FROM pg_index i
+         JOIN pg_class c ON c.oid = i.indexrelid
+         CROSS JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)
+         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+         WHERE c.relname = 'idx_file_column_stats_table_file_column'
+         ORDER BY k.ord",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    let shape: Vec<(String, bool)> = rows
+        .iter()
+        .map(|r| (r.get::<String, _>("col"), r.get::<bool, _>("is_key")))
+        .collect();
+
+    assert_eq!(
+        shape,
+        vec![
+            ("table_id".to_string(), true),
+            ("data_file_id".to_string(), true),
+            ("column_id".to_string(), true),
+            ("column_size_bytes".to_string(), false),
+        ],
+        "the stats index must key on (table_id, data_file_id, column_id) in that \
+         order and include column_size_bytes; got {shape:?}"
+    );
+}
+
+/// An interrupted `CREATE INDEX CONCURRENTLY` leaves an invalid index, and a plain
+/// `CREATE INDEX IF NOT EXISTS` would then skip it forever — every write paying to
+/// maintain an index no read can use. Initialization must drop the invalid one and
+/// rebuild it. Marking `indisvalid = false` by hand is the only way to reach that
+/// state deterministically; it is what an interrupted concurrent build leaves behind.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn an_invalid_file_column_stats_index_is_rebuilt_on_initialize() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+
+    sqlx::query(
+        "UPDATE pg_index SET indisvalid = false
+         WHERE indexrelid = 'idx_file_column_stats_table_file_column'::regclass",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Pre-assert: if this fails the test proved nothing, so fail here rather than
+    // sail on to a green assertion below.
+    let invalid_now: bool = sqlx::query_scalar(
+        "SELECT NOT indisvalid FROM pg_index
+         WHERE indexrelid = 'idx_file_column_stats_table_file_column'::regclass",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(invalid_now, "setup failed to mark the index invalid");
+
+    initialize_multicatalog_schema(&pool).await.unwrap();
+
+    let valid: Vec<bool> = sqlx::query_scalar(
+        "SELECT i.indisvalid FROM pg_index i
+         JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = 'idx_file_column_stats_table_file_column'",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+        valid,
+        vec![true],
+        "initialization must leave exactly one valid stats index; an invalid one \
+         left in place is skipped by CREATE INDEX IF NOT EXISTS forever"
+    );
+}


### PR DESCRIPTION
## Summary

Creates a Postgres index on `ducklake_file_column_stats` during schema initialization.

Every planning read of that table filters `table_id` for equality and then walks `data_file_id` as a range. With no index — and the DuckLake schema defines none — Postgres has no choice but a sequential scan of the entire table, on the planning path of *every* query. The table grows with the number of data files ever written, so the cost is unbounded and paid by queries that touch none of the rows scanned.

The three reads this serves, all in this crate:

- the statistics page query in `MulticatalogProvider` — `WHERE stats.table_id = $1 AND stats.data_file_id > $4 AND stats.data_file_id <= $5`, ordered by `(data_file_id, column_id)`
- the column-size roll-up beside it — same `table_id` filter, `GROUP BY stats.column_id`, and it projects only `column_id` and `column_size_bytes`
- `recompute_table_column_stats` in the Postgres writer, which runs on every commit

## Why not the shape upstream suggests

duckdb/ducklake#1147 recommends `(table_id, column_id)`. That is the right index for the DuckDB extension, whose pushdown emits `WHERE column_id = ? AND table_id = ?` — two equalities. This crate's queries are different: `table_id` is the only equality, and `data_file_id` is a range and the join key. `(table_id, column_id)` would leave the range and the sort unserved.

Column order here follows the predicates:

- `table_id` — the only equality, so it leads
- `data_file_id` — the only range, and the join key, so it is last-constrained
- `column_id` — 8 bytes, and it lets the planner satisfy the `ORDER BY` without a sort

`column_size_bytes` is in `INCLUDE` so the roll-up query, which projects nothing else from this table, can be served index-only.

`min_value` / `max_value` are deliberately excluded. Each is capped at `MAX_STRING_STAT_BYTES`, and an `INCLUDE` payload can be compressed but never moved out of line, so a wide pair would exceed the btree tuple limit and fail the `INSERT`. That turns a read optimisation into a write outage, which is not a trade worth making for a covering scan.

## Why create it here rather than leave it to the operator

The DuckLake spec defines tables and columns, not indexes, and upstream leaves this one to the operator on Postgres — reasonable when a person owns the catalog and knows the backend. It works less well when a library owns it: nothing surfaces the need, and the failure mode is a slow query rather than an error, so a deployment can pay this cost indefinitely without a signal.

An index is invisible to the format. It changes no table, no column and no value, so a catalog carrying it stays readable by any other DuckLake implementation. Upstream notes in #1147 that the Postgres spec may revisit this; if it does, this becomes the same index by a different route.

## The invalid-index guard

`CREATE INDEX CONCURRENTLY` that is interrupted leaves an *invalid* index behind, and `CREATE INDEX IF NOT EXISTS` then skips it forever — every write maintaining an index no read can use, silently and permanently. The `DO $$` block drops an invalid index of this name before the create, so an interrupted concurrent build self-heals on the next initialization.

## Operational note

On an existing catalog with a large `ducklake_file_column_stats`, build the index out of band with `CREATE INDEX CONCURRENTLY` before upgrading. The statement here is a plain `CREATE INDEX IF NOT EXISTS`, which takes `ACCESS EXCLUSIVE` for the duration of the build; on a fresh catalog the table is empty and it is free.

## Tests

Two, both in `multicatalog_postgres_tests.rs`:

- `file_column_stats_index_has_the_documented_shape` asserts the key columns *in order* plus the included column. Asserting only that an index of that name exists would pass with the columns reordered, and the order is the entire reason it works.
- `an_invalid_file_column_stats_index_is_rebuilt_on_initialize` marks the index invalid, re-runs initialization, and asserts exactly one valid index remains. It fails without the guard.

Plan-shape assertions were considered and left out: `EXPLAIN` output over a synthetic table depends on row counts, parallelism settings and the server version, and a test that flaps is worse than one that is absent.
