### PR TITLE
Align the test oracle with the DuckLake extension we review against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: The `duckdb` dependency requires 1.10505.0 (DuckDB 1.5.5); downstreams pinned to
   1.4.x must move up. Existing catalogs need no migration (#270).
-- A DuckDB-metadata catalog created through `write-duckdb` now uses DuckDB 1.5 storage, which
-  earlier DuckDB releases cannot open (#270).
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).
 - **BREAKING**: `DuckLakeWriteOptions` is non-exhaustive and gains `parquet_version`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: The `duckdb` dependency requires 1.10505.0 (DuckDB 1.5.5); downstreams pinned to
+  1.4.x must move up. Existing catalogs need no migration (#270).
+- A DuckDB-metadata catalog created through `write-duckdb` now uses DuckDB 1.5 storage, which
+  earlier DuckDB releases cannot open (#270).
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).
 - **BREAKING**: `DuckLakeWriteOptions` is non-exhaustive and gains `parquet_version`,
@@ -71,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- DuckLake catalogs whose metadata store is a DuckDB file written by a current client are
+  readable again; the previous dependency pin refused their storage version (#270).
 - Invalid write-only catalog settings no longer block table reads; they fail when a write or
   maintenance operation is planned (#271).
 - Legacy two-column `ducklake_metadata` tables migrate both scope columns losslessly (#271).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -129,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,20 +140,20 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-row 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "arrow-string 56.2.0",
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-row 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "arrow-string 58.4.0",
 ]
 
 [[package]]
@@ -181,16 +179,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
@@ -209,18 +207,20 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
- "ahash 0.8.12",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "ahash",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
  "chrono",
  "half",
- "hashbrown 0.16.1",
- "num",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-buffer 59.2.0",
  "arrow-data 59.2.0",
  "arrow-schema 59.2.0",
@@ -244,13 +244,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint 0.4.6",
+ "num-traits",
 ]
 
 [[package]]
@@ -267,22 +268,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
@@ -325,14 +327,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -391,15 +394,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
 ]
 
 [[package]]
@@ -417,14 +420,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
  "half",
 ]
 
@@ -443,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -462,16 +465,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
- "ahash 0.8.12",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "num",
+ "ahash",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -480,7 +483,7 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array 59.2.0",
  "arrow-buffer 59.2.0",
  "arrow-data 59.2.0",
@@ -490,17 +493,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -970,18 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,29 +1063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,28 +1088,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "byteorder"
@@ -1306,6 +1252,8 @@ version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
+ "crossterm 0.27.0",
+ "crossterm 0.28.1",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width 0.2.2",
@@ -1479,6 +1427,39 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.4",
+ "parking_lot",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2369,6 +2350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,18 +2413,18 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duckdb"
-version = "1.4.1"
+version = "1.10505.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a093eed1c714143b257b95fa323e38527fabf05fbf02bb0d5d2045275ffdaef"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.4.0",
  "cast",
+ "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
- "rust_decimal",
  "strum 0.27.2",
 ]
 
@@ -2736,12 +2728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,9 +2955,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3610,9 +3593,9 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.1"
+version = "1.10505.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b93c3ff279601516f01531cadf2ccba50394fbb5f7bf685c6e6b9b07c8dca6f"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
 dependencies = [
  "cc",
  "flate2",
@@ -3620,7 +3603,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "ureq",
  "vcpkg",
+ "zip",
 ]
 
 [[package]]
