### PR TITLE
Attach cached parquet reader factory to scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,6 +1926,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "datafusion",
  "datafusion-datasource",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,6 +1930,7 @@ dependencies = [
  "chrono",
  "datafusion",
  "datafusion-datasource",
+ "datafusion-datasource-parquet",
  "duckdb",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ autotests = false
 [dependencies]
 datafusion = { version = "55", default-features = false, features = ["parquet", "recursive_protection", "sql"] }
 datafusion-datasource = { version = "55", default-features = false }
+# `DFParquetMetadata` — the umbrella `datafusion` crate re-exports
+# `ParquetSource` but not this module, so a direct pin is needed to read a
+# file's footer through the same `RuntimeEnv` `FileMetadataCache` a scan's
+# `CachedParquetFileReaderFactory` uses (#1323's plan-time half). Version must
+# stay in lockstep with `datafusion` above.
+datafusion-datasource-parquet = { version = "55", default-features = false }
 arrow = "59.2"
 parquet = { version = "59.2", features = ["async"] }
 object_store = { version = "0.13", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ sqlx = { version = "0.9", features = ["runtime-tokio"], optional = true }
 [dev-dependencies]
 datafusion = "55"
 object_store = { version = "0.13", features = ["aws", "fs"] }
+bytes = "1"
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["minio", "postgres", "mysql"] }
 tempfile = "3.14"

--- a/src/table.rs
+++ b/src/table.rs
@@ -6508,8 +6508,8 @@ mod tests {
             self.inner.get_ranges(location, ranges).await
         }
 
-        fn delete_stream<'a>(
-            &'a self,
+        fn delete_stream(
+            &self,
             locations: futures::stream::BoxStream<'static, object_store::Result<ObjectPath>>,
         ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectPath>> {
             self.inner.delete_stream(locations)

--- a/src/table.rs
+++ b/src/table.rs
@@ -56,8 +56,9 @@ use datafusion::common::stats::Precision;
 use datafusion::common::{Column, ColumnStatistics, ScalarValue, Statistics};
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::memory::MemorySourceConfig;
+use datafusion::datasource::physical_plan::parquet::CachedParquetFileReaderFactory;
 use datafusion::datasource::physical_plan::{
-    FileGroup, FileScanConfigBuilder, FileSource, ParquetSource,
+    FileGroup, FileScanConfigBuilder, FileSource, ParquetFileReaderFactory, ParquetSource,
 };
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::datasource::table_schema::TableSchema;
@@ -905,6 +906,26 @@ pub(crate) async fn read_parquet_footer_facts(
         arrow_schema: builder.schema().clone(),
         row_group_count: builder.metadata().row_groups().len(),
     })
+}
+
+/// Build a [`CachedParquetFileReaderFactory`] reading `object_store_url`'s
+/// store through `state`'s shared file-metadata cache (the `RuntimeEnv`'s
+/// `FileMetadataCache`, sized by `with_metadata_cache_limit`), rather than the
+/// uncached `DefaultParquetFileReaderFactory` a bare `ParquetSource::new`
+/// falls back to (#1323). Every query-time `ParquetSource` this crate builds
+/// should attach one, so a footer fetched once (by this scan, another scan, or
+/// the caller's own footer sampling) is never re-fetched for the life of the
+/// cache.
+pub(crate) fn cached_parquet_reader_factory(
+    state: &dyn Session,
+    object_store_url: &ObjectStoreUrl,
+) -> DataFusionResult<Arc<dyn ParquetFileReaderFactory>> {
+    let object_store = state.runtime_env().object_store(object_store_url)?;
+    let metadata_cache = state.runtime_env().cache_manager.get_file_metadata_cache();
+    Ok(Arc::new(CachedParquetFileReaderFactory::new(
+        object_store,
+        metadata_cache,
+    )))
 }
 
 /// Resolve one file's columns against `columns` by field id.
@@ -1948,17 +1969,27 @@ impl DuckLakeTable {
 
     /// Create a ParquetSource with encryption support if enabled and needed
     /// Build the parquet source for a scan, with the table's encryption factory
-    /// attached when one is installed.
+    /// attached when one is installed, and a [`CachedParquetFileReaderFactory`]
+    /// attached so the scan reads footers through `state`'s shared
+    /// file-metadata cache instead of re-fetching them per file per query
+    /// (#1323).
     ///
     /// Accepts either a plain file schema or a [`TableSchema`] — the latter is
     /// how a *positional* scan asks the reader for the physical-position virtual
     /// column (see [`positional_table_schema`]).
-    fn create_parquet_source(&self, schema: impl Into<TableSchema>) -> ParquetSource {
+    fn create_parquet_source(
+        &self,
+        state: &dyn Session,
+        schema: impl Into<TableSchema>,
+    ) -> DataFusionResult<ParquetSource> {
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         #[cfg(feature = "encryption")]
         if let Some(factory) = self.encryption_keys.factory.get() {
-            return ParquetSource::new(schema).with_encryption_factory(Arc::clone(factory));
+            return Ok(ParquetSource::new(schema)
+                .with_encryption_factory(Arc::clone(factory))
+                .with_parquet_file_reader_factory(reader_factory));
         }
-        ParquetSource::new(schema)
+        Ok(ParquetSource::new(schema).with_parquet_file_reader_factory(reader_factory))
     }
 
     fn scan_config_builder(&self, source: Arc<dyn FileSource>) -> FileScanConfigBuilder {
@@ -2197,7 +2228,7 @@ impl DuckLakeTable {
         // instead of every row of the file. Positions stay true under pruning
         // because the reader derives them from row-group offsets, and a row the
         // reader drops could not have matched anyway.
-        let mut source = self.create_parquet_source(table_schema);
+        let mut source = self.create_parquet_source(state, table_schema)?;
         if self.predicate_is_prunable(&predicate, &file_cfg) {
             source = source.with_predicate(Arc::clone(&predicate));
         }
@@ -2314,7 +2345,7 @@ impl DuckLakeTable {
         // Create file scan config for the delete file
         let file_scan_config = FileScanConfigBuilder::new(
             self.object_store_url.as_ref().clone(),
-            Arc::new(self.create_parquet_source(delete_schema)),
+            Arc::new(self.create_parquet_source(state, delete_schema)?),
         )
         .with_file_group(FileGroup::new(vec![pf]))
         .build();
@@ -2484,7 +2515,9 @@ impl DuckLakeTable {
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(groups.len());
         for ((read_schema, name_mapping, constants), partitioned_files) in groups {
             let mut builder = self
-                .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
+                .scan_config_builder(Arc::new(
+                    self.create_parquet_source(state, read_schema.clone())?,
+                ))
                 .with_limit(limit)
                 .with_file_group(FileGroup::new(partitioned_files));
 
@@ -2743,7 +2776,7 @@ impl DuckLakeTable {
                 file_statistics,
             )?;
             let mut builder = self
-                .scan_config_builder(Arc::new(self.create_parquet_source(table_schema)))
+                .scan_config_builder(Arc::new(self.create_parquet_source(state, table_schema)?))
                 .with_file_group(FileGroup::new(vec![pf]));
             builder = builder.with_projection_indices(Some(proj))?;
             let scan = DataSourceExec::from_data_source(builder.build());
@@ -2763,7 +2796,7 @@ impl DuckLakeTable {
             )?;
             let mut builder = self
                 .scan_config_builder(Arc::new(
-                    self.create_parquet_source(file_cfg.read_schema.clone()),
+                    self.create_parquet_source(state, file_cfg.read_schema.clone())?,
                 ))
                 .with_limit(limit)
                 .with_file_group(FileGroup::new(vec![pf]));
@@ -2976,7 +3009,7 @@ impl DuckLakeTable {
 
             let pf = self.partitioned_data_file(table_file, has_embedded, file_statistics)?;
             let mut builder = self
-                .scan_config_builder(Arc::new(self.create_parquet_source(table_schema)))
+                .scan_config_builder(Arc::new(self.create_parquet_source(state, table_schema)?))
                 .with_file_group(FileGroup::new(vec![pf]));
             builder = builder.with_projection_indices(Some(proj))?;
             let mut plan: Arc<dyn ExecutionPlan> =
@@ -3006,7 +3039,7 @@ impl DuckLakeTable {
             let pf = self.partitioned_data_file(table_file, true, file_statistics)?;
             let mut builder = self
                 .scan_config_builder(Arc::new(
-                    self.create_parquet_source(file_cfg.read_schema.clone()),
+                    self.create_parquet_source(state, file_cfg.read_schema.clone())?,
                 ))
                 .with_limit(limit)
                 .with_file_group(FileGroup::new(vec![pf]));
@@ -3169,7 +3202,9 @@ impl DuckLakeTable {
                 pf = pf.with_metadata_size_hint(hint);
             }
             let builder = self
-                .scan_config_builder(Arc::new(self.create_parquet_source(read_schema.clone())))
+                .scan_config_builder(Arc::new(
+                    self.create_parquet_source(state, read_schema.clone())?,
+                ))
                 .with_file_group(FileGroup::new(vec![pf]))
                 .with_projection_indices(Some(projection))?;
             DataSourceExec::from_data_source(builder.build())
@@ -3182,7 +3217,7 @@ impl DuckLakeTable {
             proj.push(pos_table_idx);
             let pos_index = proj.len() - 1;
             let builder = self
-                .scan_config_builder(Arc::new(self.create_parquet_source(table_schema)))
+                .scan_config_builder(Arc::new(self.create_parquet_source(state, table_schema)?))
                 .with_file_group(FileGroup::new(vec![
                     self.partitioned_file(&table_file.file)?,
                 ]))
@@ -3471,7 +3506,7 @@ impl DuckLakeTable {
         let pos_index = proj.len() - 1;
 
         let scan: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(
-            self.scan_config_builder(Arc::new(self.create_parquet_source(table_schema)))
+            self.scan_config_builder(Arc::new(self.create_parquet_source(state, table_schema)?))
                 .with_file_group(FileGroup::new(vec![
                     self.partitioned_file(&table_file.file)?,
                 ]))
@@ -4554,7 +4589,9 @@ mod tests {
     };
     use crate::partition::{PartitionSpecColumn, PartitionTransform};
     use crate::types::build_arrow_schema;
+    use datafusion::datasource::physical_plan::FileScanConfig;
     use datafusion::prelude::{SessionContext, col, lit};
+    use object_store::ObjectStore;
     use rstest::rstest;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -6355,5 +6392,264 @@ mod tests {
             "This feature is not implemented: DuckLake sort order 9 contains an unsupported \
              expression; datafusion-ducklake can write only bare-column sort keys",
         );
+    }
+
+    // --- #1323: the DuckLake scan attaches the footer metadata cache ---
+
+    /// Real parquet bytes for a single row group matching `fixed_table`'s
+    /// `id`/`region` (Int64, Int64) schema, so a scan can actually read a
+    /// footer instead of only exercising catalog-side planning.
+    fn footer_cache_fixture_bytes() -> Vec<u8> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("region", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from((0..10).collect::<Vec<i64>>())) as ArrayRef,
+                Arc::new(Int64Array::from(vec![1i64; 10])) as ArrayRef,
+            ],
+        )
+        .expect("build fixture batch");
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                parquet::arrow::ArrowWriter::try_new(&mut buf, schema, None).expect("open writer");
+            writer.write(&batch).expect("write batch");
+            writer.close().expect("close writer");
+        }
+        buf
+    }
+
+    /// An `ObjectStore` wrapper that counts range reads whose end lands
+    /// exactly on `file_len` — the footer/page-index suffix a cold
+    /// `DFParquetMetadata::fetch_metadata_from_store` fetches
+    /// (`datafusion-datasource-parquet`'s `metadata.rs`), which is the read a
+    /// warm [`CachedParquetFileReaderFactory`] must not repeat. Delegates
+    /// every other `ObjectStore` method to `inner` untouched.
+    #[derive(Debug)]
+    struct FooterCountingStore {
+        inner: Arc<dyn object_store::ObjectStore>,
+        file_len: u64,
+        footer_reads: AtomicUsize,
+    }
+
+    impl FooterCountingStore {
+        fn new(inner: Arc<dyn object_store::ObjectStore>, file_len: u64) -> Self {
+            Self {
+                inner,
+                file_len,
+                footer_reads: AtomicUsize::new(0),
+            }
+        }
+
+        fn footer_reads(&self) -> usize {
+            self.footer_reads.load(Ordering::SeqCst)
+        }
+
+        fn count_footer_ranges(&self, ranges: &[std::ops::Range<u64>]) {
+            for range in ranges {
+                if range.end == self.file_len {
+                    self.footer_reads.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+    }
+
+    impl std::fmt::Display for FooterCountingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FooterCountingStore({})", self.inner)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl object_store::ObjectStore for FooterCountingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjectPath,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjectPath,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjectPath,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            // Not exercised by the parquet reader on this crate's read path (it
+            // calls `get_ranges` below), but counted for completeness in case a
+            // future reader routes a footer-sized range through here instead.
+            if let Some(range) = &options.range
+                && let Ok(resolved) = range.as_range(self.file_len)
+                && resolved.end == self.file_len
+            {
+                self.footer_reads.fetch_add(1, Ordering::SeqCst);
+            }
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &ObjectPath,
+            ranges: &[std::ops::Range<u64>],
+        ) -> object_store::Result<Vec<bytes::Bytes>> {
+            self.count_footer_ranges(ranges);
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream<'a>(
+            &'a self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjectPath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectPath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjectPath,
+            to: &ObjectPath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// `create_parquet_source` must attach a [`CachedParquetFileReaderFactory`]
+    /// — reading through `state`'s shared file-metadata cache — rather than
+    /// leaving DataFusion to fall back to the uncached
+    /// `DefaultParquetFileReaderFactory` (#1323). Builds a real
+    /// `DataSourceExec`/`FileScanConfig` scan plan, exactly as a caller of
+    /// `create_parquet_source` does, and downcasts down to the `ParquetSource`
+    /// to inspect the attached factory.
+    #[tokio::test]
+    async fn ducklake_scan_attaches_the_cached_parquet_reader_factory() -> Result<()> {
+        let table = fixed_table(vec![], None)?;
+
+        let store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let store_url = url::Url::parse(table.object_store_url().as_str()).expect("valid url");
+        let ctx = SessionContext::new();
+        ctx.runtime_env().register_object_store(&store_url, store);
+        let state = ctx.state();
+
+        let source = table.create_parquet_source(&state, Arc::clone(&table.physical_schema))?;
+        let plan: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(
+            table
+                .scan_config_builder(Arc::new(source))
+                .with_file_group(FileGroup::new(vec![]))
+                .build(),
+        );
+
+        let found_source = plan
+            .downcast_ref::<DataSourceExec>()
+            .and_then(|exec| exec.data_source().downcast_ref::<FileScanConfig>())
+            .and_then(|config| config.file_source().downcast_ref::<ParquetSource>())
+            .expect("plan is a DataSourceExec wrapping a parquet FileScanConfig");
+
+        let factory = found_source
+            .parquet_file_reader_factory()
+            .expect("a query-time ParquetSource must attach a reader factory (#1323)");
+        let debug = format!("{factory:?}");
+        assert!(
+            debug.contains("CachedParquetFileReaderFactory"),
+            "expected the metadata-cache-backed reader factory, got: {debug}",
+        );
+
+        Ok(())
+    }
+
+    /// End-to-end: scanning the same file twice on one `SessionContext` must
+    /// issue the footer/page-index read only on the cold run. The warm run's
+    /// `ParquetSource` reads through the same `RuntimeEnv` file-metadata cache
+    /// the cold run just populated (#1323), so it performs zero range reads
+    /// whose end lands on the file's length.
+    #[tokio::test]
+    async fn ducklake_parquet_source_reuses_cached_footer_metadata_across_scans() -> Result<()> {
+        let table = fixed_table(vec![], None)?;
+
+        let bytes = footer_cache_fixture_bytes();
+        let file_len = bytes.len() as u64;
+
+        let inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let object_path = ObjectPath::from("footer-cache.parquet");
+        inner
+            .put(&object_path, bytes.into())
+            .await
+            .expect("seed the fixture file");
+        let counting = Arc::new(FooterCountingStore::new(inner, file_len));
+
+        let store_url = url::Url::parse(table.object_store_url().as_str()).expect("valid url");
+        let ctx = SessionContext::new();
+        ctx.runtime_env()
+            .register_object_store(&store_url, Arc::clone(&counting) as Arc<dyn ObjectStore>);
+        let state = ctx.state();
+
+        let build_plan = |state: &datafusion::execution::SessionState| -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            let source = table.create_parquet_source(state, Arc::clone(&table.physical_schema))?;
+            let pf = PartitionedFile::new("footer-cache.parquet", file_len);
+            Ok(DataSourceExec::from_data_source(
+                table
+                    .scan_config_builder(Arc::new(source))
+                    .with_file_group(FileGroup::new(vec![pf]))
+                    .build(),
+            ))
+        };
+
+        let plan1 = build_plan(&state)?;
+        let batches1 = datafusion::physical_plan::collect(plan1, state.task_ctx())
+            .await
+            .expect("first scan executes");
+        assert_eq!(
+            batches1.iter().map(|b| b.num_rows()).sum::<usize>(),
+            10,
+            "sanity: the fixture file's rows come back"
+        );
+        let footer_reads_after_cold_scan = counting.footer_reads();
+        assert!(
+            footer_reads_after_cold_scan >= 1,
+            "the cold scan must read the footer at least once"
+        );
+
+        let plan2 = build_plan(&state)?;
+        let batches2 = datafusion::physical_plan::collect(plan2, state.task_ctx())
+            .await
+            .expect("second scan executes");
+        assert_eq!(batches2.iter().map(|b| b.num_rows()).sum::<usize>(), 10);
+
+        assert_eq!(
+            counting.footer_reads(),
+            footer_reads_after_cold_scan,
+            "a warm scan must issue zero additional footer reads once the reader factory \
+             shares the session's metadata cache (#1323)",
+        );
+
+        Ok(())
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -3,6 +3,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
+
 use crate::Result;
 use crate::column_rename::ColumnRenameExec;
 use crate::delete_filter::DeleteFilterExec;
@@ -68,16 +70,11 @@ use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion_datasource_parquet::metadata::DFParquetMetadata;
 use futures::StreamExt;
+use object_store::ObjectMeta;
 use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjectPath;
-use parquet::arrow::ParquetRecordBatchStreamBuilder;
-// Deprecated in parquet 59 in favour of a hand-rolled `AsyncFileReader`. The
-// call sites below read a footer once each, so the replacement (a custom
-// reader with its own I/O coalescing) buys nothing here.
-// See https://github.com/apache/arrow-rs/issues/10308.
-#[allow(deprecated)]
-use parquet::arrow::async_reader::ParquetObjectReader;
 use percent_encoding::percent_decode_str;
 
 #[cfg(feature = "encryption")]
@@ -851,60 +848,109 @@ pub(crate) struct ParquetFileLayout {
     pub(crate) row_group_count: usize,
 }
 
-/// Read `resolved_path`'s parquet footer once. `encryption_key` is the file's
-/// DuckLake encryption key when it has one; it is only usable with the
-/// `encryption` feature, and this function cannot open an encrypted file
-/// without it.
+/// The [`ObjectMeta`] DuckLake's own scan-time `PartitionedFile::new(path,
+/// size)` builds (see [`DuckLakeTable::partitioned_file`]): epoch
+/// `last_modified`, no e_tag or version. A plan-time footer probe that builds
+/// this exact shape can share the `RuntimeEnv` `FileMetadataCache` entry with
+/// the scan's own `CachedParquetFileReaderFactory` read (#1323) —
+/// `CachedFileMetadataEntry::is_valid_for` requires an exact `size` AND
+/// `last_modified` match (the cache itself keys only by location), so any
+/// other `last_modified` would silently miss the entry the scan populates,
+/// and vice versa.
+fn epoch_object_meta(location: ObjectPath, size: u64) -> ObjectMeta {
+    ObjectMeta {
+        location,
+        last_modified: DateTime::<Utc>::from_timestamp_nanos(0),
+        size,
+        e_tag: None,
+        version: None,
+    }
+}
+
+/// Read `resolved_path`'s parquet footer once, through `state`'s shared
+/// `RuntimeEnv` file-metadata cache (#1323) rather than the uncached
+/// one-shot `ParquetObjectReader` this used before: a warm cache serves this
+/// from memory, whether the entry was populated by an earlier call here or by
+/// the scan's own `CachedParquetFileReaderFactory` (same cache key — see
+/// [`epoch_object_meta`]).
+///
+/// `file_size_bytes` is the catalog's recorded size for the file, needed to
+/// build the `ObjectMeta` the cache validates against. It is taken as a
+/// parameter rather than resolved via a `head()` call, which would cost
+/// exactly the round trip this function exists to avoid.
+///
+/// `encryption_key` is the file's DuckLake encryption key when it has one; it
+/// is only usable with the `encryption` feature, and this function cannot
+/// open an encrypted file without it. Note an encrypted footer is never
+/// cached — `DFParquetMetadata::fetch_metadata` treats a fetch made with
+/// decryption properties as uncacheable (see its `cache_metadata` gate) — so
+/// this saves nothing for that path beyond sharing one code path with the
+/// unencrypted one.
 pub(crate) async fn read_parquet_footer_facts(
     state: &dyn Session,
     object_store_url: &ObjectStoreUrl,
     resolved_path: &str,
+    file_size_bytes: Option<i64>,
     encryption_key: Option<&str>,
 ) -> DataFusionResult<ParquetFooterFacts> {
     let object_store = state.runtime_env().object_store(object_store_url)?;
     let object_path = ObjectPath::from(resolved_path);
-    #[allow(deprecated)]
-    let reader = ParquetObjectReader::new(object_store, object_path);
+    let size = match file_size_bytes {
+        Some(size) => validated_file_size(size, resolved_path)?,
+        // The caller doesn't have the catalog's recorded size in reach (a
+        // `file_layout` lookup, keyed only by path). One `head()` — not a
+        // ranged read, so it never shows up as a footer read — resolves the
+        // true size so the `ObjectMeta` built below still matches what a
+        // scan's own `PartitionedFile` would carry, and the cache entry is
+        // still shared rather than silently keyed apart from it.
+        None => object_store.head(&object_path).await?.size,
+    };
+    let object_meta = epoch_object_meta(object_path, size);
 
     #[cfg(feature = "encryption")]
-    let builder = {
-        use parquet::arrow::arrow_reader::ArrowReaderOptions;
-        let options = match encryption_key {
-            Some(key) if !key.is_empty() => {
-                let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
-                let decryption_props =
-                    parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
-                        .build()
-                        .map_err(|e| {
-                            DataFusionError::Execution(format!(
-                                "Failed to create decryption properties: {}",
-                                e
-                            ))
-                        })?;
-                ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
-            },
-            _ => ArrowReaderOptions::new(),
-        };
-        ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
+    let decryption_properties = match encryption_key {
+        Some(key) if !key.is_empty() => {
+            let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
+            let props = parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
+                .build()
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to create decryption properties: {}",
+                        e
+                    ))
+                })?;
+            Some(props)
+        },
+        _ => None,
     };
-
     #[cfg(not(feature = "encryption"))]
-    let builder = {
+    let decryption_properties = {
         // Without the feature there is no decryption to configure.
         let _ = encryption_key;
-        ParquetRecordBatchStreamBuilder::new(reader)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
+        None
     };
 
-    let field_ids = extract_parquet_field_ids(builder.metadata());
+    let metadata = DFParquetMetadata::new(object_store.as_ref(), &object_meta)
+        .with_file_metadata_cache(Some(
+            state.runtime_env().cache_manager.get_file_metadata_cache(),
+        ))
+        .with_decryption_properties(decryption_properties)
+        .fetch_metadata()
+        .await?;
+
+    let field_ids = extract_parquet_field_ids(&metadata);
+    let arrow_schema = Arc::new(
+        parquet::arrow::parquet_to_arrow_schema(
+            metadata.file_metadata().schema_descr(),
+            metadata.file_metadata().key_value_metadata(),
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))?,
+    );
 
     Ok(ParquetFooterFacts {
         field_ids,
-        arrow_schema: builder.schema().clone(),
-        row_group_count: builder.metadata().row_groups().len(),
+        arrow_schema,
+        row_group_count: metadata.row_groups().len(),
     })
 }
 
@@ -937,12 +983,19 @@ pub(crate) async fn read_parquet_file_layout(
     state: &dyn Session,
     object_store_url: &ObjectStoreUrl,
     resolved_path: &str,
+    file_size_bytes: Option<i64>,
     encryption_key: Option<&str>,
     columns: &[DuckLakeTableColumn],
     fallback_schema: &SchemaRef,
 ) -> DataFusionResult<Arc<ParquetFileLayout>> {
-    let facts =
-        read_parquet_footer_facts(state, object_store_url, resolved_path, encryption_key).await?;
+    let facts = read_parquet_footer_facts(
+        state,
+        object_store_url,
+        resolved_path,
+        file_size_bytes,
+        encryption_key,
+    )
+    .await?;
 
     let (read_schema, name_mapping) = if facts.field_ids.is_empty() {
         (fallback_schema.clone(), HashMap::new())
@@ -2081,66 +2134,89 @@ impl DuckLakeTable {
         file: &DuckLakeFileData,
     ) -> DataFusionResult<SchemaMapping> {
         let resolved_path = self.resolve_file_path(file)?;
+
+        // A file with a physical rename mapping resolves entirely from the
+        // mapping row (`mapped_schema`) — never from the file's own footer
+        // field ids. Checked FIRST, before any I/O: a renamed file used to pay
+        // a footer fetch here on every `scan()` whose result this branch then
+        // discarded outright (the dominant plan-time footer cost, worse than
+        // the execute-time read #1323 originally fixed, since it ran even for
+        // files this method never needed to open at all).
+        if let Some(mapping_id) = file.mapping_id {
+            return self.mapped_schema(mapping_id, &resolved_path);
+        }
+
         let object_store = state
             .runtime_env()
             .object_store(self.object_store_url.as_ref())?;
         let object_path = ObjectPath::from(resolved_path.as_str());
+        let object_meta = epoch_object_meta(
+            object_path,
+            validated_file_size(file.file_size_bytes, &resolved_path)?,
+        );
+        let metadata_size_hint = file
+            .footer_size
+            .filter(|&size| size > 0)
+            .and_then(|size| usize::try_from(size).ok());
 
-        #[allow(deprecated)]
-        let reader = ParquetObjectReader::new(object_store, object_path);
-
-        // Build the ParquetRecordBatchStreamBuilder with decryption if needed
+        // Resolve decryption properties (if any) before touching the store, the
+        // same way `read_parquet_footer_facts` does.
         #[cfg(feature = "encryption")]
-        let builder = {
-            use parquet::arrow::arrow_reader::ArrowReaderOptions;
-
-            // Check if file has encryption key
-            let options = if let Some(ref key) = file.encryption_key {
-                if !key.is_empty() {
-                    let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
-                    let decryption_props =
-                        parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
-                            .build()
-                            .map_err(|e| {
-                                DataFusionError::Execution(format!(
-                                    "Failed to create decryption properties: {}",
-                                    e
-                                ))
-                            })?;
-                    ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
-                } else {
-                    ArrowReaderOptions::new()
-                }
-            } else {
-                ArrowReaderOptions::new()
-            };
-
-            ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        let decryption_properties = match file.encryption_key.as_deref() {
+            Some(key) if !key.is_empty() => {
+                let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
+                let props =
+                    parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
+                        .build()
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to create decryption properties: {}",
+                                e
+                            ))
+                        })?;
+                Some(props)
+            },
+            _ => None,
         };
-
         #[cfg(not(feature = "encryption"))]
-        let builder = ParquetRecordBatchStreamBuilder::new(reader)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let decryption_properties = None;
 
-        let field_id_map = extract_parquet_field_ids(builder.metadata());
+        // Read the footer through `state`'s shared `RuntimeEnv` file-metadata
+        // cache (#1323) — the same cache key a scan's own
+        // `CachedParquetFileReaderFactory` read uses (see `epoch_object_meta`),
+        // so whichever of the two runs first for a given file populates the
+        // entry the other then hits for free. Note an encrypted footer is
+        // never cached either way (`DFParquetMetadata::fetch_metadata` treats
+        // a fetch made with decryption properties as uncacheable), so this
+        // saves nothing new for that path beyond sharing the code with the
+        // unencrypted one.
+        let metadata = DFParquetMetadata::new(object_store.as_ref(), &object_meta)
+            .with_metadata_size_hint(metadata_size_hint)
+            .with_file_metadata_cache(Some(
+                state.runtime_env().cache_manager.get_file_metadata_cache(),
+            ))
+            .with_decryption_properties(decryption_properties)
+            .fetch_metadata()
+            .await?;
 
-        if let Some(mapping_id) = file.mapping_id {
-            return self.mapped_schema(mapping_id, &resolved_path);
-        }
+        let field_id_map = extract_parquet_field_ids(&metadata);
 
         // No field_ids means external file - use current schema directly
         if field_id_map.is_empty() {
             return Ok((self.schema.clone(), HashMap::new(), HashMap::new()));
         }
 
+        let arrow_schema = parquet::arrow::parquet_to_arrow_schema(
+            metadata.file_metadata().schema_descr(),
+            metadata.file_metadata().key_value_metadata(),
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
         let (read_schema, name_mapping) = build_read_schema_with_field_id_mapping_from_schema(
             &self.columns,
             self.physical_schema.as_ref(),
             &field_id_map,
-            Some(builder.schema().as_ref()),
+            Some(&arrow_schema),
         )
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
@@ -2861,6 +2937,7 @@ impl DuckLakeTable {
             state,
             self.object_store_url.as_ref(),
             &resolved_path,
+            Some(file.file_size_bytes),
             encryption_key,
             &self.columns,
             &self.physical_schema,
@@ -6426,8 +6503,15 @@ mod tests {
     /// exactly on `file_len` — the footer/page-index suffix a cold
     /// `DFParquetMetadata::fetch_metadata_from_store` fetches
     /// (`datafusion-datasource-parquet`'s `metadata.rs`), which is the read a
-    /// warm [`CachedParquetFileReaderFactory`] must not repeat. Delegates
-    /// every other `ObjectStore` method to `inner` untouched.
+    /// warm [`CachedParquetFileReaderFactory`] must not repeat. Covers every
+    /// method a footer fetch could arrive through: `get_ranges` directly
+    /// (`DFParquetMetadata`'s own call, and the only one this crate's footer
+    /// reads use now that both the scan and `file_schema_mapping` route
+    /// through it — #1323), `get_opts` (a single bounded range there would
+    /// also qualify), and `get_range`, whose `ObjectStoreExt` default
+    /// implementation calls `get_opts` on `self` and so is covered by the
+    /// same override. Delegates every other `ObjectStore` method to `inner`
+    /// untouched.
     #[derive(Debug)]
     struct FooterCountingStore {
         inner: Arc<dyn object_store::ObjectStore>,
@@ -6487,9 +6571,11 @@ mod tests {
             location: &ObjectPath,
             options: object_store::GetOptions,
         ) -> object_store::Result<object_store::GetResult> {
-            // Not exercised by the parquet reader on this crate's read path (it
-            // calls `get_ranges` below), but counted for completeness in case a
-            // future reader routes a footer-sized range through here instead.
+            // Not exercised by `DFParquetMetadata` today (it always calls
+            // `get_ranges` below, cold or warm, execution-time or plan-time —
+            // see the struct doc), but counted for completeness: `get_range`
+            // (built on this) and any future reader that fetches the footer
+            // as a single `get_opts` range would otherwise go uncounted.
             if let Some(range) = &options.range
                 && let Ok(resolved) = range.as_range(self.file_len)
                 && resolved.end == self.file_len

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -42,8 +42,9 @@ use crate::metadata_provider::{DataFileChange, DuckLakeTableColumn, MetadataProv
 use crate::path_resolver::resolve_path;
 use crate::row_id::{SNAPSHOT_ID_PARQUET_FIELD_ID, positional_table_schema_reserving};
 use crate::table::{
-    ParquetFileLayout, apply_name_mapping_to_layout, delete_file_schema, read_parquet_file_layout,
-    read_parquet_footer_facts, validated_file_size, validated_record_count,
+    ParquetFileLayout, apply_name_mapping_to_layout, cached_parquet_reader_factory,
+    delete_file_schema, read_parquet_file_layout, read_parquet_footer_facts, validated_file_size,
+    validated_record_count,
 };
 use crate::types::ABSENT_FIELD_PREFIX;
 
@@ -679,10 +680,13 @@ impl TableChangesTable {
         encryption_factory: &Option<Arc<dyn EncryptionFactory>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let read_schema = self.file_read_schema(layout);
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         let parquet_source = if let Some(factory) = encryption_factory {
-            ParquetSource::new(read_schema).with_encryption_factory(Arc::clone(factory))
-        } else {
             ParquetSource::new(read_schema)
+                .with_encryption_factory(Arc::clone(factory))
+                .with_parquet_file_reader_factory(reader_factory)
+        } else {
+            ParquetSource::new(read_schema).with_parquet_file_reader_factory(reader_factory)
         };
         self.build_exec_for_file_impl(state, data_file, layout, proj_info, parquet_source)
             .await
@@ -697,7 +701,9 @@ impl TableChangesTable {
         layout: Option<&ParquetFileLayout>,
         proj_info: &ProjectionInfo,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        let parquet_source = ParquetSource::new(self.file_read_schema(layout));
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
+        let parquet_source = ParquetSource::new(self.file_read_schema(layout))
+            .with_parquet_file_reader_factory(reader_factory);
         self.build_exec_for_file_impl(state, data_file, layout, proj_info, parquet_source)
             .await
     }
@@ -886,10 +892,12 @@ impl TableChangesTable {
     /// so the position column passes straight through.
     fn build_insert_scan(
         &self,
+        state: &dyn Session,
         data_file: &DataFileChange,
         layout: &ParquetFileLayout,
         need_rowid_resolution: bool,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         let resolved = resolve_path(
             &self.table_path,
             &data_file.path,
@@ -917,7 +925,10 @@ impl TableChangesTable {
         let plain_scan = |pf: PartitionedFile, schema: SchemaRef| {
             let builder = FileScanConfigBuilder::new(
                 self.object_store_url.as_ref().clone(),
-                Arc::new(ParquetSource::new(schema)),
+                Arc::new(
+                    ParquetSource::new(schema)
+                        .with_parquet_file_reader_factory(Arc::clone(&reader_factory)),
+                ),
             )
             .with_file_group(FileGroup::new(vec![pf]));
             DataSourceExec::from_data_source(builder.build())
@@ -939,7 +950,10 @@ impl TableChangesTable {
                 );
                 let builder = FileScanConfigBuilder::new(
                     self.object_store_url.as_ref().clone(),
-                    Arc::new(ParquetSource::new(table_schema)),
+                    Arc::new(
+                        ParquetSource::new(table_schema)
+                            .with_parquet_file_reader_factory(Arc::clone(&reader_factory)),
+                    ),
                 )
                 .with_file_group(FileGroup::new(vec![pf]));
                 DataSourceExec::from_data_source(builder.build())
@@ -962,12 +976,14 @@ impl TableChangesTable {
     /// regardless of how the scan is pruned, split or reordered.
     fn build_delete_data_scan(
         &self,
+        state: &dyn Session,
         resolved_path: &str,
         size_bytes: i64,
         footer_size: i64,
         layout: &ParquetFileLayout,
         embedded_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         let mut pf = PartitionedFile::new(
             resolved_path,
             validated_file_size(size_bytes, resolved_path)?,
@@ -985,7 +1001,9 @@ impl TableChangesTable {
         );
         let builder = FileScanConfigBuilder::new(
             self.object_store_url.as_ref().clone(),
-            Arc::new(ParquetSource::new(table_schema)),
+            Arc::new(
+                ParquetSource::new(table_schema).with_parquet_file_reader_factory(reader_factory),
+            ),
         )
         .with_file_group(FileGroup::new(vec![pf]));
         let scan = DataSourceExec::from_data_source(builder.build());
@@ -1001,12 +1019,14 @@ impl TableChangesTable {
     /// the correlation path reads its `pos` column to find newly-deleted rows.
     fn build_delete_file_scan(
         &self,
+        state: &dyn Session,
         path: &str,
         is_relative: bool,
         size_bytes: i64,
         footer_size: i64,
         snapshot_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
         let mut pf = PartitionedFile::new(&resolved, validated_file_size(size_bytes, &resolved)?);
@@ -1031,7 +1051,7 @@ impl TableChangesTable {
         };
         let builder = FileScanConfigBuilder::new(
             self.object_store_url.as_ref().clone(),
-            Arc::new(ParquetSource::new(schema)),
+            Arc::new(ParquetSource::new(schema).with_parquet_file_reader_factory(reader_factory)),
         )
         .with_file_group(FileGroup::new(vec![pf]));
         Ok(DataSourceExec::from_data_source(builder.build()))
@@ -1185,7 +1205,7 @@ impl TableChangesTable {
                     i
                 });
             let pos_col_idx = (!has_embedded_rowid && resolve_rowid).then_some(next_idx);
-            let scan = self.build_insert_scan(df, layout, resolve_rowid)?;
+            let scan = self.build_insert_scan(state, df, layout, resolve_rowid)?;
             #[cfg(debug_assertions)]
             if let Some(idx) = pos_col_idx {
                 let schema = scan.schema();
@@ -1234,6 +1254,7 @@ impl TableChangesTable {
                     .await?;
                 let old_embedded = source_layout.embedded_rowid_parquet_name.clone();
                 let data_scan = self.build_delete_data_scan(
+                    state,
                     &resolved,
                     dfc.data_file_size_bytes,
                     dfc.data_file_footer_size.unwrap_or(0),
@@ -1268,6 +1289,7 @@ impl TableChangesTable {
                 let cumulative = snapshot_name.is_some();
                 let current_delete_scan = match &dfc.current_delete_path {
                     Some(p) => Some(self.build_delete_file_scan(
+                        state,
                         p,
                         dfc.current_delete_path_is_relative.unwrap_or(true),
                         dfc.current_delete_file_size_bytes.unwrap_or(0),
@@ -1278,6 +1300,7 @@ impl TableChangesTable {
                 };
                 let previous_delete_scan = match &dfc.previous_delete_path {
                     Some(p) if !cumulative => Some(self.build_delete_file_scan(
+                        state,
                         p,
                         dfc.previous_delete_path_is_relative.unwrap_or(true),
                         dfc.previous_delete_file_size_bytes.unwrap_or(0),

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -560,6 +560,9 @@ impl TableChangesTable {
             state,
             self.object_store_url.as_ref(),
             &resolved,
+            // `file_layout` is keyed only by path — no catalog size in reach
+            // here, so `read_parquet_file_layout` resolves it via `head()`.
+            None,
             None,
             columns,
             &self.table_schema,
@@ -837,12 +840,18 @@ impl TableChangesTable {
         state: &dyn Session,
         path: &str,
         is_relative: bool,
+        size_bytes: Option<i64>,
     ) -> DataFusionResult<Option<String>> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let facts =
-            read_parquet_footer_facts(state, self.object_store_url.as_ref(), &resolved, None)
-                .await?;
+        let facts = read_parquet_footer_facts(
+            state,
+            self.object_store_url.as_ref(),
+            &resolved,
+            size_bytes,
+            None,
+        )
+        .await?;
         Ok(facts.field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned())
     }
 
@@ -1271,6 +1280,7 @@ impl TableChangesTable {
                             state,
                             p,
                             dfc.current_delete_path_is_relative.unwrap_or(true),
+                            dfc.current_delete_file_size_bytes,
                         )
                         .await?
                     },

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -54,8 +54,9 @@ use crate::metadata_provider::{DeleteFileChange, DuckLakeTableColumn, MetadataPr
 use crate::path_resolver::resolve_path;
 use crate::row_id::{SNAPSHOT_ID_PARQUET_FIELD_ID, positional_table_schema_reserving};
 use crate::table::{
-    ParquetFileLayout, apply_name_mapping_to_layout, read_parquet_file_layout,
-    read_parquet_footer_facts, validated_file_size, validated_record_count,
+    ParquetFileLayout, apply_name_mapping_to_layout, cached_parquet_reader_factory,
+    read_parquet_file_layout, read_parquet_footer_facts, validated_file_size,
+    validated_record_count,
 };
 use crate::table_changes::{check_column_count, present_catalog_schema};
 
@@ -253,6 +254,7 @@ impl TableDeletionsTable {
         // Create scan for current delete file (if exists - None means full file delete)
         let current_delete_exec = if let Some(ref current_path) = delete_file.current_delete_path {
             Some(self.build_delete_file_scan(
+                state,
                 current_path,
                 delete_file.current_delete_path_is_relative.unwrap_or(true),
                 delete_file.current_delete_file_size_bytes.unwrap_or(0),
@@ -267,6 +269,7 @@ impl TableDeletionsTable {
         // cumulative mode, where the per-row window filter replaces it)
         let previous_delete_exec = match &delete_file.previous_delete_path {
             Some(prev_path) if snapshot_name.is_none() => Some(self.build_delete_file_scan(
+                state,
                 prev_path,
                 delete_file.previous_delete_path_is_relative.unwrap_or(true),
                 delete_file.previous_delete_file_size_bytes.unwrap_or(0),
@@ -313,6 +316,7 @@ impl TableDeletionsTable {
 
         // Create scan for data file (with the embedded rowid column when present)
         let data_file_exec = self.build_data_file_scan(
+            state,
             &data_file_path,
             delete_file.data_file_size_bytes,
             delete_file.data_file_footer_size.unwrap_or(0),
@@ -378,12 +382,14 @@ impl TableDeletionsTable {
     /// the file's embedded per-row snapshot column is read as a third column.
     fn build_delete_file_scan(
         &self,
+        state: &dyn Session,
         path: &str,
         is_relative: bool,
         size_bytes: i64,
         footer_size: i64,
         snapshot_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         let resolved_path = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
@@ -411,7 +417,7 @@ impl TableDeletionsTable {
         };
         let builder = FileScanConfigBuilder::new(
             self.object_store_url.as_ref().clone(),
-            Arc::new(ParquetSource::new(schema)),
+            Arc::new(ParquetSource::new(schema).with_parquet_file_reader_factory(reader_factory)),
         )
         .with_file_group(FileGroup::new(vec![pf]));
 
@@ -435,12 +441,14 @@ impl TableDeletionsTable {
     /// the position column passes through.
     fn build_data_file_scan(
         &self,
+        state: &dyn Session,
         path: &str,
         size_bytes: i64,
         footer_size: i64,
         layout: &ParquetFileLayout,
         embedded_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let reader_factory = cached_parquet_reader_factory(state, self.object_store_url.as_ref())?;
         let mut pf = PartitionedFile::new(path, validated_file_size(size_bytes, path)?);
         if footer_size > 0
             && let Ok(hint) = usize::try_from(footer_size)
@@ -467,7 +475,9 @@ impl TableDeletionsTable {
         );
         let builder = FileScanConfigBuilder::new(
             self.object_store_url.as_ref().clone(),
-            Arc::new(ParquetSource::new(table_schema)),
+            Arc::new(
+                ParquetSource::new(table_schema).with_parquet_file_reader_factory(reader_factory),
+            ),
         )
         .with_file_group(FileGroup::new(vec![pf]));
         let scan = DataSourceExec::from_data_source(builder.build());

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -181,6 +181,9 @@ impl TableDeletionsTable {
             state,
             self.object_store_url.as_ref(),
             &resolved,
+            // `file_layout` is keyed only by path — no catalog size in reach
+            // here, so `read_parquet_file_layout` resolves it via `head()`.
+            None,
             None,
             columns,
             &self.table_schema,
@@ -232,6 +235,7 @@ impl TableDeletionsTable {
                     state,
                     p,
                     delete_file.current_delete_path_is_relative.unwrap_or(true),
+                    delete_file.current_delete_file_size_bytes,
                 )
                 .await?
             },
@@ -369,12 +373,18 @@ impl TableDeletionsTable {
         state: &dyn Session,
         path: &str,
         is_relative: bool,
+        size_bytes: Option<i64>,
     ) -> DataFusionResult<Option<String>> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let facts =
-            read_parquet_footer_facts(state, self.object_store_url.as_ref(), &resolved, None)
-                .await?;
+        let facts = read_parquet_footer_facts(
+            state,
+            self.object_store_url.as_ref(),
+            &resolved,
+            size_bytes,
+            None,
+        )
+        .await?;
         Ok(facts.field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned())
     }
 


### PR DESCRIPTION
Every ParquetSource this crate builds is now given a CachedParquetFileReaderFactory over the table's object store and the caller's shared FileMetadataCache, so query-time scans read footers through that cache instead of DataFusion's uncached DefaultParquetFileReaderFactory. Adds unit tests asserting the factory is attached and that a warm scan issues zero additional footer-range reads.

Also fixes the larger plan-time cost: `file_schema_mapping` opened every no-deletes-path file's footer with an uncached `ParquetObjectReader` on *every* `scan()` (even for files with a `mapping_id`, whose result it then discarded), so it now checks `mapping_id` before any I/O and reads through the same cached `DFParquetMetadata` path the execute-time fix uses, sharing one cache entry between the two.