### PR TITLE
Drop DuckDB from the default build, and remove fixture top-ups the bump made redundant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,9 +233,14 @@ jobs:
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/duckdb" --version
 
+      # `duckdb-bundled` is named explicitly and is load-bearing: almost every
+      # fixture is built by driving the DuckLake extension through the bundled
+      # engine, and `tests/it/common` is `#![cfg(feature = "metadata-duckdb")]`.
+      # Drop it and those modules cfg out, so the suite silently shrinks instead
+      # of failing. It stopped being a default feature, so it has to be listed.
       - name: Run tests (macOS; Linux is covered by test-full)
         if: steps.changes.outputs.code == 'true' && runner.os == 'macOS'
-        run: cargo test --features "skip-tests-with-docker write-sqlite"
+        run: cargo test --features "skip-tests-with-docker duckdb-bundled write-sqlite"
 
       - name: Check documentation
         if: steps.changes.outputs.code == 'true'
@@ -373,6 +378,14 @@ jobs:
             cargo check --no-default-features --features "$features"
             echo "::endgroup::"
           done
+
+      # The loop above checks the library only, and every other job names its
+      # features, so nothing else compiles the test targets on bare defaults.
+      # That is how two unit tests calling a `write`-gated method sat broken:
+      # `cargo check --tests` failed on default features and no job ran it.
+      - name: Check test targets on default features
+        if: steps.changes.outputs.code == 'true'
+        run: cargo check --tests
 
 
   test-full:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Upgrade bundled DuckDB and the CI CLI to 1.5.5; Parquet fixtures explicitly disable default small-write inlining (#273).
+- **BREAKING**: Default features are now `metadata-sqlite` alone, so a default build no longer
+  compiles DuckDB; add `features = ["duckdb-bundled"]` for the DuckDB provider and writer (#304).
 
 - Files carrying a live delete file are now pruned by their statistics, matching official
   DuckLake; previously they were kept regardless of the predicate (#293).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ the postgres/mysql provider and multicatalog tests require Docker (`testcontaine
 The integration tests are a **single binary**, `tests/it/main.rs`, with one module per
 file rather than one `tests/*.rs` target each (`autotests = false` plus an explicit
 `[[test]] name = "it"`). Cargo links one binary per test target, and with
-`duckdb-bundled` on by default each statically linked its own copy of DuckDB, so ~50
+`duckdb-bundled` enabled each statically linked its own copy of DuckDB, so ~50
 targets meant several GB of linker output per build. Practical consequences: a test's
 name now carries its module as a prefix (`write_tests::test_append_semantics`), so
 substring filters still work; and targeting one former file is
@@ -278,7 +278,8 @@ Representative groups:
 
 Run tests with:
 ```bash
-cargo test                    # Default features; postgres/mysql/multicatalog tests need Docker
+cargo test --features duckdb-bundled   # Most fixtures are built by DuckDB, so they need this
+                                       # postgres/mysql/multicatalog tests also need Docker
 cargo test delete_filter      # Delete file tests only
 cargo test concurrent         # Concurrency tests only
 cargo test --ignored          # Performance benchmarks

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -17,8 +17,8 @@ PostgreSQL path uses the experimental multi-catalog layout described below.
 
 | Backend    | Read | Write | Multi-catalog | Feature flags                                          |
 |------------|:----:|:-----:|:-------------:|--------------------------------------------------------|
-| DuckDB     |  ✅  |  ✅   |      ❌       | `metadata-duckdb` (default), `write-duckdb`            |
-| SQLite     |  ✅  |  ✅   |      ❌       | `metadata-sqlite`, `write-sqlite`                      |
+| DuckDB     |  ✅  |  ✅   |      ❌       | `metadata-duckdb` (+ `duckdb-bundled`), `write-duckdb` |
+| SQLite     |  ✅  |  ✅   |      ❌       | `metadata-sqlite` (default), `write-sqlite`            |
 | PostgreSQL |  ✅  |  ✅   |      ✅       | `metadata-postgres`, `write-postgres`, `multicatalog-postgres` |
 | MySQL      |  ✅  |  ✅   |      ❌       | `metadata-mysql`, `write-mysql`                        |
 
@@ -78,9 +78,9 @@ AWS‑LC, install the intended process‑wide Rustls `CryptoProvider` before cre
 
 | Feature                  | Description                                                              | Default |
 |--------------------------|--------------------------------------------------------------------------|:-------:|
-| `metadata-duckdb`        | DuckDB catalog read backend                                              |   ✅    |
-| `duckdb-bundled`         | Statically compile & bundle DuckDB (disable for dynamic linking)         |   ✅    |
-| `metadata-sqlite`        | SQLite catalog read backend                                              |         |
+| `metadata-duckdb`        | DuckDB catalog read backend                                              |         |
+| `duckdb-bundled`         | Statically compile & bundle DuckDB (disable for dynamic linking)         |         |
+| `metadata-sqlite`        | SQLite catalog read backend                                              |   ✅    |
 | `metadata-postgres`      | PostgreSQL catalog read backend                                          |         |
 | `metadata-mysql`         | MySQL catalog read backend                                               |         |
 | `write`                  | Base write support (INSERT, CTAS, maintenance API); needs a write backend|         |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ aws-credential-types = "1.2"
 sqllogictest = "0.23"
 
 [features]
-default = ["metadata-duckdb", "duckdb-bundled"]
+default = ["metadata-sqlite"]
 
 # Allow skipping tests that use docker (in CI, macos doesn't support docker).
 skip-tests-with-docker = []

--- a/README.md
+++ b/README.md
@@ -33,9 +33,19 @@ Add the crate:
 cargo add datafusion-ducklake
 ```
 
-The default build includes the statically bundled DuckDB catalog backend. Applications configure
-their object store implementation directly. Other catalog backends and write support are opt‑in
-via feature flags. See [COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
+The default build includes the SQLite catalog backend. Every other catalog backend, and write
+support for all of them, is opt-in via feature flags; applications configure their object store
+implementation directly. See [COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
+
+The DuckDB backend statically compiles DuckDB, which is by far the slowest dependency in this
+crate to build, so it is not a default:
+
+```toml
+# Cargo.toml — read (and write) DuckDB-backed catalogs
+[dependencies.datafusion-ducklake]
+version = "0.7"
+features = ["duckdb-bundled"]   # add "write-duckdb" to write them
+```
 
 ```toml
 # Cargo.toml — read PostgreSQL catalogs
@@ -327,6 +337,21 @@ A few highlights worth knowing up front:
   the `COUNT(*)` undercount caveat and how to avoid it.
 
 ---
+
+## Running the tests
+
+The test fixtures are built by driving the real DuckLake extension through a bundled DuckDB, and
+those modules are gated on `metadata-duckdb`. Since that is not a default feature, a bare
+`cargo test` compiles only a small fraction of the suite:
+
+```bash
+cargo test --features duckdb-bundled            # the suite as CI runs it, minus Docker
+cargo test --features "duckdb-bundled write-sqlite metadata-postgres metadata-mysql"
+```
+
+The PostgreSQL, MySQL, and multi-catalog suites need Docker (via `testcontainers`). Note that
+`--all-features` enables `skip-tests-with-docker`, which *ignores* those suites rather than
+running them, so a green `--all-features` run is not evidence that they passed.
 
 ## Project status
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -21,7 +21,9 @@ path = "src/bin/generate_tpcds.rs"
 # DataFusion-DuckLake: Uncomment ONE of the following options
 
 # Option 1: Local development (default)
-datafusion-ducklake = { path = "..", features = ["metadata-duckdb"] }
+# `duckdb-bundled` is not a default feature and this benchmark links DuckDB
+# statically, so ask for it here rather than relying on feature unification.
+datafusion-ducklake = { path = "..", features = ["duckdb-bundled"] }
 
 # Option 2: Specific git commit
 # datafusion-ducklake = { git = "https://github.com/hotdata-dev/datafusion-ducklake", rev = "COMMIT_HASH", features = ["metadata-duckdb"] }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -34,7 +34,7 @@ datafusion-ducklake = { path = "..", features = ["metadata-duckdb"] }
 
 # Core dependencies
 datafusion = "55"
-duckdb = { version = "1.4.1", features = ["bundled"] }
+duckdb = { version = "1.10505.0", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,14 @@
 //! ```no_run
 //! # async fn example() -> datafusion_ducklake::Result<()> {
 //! use datafusion::prelude::*;
-//! use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+//! use datafusion_ducklake::{DuckLakeCatalog, SqliteMetadataProvider};
 //!
 //! // Create a DataFusion session context
 //! let ctx = SessionContext::new();
 //!
-//! // Create a DuckDB metadata provider
-//! let provider = DuckdbMetadataProvider::new("path/to/catalog.ducklake")?;
+//! // Create a metadata provider for the catalog database. Each backend has its
+//! // own provider behind its own feature; `metadata-sqlite` is on by default.
+//! let provider = SqliteMetadataProvider::new("sqlite:path/to/catalog.sqlite").await?;
 //!
 //! // Register a DuckLake catalog with the provider
 //! let catalog = DuckLakeCatalog::new(provider)?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -4687,8 +4687,10 @@ mod tests {
     };
     use crate::partition::{PartitionSpecColumn, PartitionTransform};
     use crate::types::build_arrow_schema;
+    #[cfg(feature = "write")]
     use datafusion::datasource::physical_plan::FileScanConfig;
     use datafusion::prelude::{SessionContext, col, lit};
+    #[cfg(feature = "write")]
     use object_store::ObjectStore;
     use rstest::rstest;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -6654,6 +6656,8 @@ mod tests {
     /// `DataSourceExec`/`FileScanConfig` scan plan, exactly as a caller of
     /// `create_parquet_source` does, and downcasts down to the `ParquetSource`
     /// to inspect the attached factory.
+    // Reads the table's object-store URL, which is only compiled with `write`.
+    #[cfg(feature = "write")]
     #[tokio::test]
     async fn ducklake_scan_attaches_the_cached_parquet_reader_factory() -> Result<()> {
         let table = fixed_table(vec![], None)?;
@@ -6696,6 +6700,8 @@ mod tests {
     /// `ParquetSource` reads through the same `RuntimeEnv` file-metadata cache
     /// the cold run just populated (#1323), so it performs zero range reads
     /// whose end lands on the file's length.
+    // Reads the table's object-store URL, which is only compiled with `write`.
+    #[cfg(feature = "write")]
     #[tokio::test]
     async fn ducklake_parquet_source_reuses_cached_footer_metadata_across_scans() -> Result<()> {
         let table = fixed_table(vec![], None)?;

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -374,28 +374,9 @@ async fn read_mapped_rows(temp: &TempDir) -> anyhow::Result<Vec<(i32, i32)>> {
 }
 
 #[cfg(feature = "metadata-duckdb")]
-async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
+async fn normalize_official_data_file_ids(temp: &TempDir) -> anyhow::Result<()> {
     let pool = pool(temp).await;
     SqliteMetadataWriter::new_with_init(&db_url(temp)).await?;
-    let schema_version_columns = sqlx::query("PRAGMA table_info(ducklake_schema_versions)")
-        .fetch_all(&pool)
-        .await?;
-    if !schema_version_columns
-        .iter()
-        .any(|row| row.get::<String, _>(1) == "table_id")
-    {
-        // The pinned DuckDB 1.4.1 test extension predates the per-table column
-        // that released DuckDB 1.5.5 writes; keep the fixture shape equivalent
-        sqlx::query("ALTER TABLE ducklake_schema_versions ADD COLUMN table_id INTEGER")
-            .execute(&pool)
-            .await?;
-        sqlx::query(
-            "UPDATE ducklake_schema_versions
-             SET table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 't')",
-        )
-        .execute(&pool)
-        .await?;
-    }
     let data_file_columns = sqlx::query("PRAGMA table_info(ducklake_data_file)")
         .fetch_all(&pool)
         .await?;
@@ -406,7 +387,9 @@ async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
         .unwrap();
     if data_file_id_type != "INTEGER" {
         // SQLite auto-allocates only an exact INTEGER PRIMARY KEY; normalize the
-        // official BIGINT declaration to the crate writer's documented precondition
+        // official BIGINT declaration to the crate writer's documented
+        // precondition. Required until the writer allocates the id explicitly
+        // instead of relying on the rowid alias (see issue #291).
         sqlx::query("ALTER TABLE ducklake_data_file RENAME TO ducklake_data_file__official")
             .execute(&pool)
             .await?;
@@ -455,7 +438,7 @@ async fn migrate_pinned_duckdb_fixture(temp: &TempDir) -> anyhow::Result<()> {
 async fn mapped_hive_values_survive_merge_adjacent_files() -> anyhow::Result<()> {
     let temp = TempDir::new()?;
     create_official_mapped_compaction_fixture(&temp)?;
-    migrate_pinned_duckdb_fixture(&temp).await?;
+    normalize_official_data_file_ids(&temp).await?;
     assert_eq!(read_mapped_rows(&temp).await?, vec![(1, 7), (2, 8)]);
 
     let result = run_merge(&temp, MergeOptions::default()).await;

--- a/tests/it/inlined_delete_tests.rs
+++ b/tests/it/inlined_delete_tests.rs
@@ -126,9 +126,9 @@ mod duckdb_oracle {
                 .unwrap()
         };
 
-        // DuckDB 1.5 creates this table directly. The 1.4.1 library pinned by
-        // this crate emits a regular positional delete, so normalize only that
-        // metadata row into the current specification's equivalent encoding.
+        // The bundled DuckLake creates the inlined-delete table itself. Guard
+        // against an engine that emits a regular positional delete instead, by
+        // normalizing that one metadata row into the equivalent inlined encoding.
         let metadata = duckdb::Connection::open(&catalog_path).unwrap();
         let table_id: i64 = metadata
             .query_row(

--- a/tests/it/official_pushdown_parity_tests.rs
+++ b/tests/it/official_pushdown_parity_tests.rs
@@ -156,31 +156,6 @@ fn insert_fourth_file(
     with_official_ducklake(attach_target, extensions, data_path, &INSERTS[3..])
 }
 
-/// Bring a catalog written by the DuckLake extension that ships with `duckdb`
-/// 1.4.1 — the version this fixture is written by — up to the shape a released
-/// DuckDB 1.5.x writes.
-///
-/// Only `DuckdbMetadataProvider` probes for the newer catalog columns.
-/// `SqliteMetadataProvider`, `PostgresMetadataProvider` and
-/// `MySqlMetadataProvider` select `ducklake_column.default_value_type` /
-/// `default_value_dialect` and `ducklake_schema_versions.table_id`
-/// unconditionally, so on the older shape they fail the query outright rather
-/// than degrading. `compaction_sqlite_tests::migrate_pinned_duckdb_fixture`
-/// tops up the same two tables for the same reason.
-///
-/// Nothing here touches `ducklake_data_file` or `ducklake_file_column_stats`:
-/// every file and every statistic this test reads is exactly as official wrote
-/// it. `VARCHAR(255)` and `BIGINT` are accepted by all three dialects, and a
-/// statement that fails because the column is already there is discarded at the
-/// call site.
-const MIGRATE_PINNED_DUCKDB_CATALOG: [&str; 4] = [
-    "ALTER TABLE ducklake_column ADD COLUMN default_value_type VARCHAR(255)",
-    "ALTER TABLE ducklake_column ADD COLUMN default_value_dialect VARCHAR(255)",
-    "ALTER TABLE ducklake_schema_versions ADD COLUMN table_id BIGINT",
-    "UPDATE ducklake_schema_versions
-     SET table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 'filter_pushdown')",
-];
-
 /// The row the official test prints for a `SELECT *` assertion.
 struct OfficialRow {
     v: i32,
@@ -668,12 +643,6 @@ async fn sqlite_catalog_matches_official_pushdown() {
     let url = format!("sqlite:{}", catalog_path.display());
 
     build_fixture(&target, &["sqlite"], &data_path).unwrap();
-    let pool = sqlx::SqlitePool::connect(&url).await.unwrap();
-    for statement in MIGRATE_PINNED_DUCKDB_CATALOG {
-        // A column a newer extension already wrote is not an error here.
-        sqlx::query(statement).execute(&pool).await.ok();
-    }
-    pool.close().await;
 
     let provider = Arc::new(SqliteMetadataProvider::new(&url).await.unwrap());
     assert_official_parity(
@@ -720,12 +689,6 @@ async fn postgres_catalog_matches_official_pushdown() {
     let data_path = temp.path().join("data");
 
     build_fixture(&target, &["postgres"], &data_path).unwrap();
-    let pool = sqlx::PgPool::connect(&url).await.unwrap();
-    for statement in MIGRATE_PINNED_DUCKDB_CATALOG {
-        // A column a newer extension already wrote is not an error here.
-        sqlx::query(statement).execute(&pool).await.ok();
-    }
-    pool.close().await;
 
     // No divergences, on any server version. A temporal comparison is made on
     // the encoded text rather than by casting, so it needs neither
@@ -750,8 +713,7 @@ async fn postgres_catalog_matches_official_pushdown() {
 /// "Unsupported operator type HASH_JOIN in UPDATE statement — only simple
 /// deletes are supported in the MySQL connector". The first `INSERT` into a
 /// MySQL-hosted DuckLake catalog succeeds; the second aborts at commit. That is
-/// upstream and on the write path, and reproduces on DuckDB 1.5.5 as well as on
-/// the bundled 1.4.1.
+/// upstream and on the write path, and reproduces on the bundled DuckDB 1.5.5.
 ///
 /// So official DuckLake writes the catalog where it can, into its own DuckDB
 /// format, and DuckDB copies the rows across unchanged. Every statistic the
@@ -791,17 +753,9 @@ fn transport_catalog_to_mysql(catalog_path: &Path, dsn: &str) -> anyhow::Result<
     Ok(())
 }
 
-/// Top up a freshly transported catalog and open a provider on it. The
-/// transport replaces every table, so the migration has to be reapplied each
-/// time.
+/// Open a provider on a freshly transported catalog.
 #[cfg(feature = "metadata-mysql")]
 async fn open_mysql(url: &str) -> Arc<datafusion_ducklake::MySqlMetadataProvider> {
-    let pool = sqlx::MySqlPool::connect(url).await.unwrap();
-    for statement in MIGRATE_PINNED_DUCKDB_CATALOG {
-        // A column a newer extension already wrote is not an error here.
-        sqlx::query(statement).execute(&pool).await.ok();
-    }
-    pool.close().await;
     Arc::new(
         datafusion_ducklake::MySqlMetadataProvider::new(url)
             .await

--- a/tests/it/pushdown_row_preservation_tests.rs
+++ b/tests/it/pushdown_row_preservation_tests.rs
@@ -587,31 +587,6 @@ impl CatalogStore {
         }
     }
 
-    /// Bring a catalog written by the DuckLake extension that ships with
-    /// `duckdb` 1.4.1 — the version this fixture is written by — up to the shape
-    /// a released DuckDB 1.5.x writes.
-    ///
-    /// Only `DuckdbMetadataProvider` probes for the newer catalog columns. The
-    /// three SQL providers select `ducklake_column.default_value_type` /
-    /// `default_value_dialect` and `ducklake_schema_versions.table_id`
-    /// unconditionally, so on the older shape they fail the query outright.
-    /// `official_pushdown_parity_tests` and `compaction_sqlite_tests` top up the
-    /// same two tables for the same reason. Nothing here touches
-    /// `ducklake_data_file` or `ducklake_file_column_stats`: every statistic the
-    /// sweep reads is exactly as official wrote it.
-    async fn migrate(&self) {
-        for statement in [
-            "ALTER TABLE ducklake_column ADD COLUMN default_value_type VARCHAR(255)",
-            "ALTER TABLE ducklake_column ADD COLUMN default_value_dialect VARCHAR(255)",
-            "ALTER TABLE ducklake_schema_versions ADD COLUMN table_id BIGINT",
-            "UPDATE ducklake_schema_versions SET table_id =
-             (SELECT table_id FROM ducklake_table WHERE table_name = 't')",
-        ] {
-            // A column a newer extension already wrote is not an error here.
-            let _ = self.try_exec(statement).await;
-        }
-    }
-
     /// `contains_nan` is a real boolean on DuckDB and PostgreSQL and an integer
     /// on SQLite and MySQL.
     fn bool_literal(&self, value: bool) -> &'static str {
@@ -1655,9 +1630,7 @@ async fn sqlite_fixture(temp: &TempDir) -> CatalogStore {
         &data_path,
     )
     .expect("sqlite fixture builds");
-    let store = CatalogStore::Sqlite(format!("sqlite:{}", catalog_path.display()));
-    store.migrate().await;
-    store
+    CatalogStore::Sqlite(format!("sqlite:{}", catalog_path.display()))
 }
 
 /// SQLite carries the bulk: no Docker, and the dialect with the least type
@@ -1696,7 +1669,6 @@ async fn pushdown_row_preservation_duckdb() {
     )
     .expect("duckdb fixture builds");
     let store = CatalogStore::DuckDb(catalog_path);
-    store.migrate().await;
     sweep(&store, false).await;
 }
 
@@ -1726,7 +1698,6 @@ async fn pushdown_row_preservation_postgres() {
     .expect("postgres fixture builds");
 
     let store = CatalogStore::Postgres(url);
-    store.migrate().await;
     sweep(&store, false).await;
 }
 
@@ -1797,6 +1768,5 @@ async fn pushdown_row_preservation_mysql() {
     transport_catalog_to_mysql(&catalog_path, &dsn).expect("catalog transports to mysql");
 
     let store = CatalogStore::MySql(url);
-    store.migrate().await;
     sweep(&store, false).await;
 }

--- a/tests/it/sqlite_metadata_provider_test.rs
+++ b/tests/it/sqlite_metadata_provider_test.rs
@@ -18,6 +18,8 @@
 //! - Concurrent access and thread safety
 //! - Error handling and edge cases
 
+// Only the DuckDB-sourced fixtures below need these.
+#[cfg(feature = "metadata-duckdb")]
 use crate::common;
 
 use arrow::datatypes::{DataType, Field, Schema};
@@ -26,14 +28,16 @@ use datafusion::logical_expr::Operator;
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, lit};
 use datafusion::prelude::*;
+#[cfg(feature = "metadata-duckdb")]
+use datafusion_ducklake::DuckdbMetadataProvider;
 use datafusion_ducklake::metadata_provider::DuckLakeTableColumn;
 use datafusion_ducklake::stats_filter::{StatsFilter, lower_predicate};
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckdbMetadataProvider, SqliteMetadataProvider,
-    metadata_provider::MetadataProvider,
+    DuckLakeCatalog, SqliteMetadataProvider, metadata_provider::MetadataProvider,
 };
 use sqlx::SqlitePool;
 use std::sync::Arc;
+#[cfg(feature = "metadata-duckdb")]
 use tempfile::TempDir;
 
 /// Initialize DuckLake catalog schema in SQLite (for tests only)
@@ -395,6 +399,7 @@ async fn populate_test_data(provider: &SqliteMetadataProvider) -> anyhow::Result
 }
 
 /// Helper to populate SQLite with metadata from a DuckDB-created catalog
+#[cfg(feature = "metadata-duckdb")]
 async fn populate_from_duckdb_catalog(
     provider: &SqliteMetadataProvider,
 ) -> anyhow::Result<(String, TempDir)> {
@@ -1034,6 +1039,7 @@ async fn test_datafusion_integration() {
     assert!(!results.is_empty(), "Should have schema results");
 }
 
+#[cfg(feature = "metadata-duckdb")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_real_parquet_files() {
     let provider = create_sqlite_provider().await.unwrap();
@@ -1099,6 +1105,7 @@ async fn test_query_real_parquet_files() {
     assert_eq!(email_col.value(1), "bob@example.com");
 }
 
+#[cfg(feature = "metadata-duckdb")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_with_filter() {
     let provider = create_sqlite_provider().await.unwrap();


### PR DESCRIPTION
Follows #273, which moved the `duckdb` dependency to 1.10505.0 (DuckDB 1.5.5). Two commits: dead test code the bump made removable, and making DuckDB opt-in.

## 1. Remove fixture top-ups the bump made redundant

`afbe6c7` — 5 files, `+12 −105`.

DuckDB 1.4.1's DuckLake extension created `ducklake_schema_versions(begin_snapshot, schema_version)`, with no `table_id`. The SQLite, PostgreSQL and MySQL providers select `sv.table_id` unconditionally, so reading a catalog of that shape fails outright with `no such column: sv.table_id` (#251). Three test helpers therefore added the column by hand and populated it, so a fixture built by the pinned engine looked like one a released extension writes: `MIGRATE_PINNED_DUCKDB_CATALOG`, `CatalogStore::migrate`, and a `ducklake_schema_versions` block in `compaction_sqlite_tests`.

The bumped extension writes and populates that column itself, so all three are dead. Two of them also carry a latent trap:

```sql
UPDATE ducklake_schema_versions SET table_id = (SELECT table_id FROM ducklake_table WHERE table_name = ...)
```

That flattens every row onto one table's id. Both fixtures create exactly one table, so today it rewrites each row to the value the extension already wrote — idempotent and harmless. It stops being harmless if either fixture gains a second table, and it would not announce itself: the surrounding `ALTER`s are applied with errors discarded (`.ok()` / `let _ =`), which is also why nobody noticed they had already started failing as duplicate-column no-ops.

The one behavioural consequence of removing them: if the `duckdb` dependency is ever moved back below the version that writes `table_id`, these suites will fail with `no such column: sv.table_id` rather than silently self-healing.

The `data_file_id` INTEGER-vs-BIGINT normalization in `compaction_sqlite_tests` stays — it works around the writer's dependency on SQLite's rowid alias, not the dependency version. It is renamed to say what it does and now cites #291, which will retire it.

`benchmark/Cargo.toml` was the last place in the repo still asking for `duckdb 1.4.1`. It resolved to 1.10505.0 through the workspace lockfile anyway, so the declared version was merely misleading.

## 2. Stop compiling DuckDB in a default build

`176f977` — 9 files.

`default = ["metadata-duckdb", "duckdb-bundled"]` meant every build statically compiled DuckDB's C++ whether or not the caller wanted that backend. The comment at `ci.yml:349` puts it at **~427s**. Someone reading a PostgreSQL catalog paid all of it.

Defaults become `["metadata-sqlite"]`: the crate still opens a catalog out of the box, on the spec-compliant single-catalog backend the writers target, and its C dependency is SQLite's amalgamation rather than DuckDB.

```toml
datafusion-ducklake = { version = "0.7", features = ["duckdb-bundled"] }  # + "write-duckdb" to write
```

An API break and nothing more — `DuckdbMetadataProvider`, `DuckdbMetadataWriter` and the `DuckLakeError::DuckDb` variant leave a default build. No behaviour change, no catalog or data migration, and re-adding the feature restores everything.

**This does not make CI faster.** Every job already names its features, and this adds a step, so if anything CI is marginally slower. The saving is for downstream consumers.

### A pre-existing bug this surfaced

`cargo check --tests` on default features was already failing. Two unit tests in `src/table.rs` call `object_store_url()`, which is `#[cfg(feature = "write")]`, while the test module is not gated. Reproduced under the *old* default feature set:

```
$ cargo check --tests --no-default-features --features metadata-duckdb,duckdb-bundled
error[E0599]: no method named `object_store_url` found for struct `table::DuckLakeTable`
```

Nothing in CI compiles the test targets on bare defaults — clippy runs `--all-features`, the test jobs name their features, and the feature-combination loop checks the library only. A new step runs `cargo check --tests` on defaults, so this cannot quietly return.

### A SQLite suite that silently depended on DuckDB

`sqlite_metadata_provider_test` is gated on `metadata-sqlite` but builds its fixtures with DuckDB, despite module docs claiming "No Docker or external services required". Gating the whole module on `metadata-duckdb` would compile, and would leave the new default build running **zero** SQLite-provider tests. Only 1 of its 39 items needs DuckDB, so the helper, its two callers and three imports are gated instead; **28 tests still run without DuckDB.**

### Documentation, because the default build is now much thinner

A bare `cargo test` covers **29** integration tests where the old defaults covered **152** (653 under the CI feature set). CI is unaffected since it names its features, but a contributor running `cargo test` would see a small suite pass and reasonably trust it. There was no `CONTRIBUTING.md` and no testing section in the README, so:

- README gains a **Running the tests** section naming the features the suite needs, and the warning that `--all-features` *ignores* the Docker suites rather than running them
- README's Quick start claimed the default build bundles DuckDB, which is no longer true, and now shows how to ask for it
- `COMPATIBILITY.md` tables, `CLAUDE.md` testing instructions, and the `lib.rs` headline example, which used `DuckdbMetadataProvider` and stopped compiling under the new defaults

## Worth agreeing rather than inheriting

#273 promoted DuckDB from read-only to a first-class writable backend, and this demotes it from the default feature set immediately afterwards. The build-cost argument is unchanged by that and the backend is one flag away, but the ordering is a product call.

## Verification

```
fmt --check                                       OK
clippy --all-targets --all-features -D warnings   OK
RUSTDOCFLAGS=-D warnings cargo doc                OK
check --locked --lib --no-default-features        OK
check --tests on default features                 OK  (previously failed)
doctests on default features                      6 passed
feature matrix, 12 combinations                   ALL PASS
```

Full suite with `duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite write-sqlite write-postgres multicatalog-postgres`, Docker up: **552 unit + 650 integration + 8 doc** — counts identical to `main`, which is the check that the added `cfg` gates drop no test when features are on.

Three failures remain, all in `postgres_single_catalog_write_tests` — the trio #299 documents as already failing, none of whose failure modes involve DuckDB (a sqlx `i64`/`INT4` decode mismatch, an ObjectStore `NotFound`, and `Plan("failed to resolve schema: main")`, which is #290). That feature set is not in CI, so this is the first run of it here.