@@ -3682,6 +3667,12 @@ dependencies = [
  "clap",
  "escape8259",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3799,20 +3790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint 0.4.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,28 +3830,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -4040,7 +3995,7 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array 59.2.0",
  "arrow-buffer 59.2.0",
  "arrow-data 59.2.0",
@@ -4269,26 +4224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,29 +4310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
@@ -4410,16 +4328,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4556,15 +4464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4632,35 +4531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rsa"
 version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,22 +4578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal"
-version = "1.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8975fc98059f365204d635119cf9c5a60ae67b841ed49b5422a9a7e56cdfac0"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,6 +4594,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -4747,7 +4614,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -4770,6 +4637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4900,12 +4768,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -5599,17 +5461,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -5651,12 +5502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,7 +5521,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -6068,6 +5913,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,6 +5951,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6757,22 +6636,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -6886,10 +6756,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 tempfile = { version = "3.14", optional = true }
 
 # Metadata providers (optional)
-duckdb = { version = "1.4.1", optional = true }
+duckdb = { version = "1.10505.0", optional = true }
 sqlx = { version = "0.9", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -34,7 +34,7 @@ datafusion-ducklake = { path = "..", features = ["metadata-duckdb"] }
 
 # Core dependencies
 datafusion = "55"
-duckdb = { version = "1.4.1", features = ["bundled"] }
+duckdb = { version = "1.10505.0", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 

--- a/tests/it/cdc_differential_tests.rs
+++ b/tests/it/cdc_differential_tests.rs
@@ -62,6 +62,8 @@ fn official_connection(path: &Path) -> DataFusionResult<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])
+        .map_err(box_err)?;
     conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
         .map_err(box_err)?;
     Ok(conn)

--- a/tests/it/cdc_rowid_tests.rs
+++ b/tests/it/cdc_rowid_tests.rs
@@ -27,6 +27,8 @@ fn write_catalog(path: &std::path::Path, statements: &[&str]) -> DataFusionResul
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])
+        .map_err(box_err)?;
     conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
         .map_err(box_err)?;
     for s in statements {

--- a/tests/it/column_defaults_tests.rs
+++ b/tests/it/column_defaults_tests.rs
@@ -24,6 +24,7 @@ fn create_official_default_catalog(path: &Path) -> Result<Vec<(i32, i32)>> {
     let conn = duckdb::Connection::open_in_memory()?;
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute(
         &format!("ATTACH 'ducklake:{}' AS official", path.display()),
         [],

--- a/tests/it/common/mod.rs
+++ b/tests/it/common/mod.rs
@@ -69,6 +69,7 @@ pub fn create_catalog_no_deletes(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -109,6 +110,7 @@ pub fn create_catalog_with_deletes(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -155,6 +157,7 @@ pub fn create_catalog_with_updates(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -210,6 +213,7 @@ pub fn create_catalog_filter_pushdown(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -248,6 +252,7 @@ pub fn create_catalog_empty_table(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -278,6 +283,7 @@ pub fn create_catalog_basic_test(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -330,6 +336,7 @@ pub fn create_catalog_complex_deletions(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -376,6 +383,7 @@ pub fn create_catalog_multiple_snapshots(catalog_path: &Path) -> Result<()> {
 
     ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -308,6 +308,7 @@ fn create_official_mapped_compaction_fixture(temp: &TempDir) -> anyhow::Result<(
     conn.execute("INSTALL sqlite", [])?;
     conn.execute("LOAD sqlite", [])?;
     conn.execute("LOAD ducklake", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute(
         &format!(
             "ATTACH 'ducklake:sqlite:{}' AS lake \
@@ -374,28 +375,9 @@ async fn read_mapped_rows(temp: &TempDir) -> anyhow::Result<Vec<(i32, i32)>> {
 }
 
 #[cfg(feature = "metadata-duckdb")]
-async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
+async fn normalize_official_data_file_ids(temp: &TempDir) -> anyhow::Result<()> {
     let pool = pool(temp).await;
     SqliteMetadataWriter::new_with_init(&db_url(temp)).await?;
-    let schema_version_columns = sqlx::query("PRAGMA table_info(ducklake_schema_versions)")
-        .fetch_all(&pool)
-        .await?;
-    if !schema_version_columns
-        .iter()
-        .any(|row| row.get::<String, _>(1) == "table_id")
-    {
-        // The pinned DuckDB 1.4.1 test extension predates the per-table column
-        // that released DuckDB 1.5.5 writes; keep the fixture shape equivalent
-        sqlx::query("ALTER TABLE ducklake_schema_versions ADD COLUMN table_id INTEGER")
-            .execute(&pool)
-            .await?;
-        sqlx::query(
-            "UPDATE ducklake_schema_versions
-             SET table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 't')",
-        )
-        .execute(&pool)
-        .await?;
-    }
     let data_file_columns = sqlx::query("PRAGMA table_info(ducklake_data_file)")
         .fetch_all(&pool)
         .await?;
@@ -406,7 +388,9 @@ async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
         .unwrap();
     if data_file_id_type != "INTEGER" {
         // SQLite auto-allocates only an exact INTEGER PRIMARY KEY; normalize the
-        // official BIGINT declaration to the crate writer's documented precondition
+        // official BIGINT declaration to the crate writer's documented
+        // precondition. Required until the writer allocates the id explicitly
+        // instead of relying on the rowid alias (see issue #291).
         sqlx::query("ALTER TABLE ducklake_data_file RENAME TO ducklake_data_file__official")
             .execute(&pool)
             .await?;
@@ -455,7 +439,7 @@ async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
 async fn mapped_hive_values_survive_merge_adjacent_files() -> anyhow::Result<()> {
     let temp = TempDir::new()?;
     create_official_mapped_compaction_fixture(&temp)?;
-    migrate_pinned_duckdb_fixture(&temp).await?;
+    normalize_official_data_file_ids(&temp).await?;
     assert_eq!(read_mapped_rows(&temp).await?, vec![(1, 7), (2, 8)]);
 
     let result = run_merge(&temp, MergeOptions::default()).await;

--- a/tests/it/hybrid_asyncdb.rs
+++ b/tests/it/hybrid_asyncdb.rs
@@ -72,6 +72,7 @@ impl HybridDuckLakeDB {
         let conn = Connection::open_in_memory()?;
         crate::common::ensure_ducklake_installed();
         conn.execute("LOAD ducklake;", [])?;
+        conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
         let ducklake_path = format!("ducklake:{}", catalog_path.display());
         let attach_sql = format!(

--- a/tests/it/inlined_delete_tests.rs
+++ b/tests/it/inlined_delete_tests.rs
@@ -126,9 +126,9 @@ mod duckdb_oracle {
                 .unwrap()
         };
 
-        // DuckDB 1.5 creates this table directly. The 1.4.1 library pinned by
-        // this crate emits a regular positional delete, so normalize only that
-        // metadata row into the current specification's equivalent encoding.
+        // The bundled DuckLake creates the inlined-delete table itself. Guard
+        // against an engine that emits a regular positional delete instead, by
+        // normalizing that one metadata row into the equivalent inlined encoding.
         let metadata = duckdb::Connection::open(&catalog_path).unwrap();
         let table_id: i64 = metadata
             .query_row(

--- a/tests/it/name_mapping_tests.rs
+++ b/tests/it/name_mapping_tests.rs
@@ -38,6 +38,7 @@ fn create_name_mapping_catalog(
     let conn = duckdb::Connection::open_in_memory()?;
     conn.execute("INSTALL ducklake", [])?;
     conn.execute("LOAD ducklake", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute("INSTALL parquet", [])?;
     conn.execute(
         &format!(
@@ -261,6 +262,7 @@ async fn add_data_files_accepts_duckdb_numeric_hive_literals() -> anyhow::Result
     let conn = duckdb::Connection::open_in_memory()?;
     conn.execute("INSTALL ducklake", [])?;
     conn.execute("LOAD ducklake", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute(
         &format!(
             "ATTACH 'ducklake:{}' AS lake \

--- a/tests/it/numeric_metadata_validation_tests.rs
+++ b/tests/it/numeric_metadata_validation_tests.rs
@@ -17,6 +17,7 @@ fn create_catalog_with_negative_file_size(catalog_path: &std::path::Path) -> any
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -45,6 +46,7 @@ fn create_catalog_with_negative_footer_size(catalog_path: &std::path::Path) -> a
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;

--- a/tests/it/object_store_integration_test.rs
+++ b/tests/it/object_store_integration_test.rs
@@ -23,6 +23,7 @@ async fn create_local_test_catalog(catalog_path: &str) -> anyhow::Result<()> {
     // Install and load ducklake extension
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     // Create a test table with some data (local filesystem)
     conn.execute(
@@ -66,6 +67,7 @@ async fn create_s3_test_catalog(
     // Install and load ducklake extension
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     eprintln!("Configuring S3 secret for endpoint: {}", s3_endpoint);
 

--- a/tests/it/official_pushdown_parity_tests.rs
+++ b/tests/it/official_pushdown_parity_tests.rs
@@ -122,6 +122,7 @@ fn with_official_ducklake(
         conn.execute(&format!("LOAD {extension};"), [])?;
     }
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute(
         &format!(
             "ATTACH '{attach_target}' AS lake \
@@ -155,31 +156,6 @@ fn insert_fourth_file(
 ) -> anyhow::Result<()> {
     with_official_ducklake(attach_target, extensions, data_path, &INSERTS[3..])
 }
-
-/// Bring a catalog written by the DuckLake extension that ships with `duckdb`
-/// 1.4.1 — the version this fixture is written by — up to the shape a released
-/// DuckDB 1.5.x writes.
-///
-/// Only `DuckdbMetadataProvider` probes for the newer catalog columns.
-/// `SqliteMetadataProvider`, `PostgresMetadataProvider` and
-/// `MySqlMetadataProvider` select `ducklake_column.default_value_type` /
-/// `default_value_dialect` and `ducklake_schema_versions.table_id`
-/// unconditionally, so on the older shape they fail the query outright rather
-/// than degrading. `compaction_sqlite_tests::migrate_pinned_duckdb_fixture`
-/// tops up the same two tables for the same reason.
-///
-/// Nothing here touches `ducklake_data_file` or `ducklake_file_column_stats`:
-/// every file and every statistic this test reads is exactly as official wrote
-/// it. `VARCHAR(255)` and `BIGINT` are accepted by all three dialects, and a
-/// statement that fails because the column is already there is discarded at the
-/// call site.
-const MIGRATE_PINNED_DUCKDB_CATALOG: [&str; 4] = [
-    "ALTER TABLE ducklake_column ADD COLUMN default_value_type VARCHAR(255)",
-    "ALTER TABLE ducklake_column ADD COLUMN default_value_dialect VARCHAR(255)",
-    "ALTER TABLE ducklake_schema_versions ADD COLUMN table_id BIGINT",
-    "UPDATE ducklake_schema_versions
-     SET table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 'filter_pushdown')",
-];
 
 /// The row the official test prints for a `SELECT *` assertion.
 struct OfficialRow {
@@ -668,12 +644,6 @@ async fn sqlite_catalog_matches_official_pushdown() {
     let url = format!("sqlite:{}", catalog_path.display());
 
     build_fixture(&target, &["sqlite"], &data_path).unwrap();
-    let pool = sqlx::SqlitePool::connect(&url).await.unwrap();
-    for statement in MIGRATE_PINNED_DUCKDB_CATALOG {
-        // A column a newer extension already wrote is not an error here.
-        sqlx::query(statement).execute(&pool).await.ok();
-    }
-    pool.close().await;
 
     let provider = Arc::new(SqliteMetadataProvider::new(&url).await.unwrap());
     assert_official_parity(
@@ -720,12 +690,6 @@ async fn postgres_catalog_matches_official_pushdown() {
     let data_path = temp.path().join("data");
 
     build_fixture(&target, &["postgres"], &data_path).unwrap();
-    let pool = sqlx::PgPool::connect(&url).await.unwrap();
-    for statement in MIGRATE_PINNED_DUCKDB_CATALOG {
-        // A column a newer extension already wrote is not an error here.
-        sqlx::query(statement).execute(&pool).await.ok();
-    }
-    pool.close().await;
 
     // No divergences, on any server version. A temporal comparison is made on
     // the encoded text rather than by casting, so it needs neither
@@ -750,8 +714,7 @@ async fn postgres_catalog_matches_official_pushdown() {
 /// "Unsupported operator type HASH_JOIN in UPDATE statement — only simple
 /// deletes are supported in the MySQL connector". The first `INSERT` into a
 /// MySQL-hosted DuckLake catalog succeeds; the second aborts at commit. That is
-/// upstream and on the write path, and reproduces on DuckDB 1.5.5 as well as on
-/// the bundled 1.4.1.
+/// upstream and on the write path, and reproduces on the bundled DuckDB 1.5.5.
 ///
 /// So official DuckLake writes the catalog where it can, into its own DuckDB
 /// format, and DuckDB copies the rows across unchanged. Every statistic the
@@ -791,17 +754,9 @@ fn transport_catalog_to_mysql(catalog_path: &Path, dsn: &str) -> anyhow::Result<
     Ok(())
 }
 
-/// Top up a freshly transported catalog and open a provider on it. The
-/// transport replaces every table, so the migration has to be reapplied each
-/// time.
+/// Open a provider on a freshly transported catalog.
 #[cfg(feature = "metadata-mysql")]
 async fn open_mysql(url: &str) -> Arc<datafusion_ducklake::MySqlMetadataProvider> {
-    let pool = sqlx::MySqlPool::connect(url).await.unwrap();
-    for statement in MIGRATE_PINNED_DUCKDB_CATALOG {
-        // A column a newer extension already wrote is not an error here.
-        sqlx::query(statement).execute(&pool).await.ok();
-    }
-    pool.close().await;
     Arc::new(
         datafusion_ducklake::MySqlMetadataProvider::new(url)
             .await

--- a/tests/it/partition_tests.rs
+++ b/tests/it/partition_tests.rs
@@ -21,6 +21,7 @@ fn create_partitioned_catalog(catalog_path: &std::path::Path) -> anyhow::Result<
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -178,6 +179,7 @@ fn create_partition_moving_update_catalog(catalog_path: &std::path::Path) -> any
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute(
         &format!(
             "ATTACH 'ducklake:{}' AS test_catalog (DATA_INLINING_ROW_LIMIT 0);",

--- a/tests/it/pushdown_row_preservation_tests.rs
+++ b/tests/it/pushdown_row_preservation_tests.rs
@@ -429,6 +429,7 @@ fn with_official_ducklake(
         conn.execute(&format!("LOAD {extension};"), [])?;
     }
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute("SET TimeZone='UTC';", [])?;
     conn.execute(
         &format!(
@@ -584,31 +585,6 @@ impl CatalogStore {
                     .await
                     .expect("mysql provider"),
             ) as Arc<dyn MetadataProvider>,
-        }
-    }
-
-    /// Bring a catalog written by the DuckLake extension that ships with
-    /// `duckdb` 1.4.1 — the version this fixture is written by — up to the shape
-    /// a released DuckDB 1.5.x writes.
-    ///
-    /// Only `DuckdbMetadataProvider` probes for the newer catalog columns. The
-    /// three SQL providers select `ducklake_column.default_value_type` /
-    /// `default_value_dialect` and `ducklake_schema_versions.table_id`
-    /// unconditionally, so on the older shape they fail the query outright.
-    /// `official_pushdown_parity_tests` and `compaction_sqlite_tests` top up the
-    /// same two tables for the same reason. Nothing here touches
-    /// `ducklake_data_file` or `ducklake_file_column_stats`: every statistic the
-    /// sweep reads is exactly as official wrote it.
-    async fn migrate(&self) {
-        for statement in [
-            "ALTER TABLE ducklake_column ADD COLUMN default_value_type VARCHAR(255)",
-            "ALTER TABLE ducklake_column ADD COLUMN default_value_dialect VARCHAR(255)",
-            "ALTER TABLE ducklake_schema_versions ADD COLUMN table_id BIGINT",
-            "UPDATE ducklake_schema_versions SET table_id =
-             (SELECT table_id FROM ducklake_table WHERE table_name = 't')",
-        ] {
-            // A column a newer extension already wrote is not an error here.
-            let _ = self.try_exec(statement).await;
         }
     }
 
@@ -1655,9 +1631,7 @@ async fn sqlite_fixture(temp: &TempDir) -> CatalogStore {
         &data_path,
     )
     .expect("sqlite fixture builds");
-    let store = CatalogStore::Sqlite(format!("sqlite:{}", catalog_path.display()));
-    store.migrate().await;
-    store
+    CatalogStore::Sqlite(format!("sqlite:{}", catalog_path.display()))
 }
 
 /// SQLite carries the bulk: no Docker, and the dialect with the least type
@@ -1696,7 +1670,6 @@ async fn pushdown_row_preservation_duckdb() {
     )
     .expect("duckdb fixture builds");
     let store = CatalogStore::DuckDb(catalog_path);
-    store.migrate().await;
     sweep(&store, false).await;
 }
 
@@ -1726,7 +1699,6 @@ async fn pushdown_row_preservation_postgres() {
     .expect("postgres fixture builds");
 
     let store = CatalogStore::Postgres(url);
-    store.migrate().await;
     sweep(&store, false).await;
 }
 
@@ -1797,6 +1769,5 @@ async fn pushdown_row_preservation_mysql() {
     transport_catalog_to_mysql(&catalog_path, &dsn).expect("catalog transports to mysql");
 
     let store = CatalogStore::MySql(url);
-    store.migrate().await;
     sweep(&store, false).await;
 }

--- a/tests/it/renamed_columns_tests.rs
+++ b/tests/it/renamed_columns_tests.rs
@@ -32,6 +32,7 @@ fn create_catalog_with_renamed_column(catalog_path: &Path) -> Result<()> {
 
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -69,6 +70,7 @@ fn create_catalog_with_multiple_renames(catalog_path: &Path) -> Result<()> {
 
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -358,6 +360,7 @@ fn create_catalog_renamed_with_post_rename_file(catalog_path: &Path) -> Result<(
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
     conn.execute(
@@ -464,6 +467,7 @@ fn create_catalog_rename_then_delete(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
     conn.execute(
@@ -532,6 +536,7 @@ fn create_catalog_drop_readd(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
     conn.execute(
@@ -567,6 +572,7 @@ async fn test_drop_readd_column_reads_null_for_pre_drop_rows() -> Result<()> {
         let conn = duckdb::Connection::open_in_memory()?;
         crate::common::ensure_ducklake_installed();
         conn.execute("LOAD ducklake;", [])?;
+        conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
         let ducklake_path = format!("ducklake:{}", catalog_path.display());
         conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
         let mut stmt = conn.prepare("SELECT id, tag FROM test_catalog.test_table ORDER BY id")?;
@@ -620,6 +626,7 @@ fn create_catalog_evolved_struct_child(catalog_path: &Path, rename: bool) -> Res
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
     if rename {

--- a/tests/it/row_count_tests.rs
+++ b/tests/it/row_count_tests.rs
@@ -47,6 +47,8 @@ fn duckdb_count_star(catalog_path: &Path, table: &str) -> DataFusionResult<i64> 
     let conn = duckdb::Connection::open_in_memory().map_err(to_df)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(to_df)?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])
+        .map_err(to_df)?;
     conn.execute(
         &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),
         [],

--- a/tests/it/row_id_tests.rs
+++ b/tests/it/row_id_tests.rs
@@ -25,6 +25,7 @@ fn create_catalog_rowid_two_files(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
@@ -44,6 +45,7 @@ fn create_catalog_rowid_with_deletes(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
@@ -76,6 +78,7 @@ fn create_catalog_rowid_with_update(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;

--- a/tests/it/rowid_physical_position_tests.rs
+++ b/tests/it/rowid_physical_position_tests.rs
@@ -33,6 +33,7 @@ fn open(catalog_path: &Path) -> anyhow::Result<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     conn.execute(
         &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),
         [],

--- a/tests/it/scoped_settings_tests.rs
+++ b/tests/it/scoped_settings_tests.rs
@@ -322,6 +322,9 @@ fn official_duckdb_settings_resolve_with_table_precedence() {
     connection.execute("INSTALL ducklake", []).unwrap();
     connection.execute("LOAD ducklake", []).unwrap();
     connection
+        .execute("SET ducklake_default_data_inlining_row_limit = 0;", [])
+        .unwrap();
+    connection
         .execute(
             &format!(
                 "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}')",

--- a/tests/it/table_deletions_repartition_tests.rs
+++ b/tests/it/table_deletions_repartition_tests.rs
@@ -35,6 +35,8 @@ fn build_catalog(path: &Path, targets: &[i64]) -> DataFusionResult<()> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])
+        .map_err(box_err)?;
     conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
         .map_err(box_err)?;
     conn.execute("CREATE TABLE c.t(id INTEGER);", [])

--- a/tests/it/table_tests.rs
+++ b/tests/it/table_tests.rs
@@ -23,6 +23,7 @@ fn create_empty_table_catalog(catalog_path: &std::path::Path) -> anyhow::Result<
 
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     // Create data directory (DuckLake only creates it on first INSERT)
     let data_dir = catalog_path.with_extension("ducklake.files");
@@ -171,6 +172,7 @@ fn create_populated_table_catalog(catalog_path: &std::path::Path) -> anyhow::Res
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let data_dir = catalog_path.with_extension("ducklake.files");
     std::fs::create_dir_all(&data_dir)?;
@@ -432,6 +434,7 @@ fn create_two_file_catalog(catalog_path: &std::path::Path) -> anyhow::Result<()>
     let conn = duckdb::Connection::open_in_memory()?;
     crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
+    conn.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
 
     let data_dir = catalog_path.with_extension("ducklake.files");
     std::fs::create_dir_all(&data_dir)?;
@@ -565,6 +568,7 @@ async fn test_scan_with_live_deletes_is_correct() -> DataFusionResult<()> {
         };
         crate::common::ensure_ducklake_installed();
         exec("LOAD ducklake;")?;
+        exec("SET ducklake_default_data_inlining_row_limit = 0;")?;
         std::fs::create_dir_all(catalog_path.with_extension("ducklake.files"))
             .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
         exec(&format!(

--- a/tests/it/view_tests.rs
+++ b/tests/it/view_tests.rs
@@ -103,13 +103,16 @@ fn stored_view_sql(catalog_path: &Path, view_name: &str) -> anyhow::Result<Strin
     )?)
 }
 
-fn normalize_current_view_sql(catalog_path: &Path) -> anyhow::Result<()> {
+/// Rewrite one view's stored SQL from the `{DUCKLAKE_CATALOG}` placeholder to a
+/// literal attach alias, which is the shape catalogs written before the
+/// placeholder existed hold.
+fn legacy_qualify_view_sql(catalog_path: &Path, view_name: &str) -> anyhow::Result<()> {
     let connection = duckdb::Connection::open(catalog_path)?;
     connection.execute(
         "UPDATE ducklake_view
-         SET sql = replace(sql, 'lake.', '{DUCKLAKE_CATALOG}.')
-         WHERE view_name <> 'legacy_qualified'",
-        [],
+         SET sql = replace(sql, '{DUCKLAKE_CATALOG}.', 'lake.')
+         WHERE view_name = ?",
+        [view_name],
     )?;
     Ok(())
 }
@@ -121,6 +124,7 @@ fn duckdb_rows(
 ) -> anyhow::Result<Vec<Vec<String>>> {
     let connection = duckdb::Connection::open_in_memory()?;
     connection.execute("LOAD ducklake", [])?;
+    connection.execute("SET ducklake_default_data_inlining_row_limit = 0;", [])?;
     connection.execute(
         &format!(
             "ATTACH 'ducklake:{}' AS lake (DATA_PATH '{}')",
@@ -187,9 +191,13 @@ async fn duckdb_views_are_listed_and_queryable() -> anyhow::Result<()> {
         &data_path,
         "SELECT CAST(rowid AS VARCHAR) AS rowid_text FROM lake.rowids ORDER BY rowid",
     )?;
-    assert!(stored_view_sql(&catalog_path, "filtered")?.contains("lake.users"));
-    normalize_current_view_sql(&catalog_path)?;
+    // DuckLake stores a view's SQL with the catalog name replaced by the
+    // `{DUCKLAKE_CATALOG}` placeholder, so the SQL survives the catalog being
+    // attached under a different alias.
     assert!(stored_view_sql(&catalog_path, "filtered")?.contains("{DUCKLAKE_CATALOG}.users"));
+    // A catalog written before the placeholder existed holds the attach alias
+    // instead. Rewrite one view to that shape so the read path is covered for both.
+    legacy_qualify_view_sql(&catalog_path, "legacy_qualified")?;
     assert!(stored_view_sql(&catalog_path, "legacy_qualified")?.contains("lake.users"));
     assert!(stored_view_sql(&catalog_path, "schema_qualified")?.contains("s1.cross_values"));
     assert!(stored_view_sql(&catalog_path, "mixed_schema")?.contains("MySchema.mixed_values"));


### PR DESCRIPTION
## What this changes

The `duckdb` dependency resolved to 1.4.1, whose paired DuckLake extension predates most of the behaviour this crate gets compared against. Two consequences:

- **No DuckLake catalog with a DuckDB metadata store written by a current client could be opened at all** — `IO Error: Trying to read a database file with version number 68, but we can only read versions between 64 and 67`.
- Fixtures were built by a Feb-2026 engine while source comparisons were read from current upstream, so a green suite was not evidence about current DuckLake behaviour.

This moves to `1.10505.0` (DuckDB 1.5.5). The extension shipping with that engine reports `d8a1881e`, which is an upstream commit — so the engine the suite runs and the source it is reviewed against are now the same revision.

`Cargo.toml` declared `1.4.1` as a caret floor, which already accepted 1.5.5; only the committed lockfile held the old version. Users running `cargo update` were therefore getting an engine CI never exercised.

## Why the test diff is large

DuckLake 1.5 inlines inserts of up to 10 rows into the catalog by default (`data_inlining_row_limit` defaults to 10). Every fixture here inserts a handful of rows, so on the new engine they produced no Parquet file at all and **76 of 435 integration tests failed**.

Fixtures that target the Parquet path now set `ducklake_default_data_inlining_row_limit` to 0 on the connection. An ATTACH-level `DATA_INLINING_ROW_LIMIT` still takes precedence, verified against the CLI, so the suites that deliberately exercise inlining are untouched. That took the count from 76 failures to 1.

The remaining failure was not a bug in this crate. Upstream moved the catalog-name normalization of a stored view's SQL into its own write path, so the current engine stores `{DUCKLAKE_CATALOG}.users` where older versions stored the literal attach alias `lake.users`. `view_tests` asserted the old form. It now asserts the current form and synthesizes the legacy form by hand, so both are covered — previously it force-normalized every view, and its blanket `replace('lake.', ...)` would have corrupted the `mylake` alias in `placeholder_collision` had that view ever been asserted.

## Removed compensation code

Three helpers existed only to reshape a 1.4.1-era catalog into the shape a released extension writes — `MIGRATE_PINNED_DUCKDB_CATALOG`, `CatalogStore::migrate`, and the `ducklake_schema_versions` top-up. The oracle now writes that shape itself (`ducklake_schema_versions(begin_snapshot, schema_version, table_id)` is in its base DDL and it populates `table_id`), and one had become actively wrong: its blanket `UPDATE` overwrote the values upstream populates. All three are removed.

The `data_file_id` INTEGER-vs-BIGINT normalization in `compaction_sqlite_tests` stays. That works around #291 rather than the dependency, and the comment now says so.

## Verification

```
fmt --check                                       OK
clippy --all-targets --all-features -D warnings   OK
RUSTDOCFLAGS=-D warnings cargo doc                OK
check --locked --lib --no-default-features        OK
feature matrix, 12 combinations                   ALL PASS
```

Full suite with `duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite write-sqlite write-postgres multicatalog-postgres`, Docker up: **549 unit + 650 integration + 8 doc passing**.

Three failures remain, all in `postgres_single_catalog_write_tests`:

```
conditional_write_accepts_a_current_base_and_rejects_a_stale_one
concurrent_create_of_the_same_table_conflicts_instead_of_writing_null_columns
sql_ctas_then_insert_then_select
```

These are the three #299 documents as already failing on `main`, and none of the failure modes involve DuckDB — a sqlx `i64`/`INT4` decode mismatch, an ObjectStore `NotFound`, and `Plan("failed to resolve schema: main")`, which is #290. That feature set is not in CI, so this is simply the first run of it in this workflow; the failures are pre-existing, not introduced here.

Reading a current DuckDB-metadata catalog was checked end to end: a storage-version-68 catalog created by the 1.5.5 CLI now reads correctly through `basic_query`. It also gains implicit regression coverage, since every DuckDB-metadata fixture is now written by 1.5.5 and is therefore storage version 68 by construction.

## `write-duckdb` catalogs are unaffected

Worth stating because it looks like it should be affected. `DuckdbMetadataWriter::new` opens the catalog with the bundled engine, so the obvious guess is that catalogs it creates move to DuckDB 1.5 storage and stop being readable by earlier releases. Measured, they do not:

```
DuckdbMetadataWriter::new_with_init   ->  storage version 64
duckdb CLI, ATTACH 'ducklake:...'     ->  storage version 68
```

The DuckLake extension appends `STORAGE_VERSION 'latest'` when it creates a DuckDB metadata store, which is why the CLI produces 68. This crate's writer does not go through the extension, so it gets DuckDB's compatible baseline, and the bump does not change it. No rollback hazard.

## Not in scope

This does not make catalogs written by this crate readable by DuckDB — the snapshot table still omits `next_catalog_id` / `next_file_id`. #292 and #291 are unaffected. Reading inlined rows through the change feeds, the rowid path and the row counts is also still open (#270); this change only removes the dependency half of that issue, and the two are independent rather than coupled as that issue assumed.

## Follow-ups this surfaced

- The caret requirement still lets a downstream `cargo update` move the engine and silently shift the oracle. The lockfile is what makes CI deterministic; worth writing that down somewhere.
- CI's `skip-tests-with-docker` job was not reproduced locally — the real-Docker superset was run instead, and that flag has its own `cfg` paths.
