### PR TITLE
fix(expire): reclaim the per-file and per-commit rows official deletes

### DIFF
--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -184,6 +184,23 @@ pub async fn cleanup_old_files_in_catalog(
     .await
 }
 
+/// Reclaim metadata rows whose owning row is already gone, on a Postgres store.
+///
+/// Step 3 of a sweep, after expire and cleanup. Expire deletes the children of the
+/// owners it retires; this collects children whose owners were retired by an
+/// earlier version that did not, and which no future expire can reach because it
+/// deletes by the ids it is retiring. Bounded per call, so a large backlog drains
+/// over successive sweeps rather than stalling one.
+///
+/// Safe by construction rather than by heuristic: a row whose owner is absent is
+/// unreachable -- every read joins through the owner -- and owner and children are
+/// written in one transaction, so no snapshot sees a child whose owner has not
+/// landed.
+#[cfg(feature = "write-postgres")]
+pub async fn purge_orphaned_metadata_postgres(pool: &sqlx::PgPool) -> Result<()> {
+    crate::metadata_writer_postgres::purge_orphaned_metadata(pool).await
+}
+
 /// List the object store under `data_path`, subtract everything referenced by the
 /// catalog (passed in as `(path, path_is_relative)` pairs), filter by `.parquet`
 /// suffix + `last_modified < older_than` (when set), and delete the leftovers.

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -415,6 +415,92 @@ pub(crate) async fn migrate_column_default_metadata(pool: &PgPool) -> Result<()>
     Ok(())
 }
 
+/// Batch size for one `DELETE` inside the orphan purge, and the cap on how many
+/// batches a single call will run. Bounded on purpose: this runs during schema
+/// initialization, which callers do on startup and often behind a lock, so no
+/// single statement may run long and no single call may run away. A backlog
+/// larger than the cap drains over the next few initializations.
+const ORPHAN_PURGE_BATCH: i64 = 20_000;
+const ORPHAN_PURGE_MAX_BATCHES: usize = 10;
+
+/// Delete metadata rows whose owning row is already gone.
+///
+/// Expire used to drop `ducklake_data_file` and `ducklake_snapshot` rows without
+/// the per-file and per-commit rows hanging off them, so catalogs written by an
+/// earlier version carry rows that no query can reach — every read joins through
+/// the owner — and that nothing will ever collect: expire only cleans what it is
+/// retiring in that transaction, and these owners were retired long ago.
+///
+/// This repairs that history. It is a maintenance operation, not part of expire:
+/// expire keeps deleting exactly what official deletes, and this runs beside it on
+/// the same sweep. Deliberately not called from schema initialization -- callers
+/// bootstrap on startup, often behind a lock where one long statement is a failed
+/// boot, and a scan for orphans has no business on that path.
+///
+/// With expire and `drop_catalog` both reclaiming their children, no path left in
+/// this crate produces these orphans, so on a drained catalog every pass finds
+/// nothing. It stays in the sweep rather than being deleted after one run because
+/// it is the only thing that can reach rows an older version stranded, and because
+/// it is the check that would catch a future path that forgets its children again.
+///
+/// Safety rests on the anti-join, not on a guess about what looks stale. A row
+/// whose owner is absent is unreachable by construction, and owner and dependants
+/// are always written in one transaction, so no snapshot can observe a dependant
+/// whose owner has not landed yet. Batched by `ctid` so each statement touches a
+/// bounded number of rows.
+pub async fn purge_orphaned_metadata(pool: &PgPool) -> Result<()> {
+    // (dependant table, owning table, shared key)
+    const TARGETS: &[(&str, &str, &str)] = &[
+        (
+            "ducklake_file_column_stats",
+            "ducklake_data_file",
+            "data_file_id",
+        ),
+        (
+            "ducklake_file_partition_value",
+            "ducklake_data_file",
+            "data_file_id",
+        ),
+        (
+            "ducklake_snapshot_changes",
+            "ducklake_snapshot",
+            "snapshot_id",
+        ),
+    ];
+
+    for (child, owner, key) in TARGETS {
+        let mut removed: u64 = 0;
+        for _ in 0..ORPHAN_PURGE_MAX_BATCHES {
+            let affected = sqlx::query(AssertSqlSafe(format!(
+                "DELETE FROM {child} WHERE ctid IN (
+                     SELECT c.ctid FROM {child} c
+                     WHERE NOT EXISTS (
+                         SELECT 1 FROM {owner} o WHERE o.{key} = c.{key}
+                     )
+                     LIMIT $1
+                 )"
+            )))
+            .bind(ORPHAN_PURGE_BATCH)
+            .execute(pool)
+            .await?
+            .rows_affected();
+
+            removed += affected;
+            if affected < ORPHAN_PURGE_BATCH as u64 {
+                break;
+            }
+        }
+        if removed > 0 {
+            tracing::info!(
+                table = child,
+                removed,
+                "purged orphaned DuckLake metadata rows whose {owner} row was already gone"
+            );
+        }
+    }
+    Ok(())
+}
+
 /// PostgreSQL-based metadata writer for DuckLake catalogs.
 ///
 /// Bound to a single `catalog_id` at construction. To write to a different

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -475,13 +475,17 @@ impl SqliteMetadataWriter {
             }
             let expire_ids: Vec<i64> = candidates.iter().map(|s| s.snapshot_id).collect();
 
-            // 2. Delete the snapshot rows themselves.
-            sqlx::query(AssertSqlSafe(format!(
-                "DELETE FROM ducklake_snapshot WHERE snapshot_id IN ({})",
-                id_list(&expire_ids)
-            )))
-            .execute(&mut *tx)
-            .await?;
+            // 2. Delete the snapshot rows themselves, and the per-commit change
+            //    records that hang off them. Official deletes both in one loop
+            //    (DeleteSnapshots); a change record outlives its snapshot otherwise.
+            for table in ["ducklake_snapshot", "ducklake_snapshot_changes"] {
+                sqlx::query(AssertSqlSafe(format!(
+                    "DELETE FROM {table} WHERE snapshot_id IN ({})",
+                    id_list(&expire_ids)
+                )))
+                .execute(&mut *tx)
+                .await?;
+            }
 
             // 3. Tables whose lifetime is no longer covered by any surviving snapshot
             //    AND which have no surviving live version.
@@ -524,12 +528,26 @@ impl SqliteMetadataWriter {
             .await?;
             let data_file_ids = schedule_files(&mut tx, dead_data_files).await?;
             if !data_file_ids.is_empty() {
-                sqlx::query(AssertSqlSafe(format!(
-                    "DELETE FROM ducklake_data_file WHERE data_file_id IN ({})",
-                    id_list(&data_file_ids)
-                )))
-                .execute(&mut *tx)
-                .await?;
+                // Per-file metadata dies with its file, keyed on the same ids and in
+                // the same group official uses (DeleteSnapshots). The compaction path
+                // below already does this for the sources it retires; without it here
+                // the rows are unreachable but never reclaimed.
+                // ducklake_file_variant_stats is the fourth table official deletes
+                // here. Not in this schema, so omitted. IF IT IS EVER ADDED, ADD IT
+                // HERE TOO — a per-file table expire does not reclaim orphans
+                // silently and forever.
+                for table in [
+                    "ducklake_data_file",
+                    "ducklake_file_column_stats",
+                    "ducklake_file_partition_value",
+                ] {
+                    sqlx::query(AssertSqlSafe(format!(
+                        "DELETE FROM {table} WHERE data_file_id IN ({})",
+                        id_list(&data_file_ids)
+                    )))
+                    .execute(&mut *tx)
+                    .await?;
+                }
             }
 
             // 5. Delete files orphaned by the data files above, by a dead table, or no
@@ -579,7 +597,12 @@ impl SqliteMetadataWriter {
                 for table in [
                     "ducklake_table",
                     "ducklake_table_stats",
+                    "ducklake_table_column_stats",
+                    "ducklake_partition_info",
+                    "ducklake_partition_column",
                     "ducklake_column",
+                    "ducklake_sort_info",
+                    "ducklake_sort_expression",
                     "ducklake_schema_versions",
                 ] {
                     sqlx::query(AssertSqlSafe(format!(

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -201,11 +201,24 @@ impl MulticatalogManager {
         // Catalog-scoped child rows that reference `table_id`. Filtered
         // transitively through the schema map so we only touch rows
         // owned by this catalog.
+        // Same set expire reclaims per dead table, plus the two per-file tables:
+        // all are keyed on `table_id`, so they take the scoping this loop already
+        // applies. Dropping a catalog without them orphans exactly what expire used
+        // to orphan (#248), and on SQLite a reused data_file_id would then inherit
+        // a dead file's stats and partition values.
         for child_table in [
             "ducklake_data_file",
             "ducklake_delete_file",
+            "ducklake_file_column_stats",
+            "ducklake_file_partition_value",
             "ducklake_column",
             "ducklake_schema_versions",
+            "ducklake_table_stats",
+            "ducklake_table_column_stats",
+            "ducklake_partition_info",
+            "ducklake_partition_column",
+            "ducklake_sort_info",
+            "ducklake_sort_expression",
         ] {
             sqlx::query(AssertSqlSafe(format!(
                 "DELETE FROM {} WHERE table_id IN (
@@ -242,6 +255,15 @@ impl MulticatalogManager {
         // Snapshots are catalog-scoped only via the snapshot map; they
         // carry no catalog_id of their own, so the map is the only path
         // to locate them.
+        sqlx::query(
+            "DELETE FROM ducklake_snapshot_changes WHERE snapshot_id IN (
+                SELECT snapshot_id FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1
+            )",
+        )
+        .bind(catalog_id)
+        .execute(&mut *tx)
+        .await?;
+
         sqlx::query(
             "DELETE FROM ducklake_snapshot WHERE snapshot_id IN (
                 SELECT snapshot_id FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1
@@ -717,6 +739,13 @@ impl MulticatalogManager {
             .bind(&expire_ids)
             .execute(&mut *tx)
             .await?;
+        // Official deletes ducklake_snapshot_changes in the same loop as
+        // ducklake_snapshot (DeleteSnapshots). We write one row per commit, so
+        // leaving them behind orphans at commit rate rather than at expiry rate.
+        sqlx::query("DELETE FROM ducklake_snapshot_changes WHERE snapshot_id = ANY($1)")
+            .bind(&expire_ids)
+            .execute(&mut *tx)
+            .await?;
 
         // 3. Tables in this catalog no longer covered by any surviving snapshot and with
         //    no surviving live version.
@@ -770,6 +799,31 @@ impl MulticatalogManager {
             .bind(&data_file_ids)
             .execute(&mut *tx)
             .await?;
+        // Per-file metadata dies with its file. Official deletes these in the same
+        // group as ducklake_data_file, keyed on the same ids; the compaction path
+        // here already does the same for the sources it retires. Without this the
+        // rows are unreachable (every read joins through ducklake_data_file) but
+        // never reclaimed, so the stats table grows without bound and is scanned
+        // in full on the planning path of every query.
+        // ducklake_file_variant_stats is the fourth table official deletes in this
+        // group. It is not in this schema, so it is omitted rather than skipped at
+        // runtime. IF THAT TABLE IS EVER ADDED, ADD IT HERE TOO.
+        //
+        // That instruction is the whole point of this block: omitting exactly one
+        // per-file table here is how ducklake_file_column_stats came to hold rows
+        // for files deleted long ago. Nothing reads them — every read joins through
+        // ducklake_data_file — and nothing collects them, because expire only cleans
+        // what it retires in its own transaction. The table grows without bound and
+        // is read while planning every query, so the cost lands on queries that
+        // touch none of it.
+        for table in ["ducklake_file_column_stats", "ducklake_file_partition_value"] {
+            sqlx::query(AssertSqlSafe(format!(
+                "DELETE FROM {table} WHERE data_file_id = ANY($1)"
+            )))
+            .bind(&data_file_ids)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         // 5. Delete files orphaned by the data files above, a dead table, or no surviving
         //    snapshot. (Our writer does not emit delete files yet — no-op for our catalogs.)
@@ -798,9 +852,27 @@ impl MulticatalogManager {
             .execute(&mut *tx)
             .await?;
 
-        // 6. Reclaim per-table metadata for fully-expired tables. (No ducklake_table_stats
-        //    on Postgres — that table is maintained only by the SQLite writer.)
-        for table in ["ducklake_table", "ducklake_column", "ducklake_schema_versions"] {
+        // 6. Reclaim per-table metadata for fully-expired tables. This is official's
+        //    twelve-table list from DeleteSnapshots.
+        //    Official's list is twelve (ducklake_metadata_manager.cpp, DeleteSnapshots).
+        //    ducklake_column_tag, ducklake_inlined_data_tables and
+        //    ducklake_column_mapping are omitted because this schema does not have
+        //    them. IF ANY OF THE THREE IS EVER ADDED, ADD IT HERE TOO — official
+        //    reclaims it, and a table-scoped table this loop misses orphans forever.
+        //    ducklake_table_stats is in it because this writer
+        //    creates and maintains it — the comment that used to say otherwise was
+        //    wrong — and the SQLite expire path already reclaimed it.
+        for table in [
+            "ducklake_table",
+            "ducklake_table_stats",
+            "ducklake_table_column_stats",
+            "ducklake_partition_info",
+            "ducklake_partition_column",
+            "ducklake_column",
+            "ducklake_sort_info",
+            "ducklake_sort_expression",
+            "ducklake_schema_versions",
+        ] {
             sqlx::query(AssertSqlSafe(format!(
                 "DELETE FROM {table} WHERE table_id = ANY($1)"
             )))

--- a/tests/it/maintenance_sqlite_tests.rs
+++ b/tests/it/maintenance_sqlite_tests.rs
@@ -1196,3 +1196,113 @@ async fn replace_out_of_order_commit_conflicts() {
         "exactly one column generation may be live at the head"
     );
 }
+
+/// Issue #248's correctness case, and why the SQLite half of the expire fix
+/// matters more than the Postgres half.
+///
+/// `data_file_id INTEGER PRIMARY KEY` is a rowid alias, so SQLite hands out
+/// `max(rowid) + 1` and reuses ids after deletes — unlike Postgres, where the
+/// column is `GENERATED ALWAYS AS IDENTITY` and an id is never seen twice. Leave a
+/// retired file's stats behind on SQLite and a later file can take its id and
+/// inherit statistics describing different data. Stats drive pruning and pruning
+/// decides which files are read, so the result is dropped rows, not slow queries.
+///
+/// This asserts the precondition of that bug is gone: after expire, no stats row
+/// survives for the retired file's id.
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_leaves_no_stats_behind_for_a_retired_file_id() {
+    use datafusion_ducklake::metadata_writer::ColumnStat;
+
+    let h = setup().await;
+    let stats = |ids: &[i64]| -> Vec<ColumnStat> {
+        ids.iter()
+            .map(|&column_id| ColumnStat {
+                column_id,
+                min_value: Some("1".to_string()),
+                max_value: Some("9".to_string()),
+                null_count: Some(0),
+                value_count: Some(5),
+                contains_nan: None,
+                column_size_bytes: Some(64),
+            })
+            .collect()
+    };
+
+    let s1 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s1.table_id,
+            "main",
+            "t",
+            s1.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5).with_column_stats(stats(&s1.column_ids)),
+            WriteMode::Replace,
+            s1.base_snapshot_id,
+            &cols(),
+            &s1.column_ids,
+        )
+        .unwrap();
+
+    let p = pool(&h).await;
+    let doomed_id = scalar_i64(&p, "SELECT MAX(data_file_id) FROM ducklake_data_file").await;
+    let before = scalar_i64(
+        &p,
+        &format!(
+            "SELECT COUNT(*) FROM ducklake_file_column_stats WHERE data_file_id = {doomed_id}"
+        ),
+    )
+    .await;
+    assert!(
+        before > 0,
+        "setup wrote no stats, so this test could not detect the bug"
+    );
+
+    // Replace retires f1; expiring s1 then leaves no snapshot covering it.
+    let s2 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s2.table_id,
+            "main",
+            "t",
+            s2.snapshot_id,
+            &DataFileInfo::new("f2.parquet", 100, 5).with_column_stats(stats(&s2.column_ids)),
+            WriteMode::Replace,
+            s2.base_snapshot_id,
+            &cols(),
+            &s2.column_ids,
+        )
+        .unwrap();
+    h.writer
+        .expire_snapshots(ExpireCriteria::Versions(vec![s1.snapshot_id]))
+        .unwrap();
+
+    // Precondition: if the file survived, nothing was orphaned and the assertion
+    // below would pass against unfixed code.
+    assert_eq!(
+        scalar_i64(
+            &p,
+            &format!("SELECT COUNT(*) FROM ducklake_data_file WHERE data_file_id = {doomed_id}")
+        )
+        .await,
+        0,
+        "setup did not retire the data file, so this test proves nothing"
+    );
+    assert_eq!(
+        scalar_i64(
+            &p,
+            &format!(
+                "SELECT COUNT(*) FROM ducklake_file_column_stats WHERE data_file_id = {doomed_id}"
+            )
+        )
+        .await,
+        0,
+        "expire deleted the data file but left its {before} stats rows — a file later \
+         reusing this id would inherit them"
+    );
+}

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -5760,3 +5760,465 @@ async fn an_invalid_file_column_stats_index_is_rebuilt_on_initialize() {
          left in place is skipped by CREATE INDEX IF NOT EXISTS forever"
     );
 }
+
+/// Per-column stats for every column, so a test that asserts on
+/// `ducklake_file_column_stats` is asserting on rows that actually exist.
+fn file_stats(column_ids: &[i64]) -> Vec<datafusion_ducklake::metadata_writer::ColumnStat> {
+    column_ids
+        .iter()
+        .map(
+            |&column_id| datafusion_ducklake::metadata_writer::ColumnStat {
+                column_id,
+                min_value: Some("1".to_string()),
+                max_value: Some("9".to_string()),
+                null_count: Some(0),
+                value_count: Some(5),
+                contains_nan: None,
+                column_size_bytes: Some(64),
+            },
+        )
+        .collect()
+}
+
+/// Expire must take a retired file's per-file metadata with it.
+///
+/// The live table is created FIRST on purpose. Created second, its snapshots land
+/// inside the dead file's `[begin, end)` range and keep it reachable, so expire
+/// retires nothing and the whole test passes against unfixed code — which is what
+/// the first draft of this test did.
+///
+/// The precondition assert below is what makes that impossible to reintroduce: if
+/// the dead file's row is still present, the setup orphaned nothing and the test
+/// fails there rather than sailing on to a green anti-join.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn expire_reclaims_per_file_metadata_and_spares_live_files() {
+    use datafusion_ducklake::maintenance::ExpireCriteria;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // The survivor, first, so its snapshots precede the dead file's range.
+    let live = w
+        .begin_write_transaction("public", "t_live", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        live.table_id,
+        "public",
+        "t_live",
+        live.snapshot_id,
+        &DataFileInfo::new("live.parquet", 100, 5).with_column_stats(file_stats(&live.column_ids)),
+        WriteMode::Replace,
+        live.base_snapshot_id,
+        &cols(),
+        &live.column_ids,
+    )
+    .unwrap();
+
+    let dead = w
+        .begin_write_transaction("public", "t_dead", &cols(), WriteMode::Replace)
+        .unwrap();
+    let dead_snap = w
+        .register_data_file(
+            dead.table_id,
+            "public",
+            "t_dead",
+            dead.snapshot_id,
+            &DataFileInfo::new("dead.parquet", 100, 5)
+                .with_column_stats(file_stats(&dead.column_ids)),
+            WriteMode::Replace,
+            dead.base_snapshot_id,
+            &cols(),
+            &dead.column_ids,
+        )
+        .unwrap()
+        .snapshot_id;
+
+    let dead_file_id: i64 =
+        sqlx::query("SELECT data_file_id FROM ducklake_data_file WHERE table_id = $1")
+            .bind(dead.table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    let dead_stats_before: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE data_file_id = $1")
+            .bind(dead_file_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert!(
+        dead_stats_before > 0,
+        "setup wrote no stats for the file under test"
+    );
+    let live_before: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE table_id = $1")
+            .bind(live.table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert!(live_before > 0, "setup wrote no stats for the live table");
+
+    assert!(
+        mgr.drop_table_in_catalog("pg_prod", "public", "t_dead")
+            .await
+            .unwrap()
+    );
+    mgr.expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![dead_snap]))
+        .await
+        .unwrap();
+
+    // Precondition, not a result: if the file survived, nothing was orphaned and
+    // the assertions below would pass on unfixed code.
+    let dead_file_rows: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_data_file WHERE data_file_id = $1")
+            .bind(dead_file_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        dead_file_rows, 0,
+        "setup did not retire the data file, so this test proves nothing"
+    );
+
+    let dead_stats_after: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE data_file_id = $1")
+            .bind(dead_file_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        dead_stats_after, 0,
+        "expire deleted the data file but left its {dead_stats_before} stats rows"
+    );
+
+    let live_after: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE table_id = $1")
+            .bind(live.table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        live_after, live_before,
+        "expire removed stats belonging to a live file"
+    );
+
+    // Official's per-dead-table list from DeleteSnapshots, less the three tables
+    // this schema does not have. Counted before and after: `covered` records how
+    // many of them the setup actually populated, so this cannot silently become a
+    // set of assertions against empty tables.
+    const PER_TABLE: &[&str] = &[
+        "ducklake_table",
+        "ducklake_table_stats",
+        "ducklake_table_column_stats",
+        "ducklake_partition_info",
+        "ducklake_partition_column",
+        "ducklake_column",
+        "ducklake_sort_info",
+        "ducklake_sort_expression",
+        "ducklake_schema_versions",
+    ];
+    let mut covered = 0;
+    for t in PER_TABLE {
+        let live_rows: i64 = sqlx::query(AssertSqlSafe(format!(
+            "SELECT COUNT(*) FROM {t} WHERE table_id = $1"
+        )))
+        .bind(live.table_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+        if live_rows > 0 {
+            covered += 1;
+        }
+        let dead_rows: i64 = sqlx::query(AssertSqlSafe(format!(
+            "SELECT COUNT(*) FROM {t} WHERE table_id = $1"
+        )))
+        .bind(dead.table_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+        assert_eq!(dead_rows, 0, "{t} not reclaimed for the expired table");
+        assert!(
+            live_rows > 0 || t != &"ducklake_table",
+            "the live table vanished from {t}"
+        );
+    }
+    assert!(
+        covered >= 4,
+        "only {covered} of the per-table list was populated by this setup, so the \
+         reclaim assertions are mostly vacuous"
+    );
+}
+
+/// `ducklake_snapshot_changes` is written once per commit, so leaving it behind
+/// orphans at commit rate. Official deletes it in the same loop as the snapshot.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn expire_reclaims_snapshot_changes() {
+    use datafusion_ducklake::maintenance::ExpireCriteria;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let s = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    let snap = w
+        .register_data_file(
+            s.table_id,
+            "public",
+            "t",
+            s.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
+            s.base_snapshot_id,
+            &cols(),
+            &s.column_ids,
+        )
+        .unwrap()
+        .snapshot_id;
+
+    let before: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot_changes WHERE snapshot_id = $1")
+            .bind(snap)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(before, 1, "setup did not record a change row to reclaim");
+
+    assert!(
+        mgr.drop_table_in_catalog("pg_prod", "public", "t")
+            .await
+            .unwrap()
+    );
+    mgr.expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![snap]))
+        .await
+        .unwrap();
+
+    let after: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot_changes WHERE snapshot_id = $1")
+            .bind(snap)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(after, 0, "expired snapshot left its change record behind");
+}
+
+/// The repair. Catalogs written before expire reclaimed per-file rows carry
+/// orphans no query can reach and no future expire will collect, so a sweep
+/// collects them. Seeded by hand because reproducing the historical
+/// bug would require running the old code.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn purge_removes_orphans_and_leaves_live_rows_alone() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let s = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s.table_id,
+        "public",
+        "t",
+        s.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5).with_column_stats(file_stats(&s.column_ids)),
+        WriteMode::Replace,
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
+    )
+    .unwrap();
+
+    let live_before: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert!(live_before > 0, "setup produced no live stats rows");
+
+    // Orphans: no ducklake_data_file row has id 987654, and no snapshot has id 987654.
+    sqlx::query(
+        "INSERT INTO ducklake_file_column_stats
+             (data_file_id, table_id, column_id, column_size_bytes, value_count, null_count)
+         VALUES (987654, $1, 1, 10, 1, 0), (987654, $1, 2, 10, 1, 0)",
+    )
+    .bind(s.table_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made) VALUES (987654, '')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    datafusion_ducklake::maintenance::purge_orphaned_metadata_postgres(&pool)
+        .await
+        .unwrap();
+
+    let orphans: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_file_column_stats s
+         WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_data_file d WHERE d.data_file_id = s.data_file_id
+         )",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(orphans, 0, "the purge left orphaned stats rows behind");
+
+    let stranded: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot_changes WHERE snapshot_id = 987654")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        stranded, 0,
+        "the purge left an orphaned change record behind"
+    );
+
+    let live_after: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(
+        live_after, live_before,
+        "the purge deleted stats belonging to a live file — only unreachable rows may go"
+    );
+
+    let _ = cat;
+}
+
+/// #248 site 2. Dropping a catalog deletes its data files and snapshots; without
+/// their children that strands exactly what expire used to strand. Asserts both
+/// halves: the dropped catalog leaves nothing behind, and a second catalog sharing
+/// the metadata database is untouched — the delete is scoped transitively through
+/// the schema map, so an over-broad predicate here would reach another tenant.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn drop_catalog_reclaims_children_and_spares_other_catalogs() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+
+    let write_one = |name: &'static str| {
+        let cat = futures::executor::block_on(mgr.create_catalog(name)).unwrap();
+        let w = futures::executor::block_on(PostgresMetadataWriter::with_pool(pool.clone(), cat))
+            .unwrap();
+        w.set_data_path("/data").unwrap();
+        let s = w
+            .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+            .unwrap();
+        w.register_data_file(
+            s.table_id,
+            "public",
+            "t",
+            s.snapshot_id,
+            &DataFileInfo::new("f.parquet", 100, 5).with_column_stats(file_stats(&s.column_ids)),
+            WriteMode::Replace,
+            s.base_snapshot_id,
+            &cols(),
+            &s.column_ids,
+        )
+        .unwrap();
+        s.table_id
+    };
+
+    let doomed_table = write_one("pg_doomed");
+    let keeper_table = write_one("pg_keeper");
+
+    let doomed_before: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE table_id = $1")
+            .bind(doomed_table)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    let keeper_before: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE table_id = $1")
+            .bind(keeper_table)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert!(
+        doomed_before > 0 && keeper_before > 0,
+        "setup wrote no stats, so this test could not detect anything"
+    );
+
+    mgr.drop_catalog("pg_doomed").await.unwrap();
+
+    let orphans: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_file_column_stats s
+         WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_data_file d WHERE d.data_file_id = s.data_file_id
+         )",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(orphans, 0, "drop_catalog stranded per-file metadata");
+
+    let keeper_after: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_file_column_stats WHERE table_id = $1")
+            .bind(keeper_table)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        keeper_after, keeper_before,
+        "drop_catalog reached into another catalog sharing this metadata database"
+    );
+}


### PR DESCRIPTION
Closes #248.

## Summary

Expire dropped `ducklake_data_file` and `ducklake_snapshot` rows while leaving everything keyed off them behind. Official deletes them together in `DeleteSnapshots`; this restores that, in both expire paths.

The orphans are unreachable rather than merely stale — every read joins through the owning row — and nothing collects them, because expire only cleans what it retires in its own transaction. So they accumulate for the life of the catalog. `ducklake_file_column_stats` is the expensive one: it is read while planning every query, so an unbounded table is scanned in full by queries that touch none of it.

## What now matches official

```
group             keyed on        tables
snapshot          snapshot_id     ducklake_snapshot, ducklake_snapshot_changes
per-file          data_file_id    ducklake_data_file, ducklake_file_column_stats,
                                  ducklake_file_partition_value
per-dead-table    table_id        ducklake_table, ducklake_table_stats,
                                  ducklake_table_column_stats, ducklake_partition_info,
                                  ducklake_partition_column, ducklake_column,
                                  ducklake_sort_info, ducklake_sort_expression,
                                  ducklake_schema_versions
```

The per-dead-table group was three tables of official's twelve; it is now nine. The three still absent — `ducklake_column_tag`, `ducklake_inlined_data_tables`, `ducklake_column_mapping` — do not exist in this schema, as does not `ducklake_file_variant_stats` in the per-file group. Each omission carries a comment saying to add it if the table ever arrives, because omitting exactly one per-file table is how this bug happened in the first place.

`ducklake_table_stats` joins the Postgres dead-table reclaim. The comment saying it was maintained only by the SQLite writer was wrong: this writer creates it and updates it on every commit, and the SQLite expire path already reclaimed it.

## The repair

Catalogs written before this fix hold rows whose owners were retired long ago. No future expire will ever select them — it deletes by the ids it is retiring — so they have to be found by anti-join instead.

`maintenance::purge_orphaned_metadata_postgres` does that, as a third step of a sweep beside expire and cleanup. Deliberately *not* in schema initialization: callers bootstrap on startup, often behind a lock where one long statement is a failed boot, and a scan for orphans has no business on that path. Keeping it in maintenance also leaves expire itself deleting exactly what official deletes and nothing more. Batched by `ctid` and capped per call, so a large backlog drains over successive sweeps rather than stalling one.

With expire and `drop_catalog` both reclaiming their children, no path left in this crate produces these orphans, so on a drained catalog every pass finds nothing. It stays in the sweep rather than running once because it is the only thing that can reach rows an older version stranded, and because it is the check that catches a future path that forgets its children again.

Safety rests on the anti-join, not a heuristic. A row whose owner is absent is unreachable by construction; owner and children are written in one transaction, so no snapshot observes a child whose owner has not landed; and all three owner keys are database-global identity primary keys, so a shared metadata database is not at risk. If it were wrong anyway, the failure is lost pruning — a bound is published only when every live file reports one — so queries would slow rather than lie.

## The three sites in #248

That issue names three paths deleting `ducklake_data_file` rows without their children. All three are covered here:

```
src/multicatalog.rs          expire_snapshots_in_catalog
src/multicatalog.rs          drop_catalog
src/metadata_writer_sqlite.rs  expire_snapshots
```

`drop_catalog` gains the same children through the loop it already runs — every one of them is keyed on `table_id`, so they inherit its existing transitive scoping rather than needing a new predicate. It also gains `ducklake_snapshot_changes` beside its snapshot delete.

The SQLite half is the correctness-critical one, and #248 explains why: `data_file_id INTEGER PRIMARY KEY` is a rowid alias, so SQLite hands out `max(rowid) + 1` and reuses ids. A file written after a retirement could take the dead file's id and inherit its statistics and partition values — and since stats drive pruning, and pruning decides which files are read, that drops rows from results rather than merely slowing them. Postgres is unaffected: its ids are `GENERATED ALWAYS AS IDENTITY` and never reused, so there the cost is bloat and scan time.

## Tests

Three, all confirmed to fail with the source reverted. The per-file test asserts the retired file's stats are gone *and* that an untouched table's stats are unchanged; a purge that deleted everything would satisfy the first assertion alone. It also loops the nine table-scoped tables with a counter that fails if fewer than four were actually populated, because five of the nine are empty in a simple setup and would otherwise be assertions against nothing.

The first draft of that test passed against unfixed code — the live table was created second, so its snapshots fell inside the dead file's `[begin, end)` range and expire retired nothing. It now creates the survivor first and asserts the data file is actually gone before asserting anything about its stats.

## Note for reviewers

`main` currently fails three tests in `postgres_single_catalog_write_tests` under `--features write-postgres`, unrelated to this change — I verified the same three fail on `280c6a3` without this commit. They are invisible to CI because no job enables `write-postgres`: both that file and `multicatalog_postgres_tests.rs` are gated on it, so roughly a hundred tests are compile-checked and never run. Worth addressing separately; it is the reason a rule applied in one of two places could survive here.
